### PR TITLE
clientconfig package

### DIFF
--- a/acceptance/openstack/clientconfig/clientconfig_test.go
+++ b/acceptance/openstack/clientconfig/clientconfig_test.go
@@ -1,0 +1,39 @@
+// +build acceptance clientconfig
+
+package clientconfig
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
+
+	acc_compute "github.com/gophercloud/gophercloud/acceptance/openstack/compute/v2"
+	acc_tools "github.com/gophercloud/gophercloud/acceptance/tools"
+
+	cc "github.com/gophercloud/utils/openstack/clientconfig"
+)
+
+func TestServerCreateDestroy(t *testing.T) {
+	clientOpts := &cc.ClientOpts{
+		Cloud:     "acctest",
+		EnvPrefix: "FOO",
+	}
+
+	client, err := cc.NewServiceClient("compute", clientOpts)
+	if err != nil {
+		t.Fatalf("Unable to create client: %v", err)
+	}
+
+	server, err := acc_compute.CreateServer(t, client)
+	if err != nil {
+		t.Fatalf("Unable to create server: %v", err)
+	}
+	defer acc_compute.DeleteServer(t, client, server)
+
+	newServer, err := servers.Get(client, server.ID).Extract()
+	if err != nil {
+		t.Fatalf("Unable to get server %s: %v", server.ID, err)
+	}
+
+	acc_tools.PrintResource(t, newServer)
+}

--- a/openstack/auth_yaml.go
+++ b/openstack/auth_yaml.go
@@ -1,0 +1,131 @@
+package openstack
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/gophercloud/gophercloud"
+	"gopkg.in/yaml.v2"
+)
+
+var (
+	ErrNoCloudYaml = fmt.Errorf("Clouds.yaml file not found.")
+)
+
+type Clouds struct {
+	Clouds map[string]struct {
+		Profile       string   `yaml:"profile"`
+		RegionName    string   `yaml:"region_name"`
+		Regions       []string `yaml:"regions"`
+		DNSAPIVersion string   `yaml:"dns_api_version"`
+		Auth          struct {
+			AuthURL     string `yaml:"auth_url"`
+			Username    string `yaml:"username"`
+			Password    string `yaml:"password"`
+			ProjectName string `yaml:"project_name"`
+			ProjectID   string `yaml:"project_id"`
+		} `yaml:"auth,omitempty"`
+	}
+}
+
+// AuthOptionsFromYaml fills out an identity.AuthOptions structure with the settings found in a specific
+// cloud entry of a clouds.yaml file (as per http://docs.openstack.org/developer/os-client-config)
+// If `env` is set to true, it will also override these values with the various
+// OS_* environment variables.  The following variables provide sources of truth: OS_AUTH_URL, OS_USERNAME,
+// OS_PASSWORD, OS_TENANT_ID, and OS_TENANT_NAME.  Of these, OS_USERNAME, OS_PASSWORD, and OS_AUTH_URL must
+// have settings, or an error will result.  OS_TENANT_ID and OS_TENANT_NAME are optional.
+func AuthOptionsFromYaml(cloud string, env bool) (gophercloud.AuthOptions, error) {
+	clouds := &Clouds{}
+	cloudsContent, err := cloudsYaml()
+	if err != nil {
+		return nilOptions, err
+	}
+	err = yaml.Unmarshal(cloudsContent, clouds)
+	if err != nil {
+		return nilOptions, fmt.Errorf("Failed to unmarshal YAML: %v", err)
+	}
+
+	auth := clouds.Clouds[cloud].Auth
+
+	authURL := auth.AuthURL
+	username := auth.Username
+	password := auth.Password
+	tenantID := auth.ProjectID
+	tenantName := auth.ProjectName
+
+	if env {
+		if v := os.Getenv("OS_AUTH_URL"); v != "" {
+			authURL = v
+		}
+
+		if v := os.Getenv("OS_USERNAME"); v != "" {
+			username = v
+		}
+
+		if v := os.Getenv("OS_PASSWORD"); v != "" {
+			password = v
+		}
+
+		if v := os.Getenv("OS_TENANT_ID"); v != "" {
+			tenantID = v
+		}
+
+		if v := os.Getenv("OS_TENANT_NAME"); v != "" {
+			tenantName = v
+		}
+	}
+
+	if authURL == "" {
+		err := gophercloud.ErrMissingInput{Argument: "authURL"}
+		return nilOptions, err
+	}
+
+	if username == "" {
+		err := gophercloud.ErrMissingInput{Argument: "username"}
+		return nilOptions, err
+	}
+
+	if password == "" {
+		err := gophercloud.ErrMissingInput{Argument: "password"}
+		return nilOptions, err
+	}
+
+	ao := gophercloud.AuthOptions{
+		IdentityEndpoint: authURL,
+		Username:         username,
+		Password:         password,
+		TenantID:         tenantID,
+		TenantName:       tenantName,
+	}
+
+	return ao, nil
+}
+
+func cloudsYaml() ([]byte, error) {
+	if f, ok := cloudsYamlFile(os.Getenv("USER_CONFIG_DIR")); ok {
+		return ioutil.ReadFile(f)
+	}
+
+	if f, ok := cloudsYamlFile(fmt.Sprintf("%s/.config/openstack", os.Getenv("HOME"))); ok {
+		return ioutil.ReadFile(f)
+	}
+
+	if f, ok := cloudsYamlFile(os.Getenv("SITE_CONFIG_DIR")); ok {
+		return ioutil.ReadFile(f)
+	}
+
+	if f, ok := cloudsYamlFile("/etc/openstack"); ok {
+		return ioutil.ReadFile(f)
+	}
+
+	return []byte{}, ErrNoCloudYaml
+}
+
+func cloudsYamlFile(dirname string) (string, bool) {
+	filename := fmt.Sprintf("%s/clouds.yaml", dirname)
+	if f, err := os.Stat(filename); err == nil && f.Mode().IsRegular() {
+		return filename, true
+	}
+	return "", false
+}

--- a/openstack/clientconfig/doc.go
+++ b/openstack/clientconfig/doc.go
@@ -1,0 +1,31 @@
+/*
+Package clientconfig provides convienent functions for creating OpenStack
+clients. It is based on the Python os-client-config library.
+
+See https://docs.openstack.org/os-client-config/latest for details.
+
+Example to Create a Provider Client From clouds.yaml
+
+	opts := &clientconfig.ClientOpts{
+		Name: "hawaii",
+	}
+
+	pClient, err := clientconfig.AuthenticatedClient(opts)
+	if err != nil {
+		panic(err)
+	}
+
+
+Example to Create a Service Client from clouds.yaml
+
+	opts := &clientconfig.ClientOpts{
+		Name: "hawaii",
+	}
+
+	computeClient, err := clientconfig.NewServiceClient("compute", opts)
+	if err != nil {
+		panic(err)
+	}
+
+*/
+package clientconfig

--- a/openstack/clientconfig/requests.go
+++ b/openstack/clientconfig/requests.go
@@ -2,130 +2,273 @@ package clientconfig
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack"
+
 	"gopkg.in/yaml.v2"
 )
 
-var (
-	ErrNoCloudYaml = fmt.Errorf("Clouds.yaml file not found.")
-)
+// ClientOpts represents options to customize the way a client is
+// configured.
+type ClientOpts struct {
+	// Cloud is the cloud entry in clouds.yaml to use.
+	Cloud string
 
-type Clouds struct {
-	Clouds map[string]struct {
-		Profile       string   `yaml:"profile"`
-		RegionName    string   `yaml:"region_name"`
-		Regions       []string `yaml:"regions"`
-		DNSAPIVersion string   `yaml:"dns_api_version"`
-		Auth          struct {
-			AuthURL     string `yaml:"auth_url"`
-			Username    string `yaml:"username"`
-			Password    string `yaml:"password"`
-			ProjectName string `yaml:"project_name"`
-			ProjectID   string `yaml:"project_id"`
-		} `yaml:"auth,omitempty"`
-	}
+	// EnvPrefix allows a custom environment variable prefix to be used.
+	EnvPrefix string
 }
 
-// AuthOptionsFromYaml fills out an identity.AuthOptions structure with the settings found in a specific
-// cloud entry of a clouds.yaml file (as per http://docs.openstack.org/developer/os-client-config)
-// If `env` is set to true, it will also override these values with the various
-// OS_* environment variables.  The following variables provide sources of truth: OS_AUTH_URL, OS_USERNAME,
-// OS_PASSWORD, OS_TENANT_ID, and OS_TENANT_NAME.  Of these, OS_USERNAME, OS_PASSWORD, and OS_AUTH_URL must
-// have settings, or an error will result.  OS_TENANT_ID and OS_TENANT_NAME are optional.
-func AuthOptionsFromYaml(cloud string, env bool) (gophercloud.AuthOptions, error) {
-	clouds := &Clouds{}
-	cloudsContent, err := cloudsYaml()
+// LoadYAML will load a clouds.yaml file and return the full config.
+func LoadYAML() (map[string]Cloud, error) {
+	content, err := findAndReadYAML()
 	if err != nil {
-		return nilOptions, err
+		return nil, err
 	}
-	err = yaml.Unmarshal(cloudsContent, clouds)
+
+	var clouds Clouds
+	err = yaml.Unmarshal(content, &clouds)
 	if err != nil {
-		return nilOptions, fmt.Errorf("Failed to unmarshal YAML: %v", err)
+		return nil, fmt.Errorf("failed to unmarshal yaml: %v", err)
 	}
 
-	auth := clouds.Clouds[cloud].Auth
+	return clouds.Clouds, nil
+}
 
-	authURL := auth.AuthURL
-	username := auth.Username
-	password := auth.Password
-	tenantID := auth.ProjectID
-	tenantName := auth.ProjectName
+// GetCloudFromYAML will return a cloud entry from a clouds.yaml file.
+func GetCloudFromYAML(opts *ClientOpts) (*Cloud, error) {
+	clouds, err := LoadYAML()
+	if err != nil {
+		return nil, fmt.Errorf("unable to load clouds.yaml: %s", err)
+	}
 
-	if env {
-		if v := os.Getenv("OS_AUTH_URL"); v != "" {
-			authURL = v
+	// Determine which cloud to use.
+	var cloudName string
+	if opts != nil && opts.Cloud != "" {
+		cloudName = opts.Cloud
+	}
+
+	if v := os.Getenv("OS_CLOUD"); v != "" {
+		cloudName = v
+	}
+
+	var cloud *Cloud
+	if cloudName != "" {
+		v, ok := clouds[cloudName]
+		if !ok {
+			return nil, fmt.Errorf("cloud %s does not exist in clouds.yaml", cloudName)
 		}
+		cloud = &v
+	}
 
-		if v := os.Getenv("OS_USERNAME"); v != "" {
-			username = v
-		}
-
-		if v := os.Getenv("OS_PASSWORD"); v != "" {
-			password = v
-		}
-
-		if v := os.Getenv("OS_TENANT_ID"); v != "" {
-			tenantID = v
-		}
-
-		if v := os.Getenv("OS_TENANT_NAME"); v != "" {
-			tenantName = v
+	// If a cloud was not specified, and clouds only contains
+	// a single entry, use that entry.
+	if cloudName == "" && len(clouds) == 1 {
+		for _, v := range clouds {
+			cloud = &v
 		}
 	}
 
-	if authURL == "" {
+	if cloud == nil {
+		return nil, fmt.Errorf("Unable to determine a valid entry in clouds.yaml")
+	}
+
+	return cloud, nil
+}
+
+// AuthOptions creates a gophercloud identity.AuthOptions structure with the
+// settings found in a specific cloud entry of a clouds.yaml file.
+// See http://docs.openstack.org/developer/os-client-config and
+// https://github.com/openstack/os-client-config/blob/master/os_client_config/config.py.
+func AuthOptions(opts *ClientOpts) (*gophercloud.AuthOptions, error) {
+	// Get the requested cloud.
+	cloud, err := GetCloudFromYAML(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	auth := cloud.Auth
+
+	// Create a gophercloud.AuthOptions struct based on the clouds.yaml entry.
+	ao := &gophercloud.AuthOptions{
+		IdentityEndpoint: auth.AuthURL,
+		Username:         auth.Username,
+		Password:         auth.Password,
+		TenantID:         auth.ProjectID,
+		TenantName:       auth.ProjectName,
+		DomainID:         auth.DomainID,
+		DomainName:       auth.DomainName,
+	}
+
+	// Domain scope overrides.
+	if auth.ProjectDomainID != "" {
+		ao.DomainID = auth.ProjectDomainID
+	}
+
+	if auth.ProjectDomainName != "" {
+		ao.DomainName = auth.ProjectDomainName
+	}
+
+	// Environment variable overrides.
+	envPrefix := "OS_"
+	if opts != nil && opts.EnvPrefix != "" {
+		envPrefix = opts.EnvPrefix
+	}
+
+	if v := os.Getenv(envPrefix + "AUTH_URL"); v != "" {
+		ao.IdentityEndpoint = v
+	}
+
+	if v := os.Getenv(envPrefix + "USERNAME"); v != "" {
+		ao.Username = v
+	}
+
+	if v := os.Getenv(envPrefix + "PASSWORD"); v != "" {
+		ao.Password = v
+	}
+
+	if v := os.Getenv(envPrefix + "TENANT_ID"); v != "" {
+		ao.TenantID = v
+	}
+
+	if v := os.Getenv(envPrefix + "PROJECT_ID"); v != "" {
+		ao.TenantID = v
+	}
+
+	if v := os.Getenv(envPrefix + "TENANT_NAME"); v != "" {
+		ao.TenantName = v
+	}
+
+	if v := os.Getenv(envPrefix + "PROJECT_NAME"); v != "" {
+		ao.TenantName = v
+	}
+
+	if v := os.Getenv(envPrefix + "DOMAIN_ID"); v != "" {
+		ao.DomainID = v
+	}
+
+	if v := os.Getenv(envPrefix + "PROJECT_DOMAIN_ID"); v != "" {
+		ao.DomainID = v
+	}
+
+	if v := os.Getenv(envPrefix + "DOMAIN_NAME"); v != "" {
+		ao.DomainName = v
+	}
+
+	if v := os.Getenv(envPrefix + "PROJECT_DOMAIN_NAME"); v != "" {
+		ao.DomainName = v
+	}
+
+	// Check for absolute minimum requirements.
+	if ao.IdentityEndpoint == "" {
 		err := gophercloud.ErrMissingInput{Argument: "authURL"}
-		return nilOptions, err
+		return nil, err
 	}
 
-	if username == "" {
+	if ao.Username == "" {
 		err := gophercloud.ErrMissingInput{Argument: "username"}
-		return nilOptions, err
+		return nil, err
 	}
 
-	if password == "" {
+	if ao.Password == "" {
 		err := gophercloud.ErrMissingInput{Argument: "password"}
-		return nilOptions, err
-	}
-
-	ao := gophercloud.AuthOptions{
-		IdentityEndpoint: authURL,
-		Username:         username,
-		Password:         password,
-		TenantID:         tenantID,
-		TenantName:       tenantName,
+		return nil, err
 	}
 
 	return ao, nil
 }
 
-func cloudsYaml() ([]byte, error) {
-	if f, ok := cloudsYamlFile(os.Getenv("USER_CONFIG_DIR")); ok {
-		return ioutil.ReadFile(f)
+// AuthenticatedClient is a convenience function to get a new provider client
+// based on a clouds.yaml entry.
+func AuthenticatedClient(opts *ClientOpts) (*gophercloud.ProviderClient, error) {
+	ao, err := AuthOptions(opts)
+	if err != nil {
+		return nil, err
 	}
 
-	if f, ok := cloudsYamlFile(fmt.Sprintf("%s/.config/openstack", os.Getenv("HOME"))); ok {
-		return ioutil.ReadFile(f)
-	}
-
-	if f, ok := cloudsYamlFile(os.Getenv("SITE_CONFIG_DIR")); ok {
-		return ioutil.ReadFile(f)
-	}
-
-	if f, ok := cloudsYamlFile("/etc/openstack"); ok {
-		return ioutil.ReadFile(f)
-	}
-
-	return []byte{}, ErrNoCloudYaml
+	return openstack.AuthenticatedClient(*ao)
 }
 
-func cloudsYamlFile(dirname string) (string, bool) {
-	filename := fmt.Sprintf("%s/clouds.yaml", dirname)
-	if f, err := os.Stat(filename); err == nil && f.Mode().IsRegular() {
-		return filename, true
+// NewServiceClient is a convenience function to get a new service client.
+func NewServiceClient(service string, opts *ClientOpts) (*gophercloud.ServiceClient, error) {
+	cloud, err := GetCloudFromYAML(opts)
+	if err != nil {
+		return nil, err
 	}
-	return "", false
+
+	// Environment variable overrides.
+	envPrefix := "OS_"
+	if opts != nil && opts.EnvPrefix != "" {
+		envPrefix = opts.EnvPrefix
+	}
+
+	// Get a Provider Client
+	pClient, err := AuthenticatedClient(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	// Determine the region to use.
+	var region string
+	if v := cloud.RegionName; v != "" {
+		region = cloud.RegionName
+	}
+
+	if v := os.Getenv(envPrefix + "REGION_NAME"); v != "" {
+		region = v
+	}
+
+	eo := gophercloud.EndpointOpts{
+		Region: region,
+	}
+
+	switch service {
+	case "compute":
+		return openstack.NewComputeV2(pClient, eo)
+	case "database":
+		return openstack.NewDBV1(pClient, eo)
+	case "dns":
+		return openstack.NewDNSV2(pClient, eo)
+	case "identity":
+		identityVersion := "3"
+		if v := cloud.IdentityAPIVersion; v != "" {
+			identityVersion = v
+		}
+
+		switch identityVersion {
+		case "v2", "2", "2.0":
+			return openstack.NewIdentityV2(pClient, eo)
+		case "v3", "3":
+			return openstack.NewIdentityV3(pClient, eo)
+		default:
+			return nil, fmt.Errorf("invalid identity API version")
+		}
+	case "image":
+		return openstack.NewImageServiceV2(pClient, eo)
+	case "network":
+		return openstack.NewNetworkV2(pClient, eo)
+	case "object-store":
+		return openstack.NewObjectStorageV1(pClient, eo)
+	case "orchestration":
+		return openstack.NewOrchestrationV1(pClient, eo)
+	case "sharev2":
+		return openstack.NewSharedFileSystemV2(pClient, eo)
+	case "volume":
+		volumeVersion := "2"
+		if v := cloud.VolumeAPIVersion; v != "" {
+			volumeVersion = v
+		}
+
+		switch volumeVersion {
+		case "v1", "1":
+			return openstack.NewBlockStorageV1(pClient, eo)
+		case "v2", "2":
+			return openstack.NewBlockStorageV2(pClient, eo)
+		default:
+			return nil, fmt.Errorf("invalid volume API version")
+		}
+	}
+
+	return nil, fmt.Errorf("unable to create a service client for %s", service)
 }

--- a/openstack/clientconfig/requests.go
+++ b/openstack/clientconfig/requests.go
@@ -1,4 +1,4 @@
-package openstack
+package clientconfig
 
 import (
 	"fmt"

--- a/openstack/clientconfig/results.go
+++ b/openstack/clientconfig/results.go
@@ -1,0 +1,32 @@
+package clientconfig
+
+// Clouds represents a collection of Cloud entries in a clouds.yaml file.
+// The format of clouds.yaml is documented at
+// https://docs.openstack.org/os-client-config/latest/user/configuration.html.
+type Clouds struct {
+	Clouds map[string]Cloud `yaml:"clouds"`
+}
+
+// Cloud represents an entry in a clouds.yaml file.
+type Cloud struct {
+	Auth       *CloudAuth    `yaml:"auth"`
+	RegionName string        `yaml:"region_name"`
+	Regions    []interface{} `yaml:"regions"`
+
+	// API Version overrides.
+	IdentityAPIVersion string `yaml:"identity_api_version"`
+	VolumeAPIVersion   string `yaml:"volume_api_version"`
+}
+
+// CloudAuth represents the auth section of a cloud entry.
+type CloudAuth struct {
+	AuthURL           string `yaml:"auth_url"`
+	Username          string `yaml:"username"`
+	Password          string `yaml:"password"`
+	ProjectName       string `yaml:"project_name"`
+	ProjectID         string `yaml:"project_id"`
+	DomainName        string `yaml:"domain_name"`
+	DomainID          string `yaml:"domain_id"`
+	ProjectDomainName string `yaml:"project_domain_name"`
+	ProjectDomainID   string `yaml:"project_domain_id"`
+}

--- a/openstack/clientconfig/testing/clouds.yaml
+++ b/openstack/clientconfig/testing/clouds.yaml
@@ -1,0 +1,31 @@
+clouds:
+  hawaii:
+    profile: "Some profile"
+    auth:
+      auth_url: "https://hi.example.com:5000/v3"
+      username: "jdoe"
+      password: "password"
+      project_name: "Some Project"
+      domain_name: "default"
+    region_name: "HNL"
+  florida:
+    profile: "Some profile"
+    auth:
+      auth_url: "https://fl.example.com:5000/v3"
+      username: "jdoe"
+      password: "password"
+      project_id: "12345"
+      domain_id: "abcde"
+    region_name: "MIA"
+  california:
+    profile: "Some profile"
+    auth:
+      auth_url: "https://ca.example.com:5000/v3"
+      username: "jdoe"
+      password: "password"
+      project_name: "Some Project"
+      domain_name: "default"
+    regions:
+      - SAN
+      - LAX
+

--- a/openstack/clientconfig/testing/fixtures.go
+++ b/openstack/clientconfig/testing/fixtures.go
@@ -1,0 +1,58 @@
+package testing
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/utils/openstack/clientconfig"
+)
+
+var CloudYAMLHawaii = clientconfig.Cloud{
+	RegionName: "HNL",
+	Auth: &clientconfig.CloudAuth{
+		AuthURL:     "https://hi.example.com:5000/v3",
+		Username:    "jdoe",
+		Password:    "password",
+		ProjectName: "Some Project",
+		DomainName:  "default",
+	},
+}
+
+var CloudYAMLFlorida = clientconfig.Cloud{
+	RegionName: "MIA",
+	Auth: &clientconfig.CloudAuth{
+		AuthURL:   "https://fl.example.com:5000/v3",
+		Username:  "jdoe",
+		Password:  "password",
+		ProjectID: "12345",
+		DomainID:  "abcde",
+	},
+}
+
+var CloudYAMLCalifornia = clientconfig.Cloud{
+	Regions: []interface{}{
+		"SAN",
+		"LAX",
+	},
+	Auth: &clientconfig.CloudAuth{
+		AuthURL:     "https://ca.example.com:5000/v3",
+		Username:    "jdoe",
+		Password:    "password",
+		ProjectName: "Some Project",
+		DomainName:  "default",
+	},
+}
+
+var CloudYAML = clientconfig.Clouds{
+	Clouds: map[string]clientconfig.Cloud{
+		"hawaii":     CloudYAMLHawaii,
+		"florida":    CloudYAMLFlorida,
+		"california": CloudYAMLCalifornia,
+	},
+}
+
+var HawaiiAuthOpts = &gophercloud.AuthOptions{
+	IdentityEndpoint: "https://hi.example.com:5000/v3",
+	Username:         "jdoe",
+	Password:         "password",
+	TenantName:       "Some Project",
+	DomainName:       "default",
+}

--- a/openstack/clientconfig/testing/requests_test.go
+++ b/openstack/clientconfig/testing/requests_test.go
@@ -1,0 +1,59 @@
+package testing
+
+import (
+	"os"
+	"testing"
+
+	"github.com/gophercloud/utils/openstack/clientconfig"
+
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestGetCloudFromYAML(t *testing.T) {
+	clientOpts := &clientconfig.ClientOpts{
+		Cloud:     "hawaii",
+		EnvPrefix: "FOO",
+	}
+
+	actual, err := clientconfig.GetCloudFromYAML(clientOpts)
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, &CloudYAMLHawaii, actual)
+
+	clientOpts = &clientconfig.ClientOpts{
+		Cloud:     "california",
+		EnvPrefix: "FOO",
+	}
+
+	actual, err = clientconfig.GetCloudFromYAML(clientOpts)
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, &CloudYAMLCalifornia, actual)
+}
+
+func TestAuthOptionsExplicitCloud(t *testing.T) {
+	clientOpts := &clientconfig.ClientOpts{
+		Cloud:     "hawaii",
+		EnvPrefix: "FOO",
+	}
+
+	actual, err := clientconfig.AuthOptions(clientOpts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	th.AssertDeepEquals(t, HawaiiAuthOpts, actual)
+}
+
+func TestAuthOptionsOSCLOUD(t *testing.T) {
+	os.Setenv("OS_CLOUD", "hawaii")
+
+	clientOpts := &clientconfig.ClientOpts{
+		EnvPrefix: "FOO",
+	}
+
+	actual, err := clientconfig.AuthOptions(clientOpts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	th.AssertDeepEquals(t, HawaiiAuthOpts, actual)
+}

--- a/openstack/clientconfig/utils.go
+++ b/openstack/clientconfig/utils.go
@@ -6,8 +6,6 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
-
-	"github.com/Wessie/appdirs"
 )
 
 // findAndLoadYAML attempts to locate a clouds.yaml file in the following
@@ -15,10 +13,8 @@ import (
 //
 // 1. OS_CLIENT_CONFIG_FILE
 // 2. Current directory.
-// 3. XDG OS-specific user_config_dir
-// 4. unix-specific user_config_dir (~/.config/openstack/clouds.yaml)
-// 5. XDG OS-specific site_config_dir
-// 6. unix-specific site_config_dir (/etc/openstack/clouds.yaml)
+// 3. unix-specific user_config_dir (~/.config/openstack/clouds.yaml)
+// 4. unix-specific site_config_dir (/etc/openstack/clouds.yaml)
 //
 // If found, the contents of the file is returned.
 func findAndReadYAML() ([]byte, error) {
@@ -40,18 +36,7 @@ func findAndReadYAML() ([]byte, error) {
 		return ioutil.ReadFile(filename)
 	}
 
-	// xdg os-specific user_config_dir
-	app := appdirs.New("openstack", "", "")
-	if v := app.UserConfig(); v != "" {
-		filename := filepath.Join(v, "clouds.yaml")
-		if ok := fileExists(filename); ok {
-			return ioutil.ReadFile(filename)
-		}
-	}
-
-	// unix-specific user_config_dir.
-	// xdg on Mac/Darwin is "Application Support",
-	// but maybe ~/.config/openstack exists anyway.
+	// unix user config directory: ~/.config/openstack.
 	currentUser, err := user.Current()
 	if err != nil {
 		return nil, fmt.Errorf("unable to get current user: %s", err)
@@ -65,15 +50,7 @@ func findAndReadYAML() ([]byte, error) {
 		}
 	}
 
-	// xdg OS-specific site_config_dir
-	if v := app.SiteConfig(); v != "" {
-		filename := filepath.Join(v, "clouds.yaml")
-		if ok := fileExists(filename); ok {
-			return ioutil.ReadFile(filename)
-		}
-	}
-
-	// unix-specific site_config_dir
+	// unix-specific site config directory: /etc/openstack.
 	if ok := fileExists("/etc/openstack/clouds.yaml"); ok {
 		return ioutil.ReadFile("/etc/openstack/clouds.yaml")
 	}

--- a/openstack/clientconfig/utils.go
+++ b/openstack/clientconfig/utils.go
@@ -1,0 +1,90 @@
+package clientconfig
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/user"
+	"path/filepath"
+
+	"github.com/Wessie/appdirs"
+)
+
+// findAndLoadYAML attempts to locate a clouds.yaml file in the following
+// locations:
+//
+// 1. OS_CLIENT_CONFIG_FILE
+// 2. Current directory.
+// 3. XDG OS-specific user_config_dir
+// 4. unix-specific user_config_dir (~/.config/openstack/clouds.yaml)
+// 5. XDG OS-specific site_config_dir
+// 6. unix-specific site_config_dir (/etc/openstack/clouds.yaml)
+//
+// If found, the contents of the file is returned.
+func findAndReadYAML() ([]byte, error) {
+	// OS_CLIENT_CONFIG_FILE
+	if v := os.Getenv("OS_CLIENT_CONFIG_FILE"); v != "" {
+		if ok := fileExists(v); ok {
+			return ioutil.ReadFile(v)
+		}
+	}
+
+	// current directory
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, fmt.Errorf("unable to determine working directory: %s", err)
+	}
+
+	filename := filepath.Join(cwd, "clouds.yaml")
+	if ok := fileExists(filename); ok {
+		return ioutil.ReadFile(filename)
+	}
+
+	// xdg os-specific user_config_dir
+	app := appdirs.New("openstack", "", "")
+	if v := app.UserConfig(); v != "" {
+		filename := filepath.Join(v, "clouds.yaml")
+		if ok := fileExists(filename); ok {
+			return ioutil.ReadFile(filename)
+		}
+	}
+
+	// unix-specific user_config_dir.
+	// xdg on Mac/Darwin is "Application Support",
+	// but maybe ~/.config/openstack exists anyway.
+	currentUser, err := user.Current()
+	if err != nil {
+		return nil, fmt.Errorf("unable to get current user: %s", err)
+	}
+
+	homeDir := currentUser.HomeDir
+	if homeDir != "" {
+		filename := filepath.Join(homeDir, ".config/openstack/clouds.yaml")
+		if ok := fileExists(filename); ok {
+			return ioutil.ReadFile(filename)
+		}
+	}
+
+	// xdg OS-specific site_config_dir
+	if v := app.SiteConfig(); v != "" {
+		filename := filepath.Join(v, "clouds.yaml")
+		if ok := fileExists(filename); ok {
+			return ioutil.ReadFile(filename)
+		}
+	}
+
+	// unix-specific site_config_dir
+	if ok := fileExists("/etc/openstack/clouds.yaml"); ok {
+		return ioutil.ReadFile("/etc/openstack/clouds.yaml")
+	}
+
+	return nil, fmt.Errorf("no clouds.yaml file found")
+}
+
+// fileExists checks for the existence of a file at a given location.
+func fileExists(filename string) bool {
+	if _, err := os.Stat(filename); err == nil {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
This commit introduces the clientconfig package. clientconfig
is based on the Python os-client-config library and will offer
convenience functions for creating OpenStack clients.