### PR TITLE
Implement Gnocchi archive policy list

### DIFF
--- a/acceptance/gnocchi/metric/v1/archivepolicies_test.go
+++ b/acceptance/gnocchi/metric/v1/archivepolicies_test.go
@@ -1,0 +1,30 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/acceptance/tools"
+	"github.com/gophercloud/utils/acceptance/clients"
+	"github.com/gophercloud/utils/gnocchi/metric/v1/archivepolicies"
+)
+
+func TestArchivePoliciesList(t *testing.T) {
+	client, err := clients.NewGnocchiV1Client()
+	if err != nil {
+		t.Fatalf("Unable to create a Gnocchi client: %v", err)
+	}
+
+	allPages, err := archivepolicies.List(client).AllPages()
+	if err != nil {
+		t.Fatalf("Unable to list archive policies: %v", err)
+	}
+
+	allArchivePolicies, err := archivepolicies.ExtractArchivePolicies(allPages)
+	if err != nil {
+		t.Fatalf("Unable to extract archive policies: %v", err)
+	}
+
+	for _, archivePolicy := range allArchivePolicies {
+		tools.PrintResource(t, archivePolicy)
+	}
+}

--- a/acceptance/gnocchi/metric/v1/archivepolicies_test.go
+++ b/acceptance/gnocchi/metric/v1/archivepolicies_test.go
@@ -1,3 +1,5 @@
+// +build acceptance metric archivepolicies
+
 package v1
 
 import (

--- a/acceptance/gnocchi/metric/v1/pkg.go
+++ b/acceptance/gnocchi/metric/v1/pkg.go
@@ -1,0 +1,1 @@
+package v1

--- a/gnocchi/metric/v1/archivepolicies/doc.go
+++ b/gnocchi/metric/v1/archivepolicies/doc.go
@@ -1,0 +1,21 @@
+/*
+Package archivepolicies provides the ability to retrieve archive policies
+through the Gnocchi API.
+
+Example of Listing archive policies
+
+	allPages, err := archivepolicies.List(gnocchiClient).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allArchivePolicies, err := archivepolicies.ExtractArchivePolicies(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, archivePolicy := range allArchivePolicies {
+		fmt.Printf("%+v\n", archivePolicy)
+	}
+*/
+package archivepolicies

--- a/gnocchi/metric/v1/archivepolicies/requests.go
+++ b/gnocchi/metric/v1/archivepolicies/requests.go
@@ -1,0 +1,13 @@
+package archivepolicies
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// List makes a request against the Gnocchi API to list archive policies.
+func List(client *gophercloud.ServiceClient) pagination.Pager {
+	return pagination.NewPager(client, listURL(client), func(r pagination.PageResult) pagination.Page {
+		return ArchivePolicyPage{pagination.SinglePageBase(r)}
+	})
+}

--- a/gnocchi/metric/v1/archivepolicies/results.go
+++ b/gnocchi/metric/v1/archivepolicies/results.go
@@ -1,0 +1,74 @@
+package archivepolicies
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+type archivePolicyResult struct {
+	gophercloud.Result
+}
+
+// ArchivePolicy represents a Gnocchi archive policy.
+// Archive policy is an aggregate storage policy attached to a metric.
+// It determines how long aggregates will be kept in a metric and how they will be aggregated.
+type ArchivePolicy struct {
+	// AggregationMethods is a list of functions used to aggregate
+	// multiple measures into an aggregate.
+	AggregationMethods []string `json:"aggregation_methods"`
+
+	// BackWindow configures number of coarsest periods to keep.
+	// It allows to process measures that are older
+	// than the last timestamp period boundary.
+	BackWindow int `json:"back_window"`
+
+	// Definitions is a list of parameters that configures
+	// archive policy precision and timespan.
+	Definitions []ArchivePolicyDefinition `json:"definition"`
+
+	// Name is a name of an archive policy.
+	Name string `json:"name"`
+}
+
+// ArchivePolicyDefinition represents definition of how metrics will
+// be saved with the selected archive policy.
+// It configures precision and timespan.
+type ArchivePolicyDefinition struct {
+	// Granularity is the level of  precision that must be kept when aggregating data.
+	Granularity string `json:"granularity"`
+
+	// Points is a given aggregates or samples in the lifespan of a time series.
+	// Time series is a list of aggregates ordered by time.
+	Points int `json:"points"`
+
+	// TimeSpan is the time period for which a metric keeps its aggregates.
+	TimeSpan string `json:"timespan"`
+}
+
+// ArchivePolicyPage abstracts the raw results of making a List() request against
+// the Gnocchi API.
+//
+// As Gnocchi API may freely alter the response bodies of structures
+// returned to the client, you may only safely access the data provided through
+// the ExtractArchivePolicies call.
+type ArchivePolicyPage struct {
+	pagination.SinglePageBase
+}
+
+// IsEmpty returns true if an ArchivePolicyPage contains no archive policies.
+func (r ArchivePolicyPage) IsEmpty() (bool, error) {
+	archivePolicies, err := ExtractArchivePolicies(r)
+	return len(archivePolicies) == 0, err
+}
+
+// ExtractArchivePolicies interprets the results of a single page from a List() call,
+// producing a slice of ArchivePolicy structs.
+func ExtractArchivePolicies(r pagination.Page) ([]ArchivePolicy, error) {
+	var s []ArchivePolicy
+	err := (r.(ArchivePolicyPage)).ExtractInto(&s)
+	if err != nil {
+		return nil, err
+	}
+
+	return s, err
+}

--- a/gnocchi/metric/v1/archivepolicies/results.go
+++ b/gnocchi/metric/v1/archivepolicies/results.go
@@ -1,13 +1,6 @@
 package archivepolicies
 
-import (
-	"github.com/gophercloud/gophercloud"
-	"github.com/gophercloud/gophercloud/pagination"
-)
-
-type archivePolicyResult struct {
-	gophercloud.Result
-}
+import "github.com/gophercloud/gophercloud/pagination"
 
 // ArchivePolicy represents a Gnocchi archive policy.
 // Archive policy is an aggregate storage policy attached to a metric.

--- a/gnocchi/metric/v1/archivepolicies/results.go
+++ b/gnocchi/metric/v1/archivepolicies/results.go
@@ -15,9 +15,9 @@ type ArchivePolicy struct {
 	// than the last timestamp period boundary.
 	BackWindow int `json:"back_window"`
 
-	// Definitions is a list of parameters that configures
+	// Definition is a list of parameters that configures
 	// archive policy precision and timespan.
-	Definitions []ArchivePolicyDefinition `json:"definition"`
+	Definition []ArchivePolicyDefinition `json:"definition"`
 
 	// Name is a name of an archive policy.
 	Name string `json:"name"`

--- a/gnocchi/metric/v1/archivepolicies/testing/doc.go
+++ b/gnocchi/metric/v1/archivepolicies/testing/doc.go
@@ -1,0 +1,2 @@
+// archivepolicies unit tests
+package testing

--- a/gnocchi/metric/v1/archivepolicies/testing/fixtures.go
+++ b/gnocchi/metric/v1/archivepolicies/testing/fixtures.go
@@ -1,0 +1,103 @@
+package testing
+
+import (
+	"github.com/gophercloud/gophercloud/utils/gnocchi/metric/v1/archivepolicies"
+)
+
+// ArchivePoliciesListResult represents raw server response from a server to a list call.
+const ArchivePoliciesListResult = `[
+    {
+        "aggregation_methods": [
+					"max",
+					"min"
+        ],
+        "back_window": 0,
+        "definition": [
+            {
+                "granularity": "1:00:00",
+                "points": 2304,
+                "timespan": "96 days, 0:00:00"
+            },
+            {
+                "granularity": "0:05:00",
+                "points": 9216,
+                "timespan": "32 days, 0:00:00"
+            },
+            {
+                "granularity": "1 day, 0:00:00",
+                "points": 400,
+                "timespan": "400 days, 0:00:00"
+            }
+        ],
+        "name": "precise"
+    },
+    {
+	        "aggregation_methods": [
+							"mean",
+							"sum"
+	        ],
+	        "back_window": 12,
+	        "definition": [
+			    {
+					    "granularity": "1:00:00",
+					    "points": 2160,
+					    "timespan": "90 days, 0:00:00"
+			    },
+			    {
+				      "granularity": "1 day, 0:00:00",
+				      "points": 200,
+				      "timespan": "200 days, 0:00:00"
+			    }
+	        ],
+	        "name": "not_so_precise"
+    }
+]`
+
+// ListArchivePoliciesExpected represents an expected repsonse from a List request.
+var ListArchivePoliciesExpected = []archivepolicies.ArchivePolicy{
+	{
+		AggregationMethods: []string{
+			"max",
+			"min",
+		},
+		BackWindow: 0,
+		Definitions: []archivepolicies.ArchivePolicyDefinition{
+			{
+				Granularity: "1:00:00",
+				Points:      2304,
+				TimeSpan:    "96 days, 0:00:00",
+			},
+			{
+				Granularity: "0:05:00",
+				Points:      9216,
+				TimeSpan:    "32 days, 0:00:00",
+			},
+			{
+				Granularity: "1 day, 0:00:00",
+				Points:      400,
+				TimeSpan:    "400 days, 0:00:00",
+			},
+		},
+		Name: "precise",
+	},
+	{
+		AggregationMethods: []string{
+			"mean",
+			"sum",
+		},
+		BackWindow: 12,
+		Definitions: []archivepolicies.ArchivePolicyDefinition{
+			{
+				Granularity: "1:00:00",
+				Points:      2160,
+				TimeSpan:    "90 days, 0:00:00",
+			},
+			{
+				Granularity: "1 day, 0:00:00",
+				Points:      200,
+				TimeSpan:    "200 days, 0:00:00",
+			},
+		},
+		Name: "not_so_precise",
+	},
+}

--- a/gnocchi/metric/v1/archivepolicies/testing/fixtures.go
+++ b/gnocchi/metric/v1/archivepolicies/testing/fixtures.go
@@ -63,7 +63,7 @@ var ListArchivePoliciesExpected = []archivepolicies.ArchivePolicy{
 			"min",
 		},
 		BackWindow: 0,
-		Definitions: []archivepolicies.ArchivePolicyDefinition{
+		Definition: []archivepolicies.ArchivePolicyDefinition{
 			{
 				Granularity: "1:00:00",
 				Points:      2304,
@@ -88,7 +88,7 @@ var ListArchivePoliciesExpected = []archivepolicies.ArchivePolicy{
 			"sum",
 		},
 		BackWindow: 12,
-		Definitions: []archivepolicies.ArchivePolicyDefinition{
+		Definition: []archivepolicies.ArchivePolicyDefinition{
 			{
 				Granularity: "1:00:00",
 				Points:      2160,

--- a/gnocchi/metric/v1/archivepolicies/testing/fixtures.go
+++ b/gnocchi/metric/v1/archivepolicies/testing/fixtures.go
@@ -1,7 +1,7 @@
 package testing
 
 import (
-	"github.com/gophercloud/gophercloud/utils/gnocchi/metric/v1/archivepolicies"
+	"github.com/gophercloud/utils/gnocchi/metric/v1/archivepolicies"
 )
 
 // ArchivePoliciesListResult represents raw server response from a server to a list call.

--- a/gnocchi/metric/v1/archivepolicies/testing/fixtures.go
+++ b/gnocchi/metric/v1/archivepolicies/testing/fixtures.go
@@ -5,11 +5,12 @@ import (
 )
 
 // ArchivePoliciesListResult represents raw server response from a server to a list call.
-const ArchivePoliciesListResult = `[
+const ArchivePoliciesListResult = `
+[
     {
         "aggregation_methods": [
-					"max",
-					"min"
+            "max",
+            "min"
         ],
         "back_window": 0,
         "definition": [
@@ -32,26 +33,27 @@ const ArchivePoliciesListResult = `[
         "name": "precise"
     },
     {
-	        "aggregation_methods": [
-							"mean",
-							"sum"
-	        ],
-	        "back_window": 12,
-	        "definition": [
-			    {
-					    "granularity": "1:00:00",
-					    "points": 2160,
-					    "timespan": "90 days, 0:00:00"
-			    },
-			    {
-				      "granularity": "1 day, 0:00:00",
-				      "points": 200,
-				      "timespan": "200 days, 0:00:00"
-			    }
-	        ],
-	        "name": "not_so_precise"
+        "aggregation_methods": [
+            "mean",
+            "sum"
+        ],
+        "back_window": 12,
+        "definition": [
+            {
+                "granularity": "1:00:00",
+                "points": 2160,
+                "timespan": "90 days, 0:00:00"
+            },
+            {
+                "granularity": "1 day, 0:00:00",
+                "points": 200,
+                "timespan": "200 days, 0:00:00"
+            }
+        ],
+        "name": "not_so_precise"
     }
-]`
+]
+`
 
 // ListArchivePoliciesExpected represents an expected repsonse from a List request.
 var ListArchivePoliciesExpected = []archivepolicies.ArchivePolicy{

--- a/gnocchi/metric/v1/archivepolicies/testing/requests_test.go
+++ b/gnocchi/metric/v1/archivepolicies/testing/requests_test.go
@@ -1,0 +1,65 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/pagination"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/utils/gnocchi/metric/v1/archivepolicies"
+	fake "github.com/gophercloud/gophercloud/utils/gnocchi/metric/v1/common"
+)
+
+func TestListArchivePolicies(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v1/archive_policy", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, ArchivePoliciesListResult)
+	})
+
+	expected := ListArchivePoliciesExpected
+	pages := 0
+	err := archivepolicies.List(fake.ServiceClient()).EachPage(func(page pagination.Page) (bool, error) {
+		pages++
+
+		actual, err := archivepolicies.ExtractArchivePolicies(page)
+		th.AssertNoErr(t, err)
+
+		if len(actual) != 2 {
+			t.Fatalf("Expected 2 archive policy, got %d", len(actual))
+		}
+		th.CheckDeepEquals(t, expected, actual)
+
+		return true, nil
+	})
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, 1, pages)
+}
+
+func TestListArchivePoliciesAllPages(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v1/archive_policy", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, ArchivePoliciesListResult)
+	})
+
+	allPages, err := archivepolicies.List(fake.ServiceClient()).AllPages()
+	th.AssertNoErr(t, err)
+	_, err = archivepolicies.ExtractArchivePolicies(allPages)
+	th.AssertNoErr(t, err)
+}

--- a/gnocchi/metric/v1/archivepolicies/testing/requests_test.go
+++ b/gnocchi/metric/v1/archivepolicies/testing/requests_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/gophercloud/gophercloud/pagination"
 	th "github.com/gophercloud/gophercloud/testhelper"
-	"github.com/gophercloud/gophercloud/utils/gnocchi/metric/v1/archivepolicies"
-	fake "github.com/gophercloud/gophercloud/utils/gnocchi/metric/v1/common"
+	"github.com/gophercloud/utils/gnocchi/metric/v1/archivepolicies"
+	fake "github.com/gophercloud/utils/gnocchi/metric/v1/common"
 )
 
 func TestListArchivePolicies(t *testing.T) {

--- a/gnocchi/metric/v1/archivepolicies/testing/requests_test.go
+++ b/gnocchi/metric/v1/archivepolicies/testing/requests_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/gophercloud/gophercloud/pagination"
 	th "github.com/gophercloud/gophercloud/testhelper"
 	"github.com/gophercloud/utils/gnocchi/metric/v1/archivepolicies"
-	fake "github.com/gophercloud/utils/gnocchi/metric/v1/common"
+	fake "github.com/gophercloud/utils/gnocchi/testhelper/client"
 )
 
 func TestListArchivePolicies(t *testing.T) {

--- a/gnocchi/metric/v1/archivepolicies/urls.go
+++ b/gnocchi/metric/v1/archivepolicies/urls.go
@@ -1,0 +1,13 @@
+package archivepolicies
+
+import "github.com/gophercloud/gophercloud"
+
+const resourcePath = "archive_policy"
+
+func rootURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL(resourcePath)
+}
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return rootURL(c)
+}

--- a/gnocchi/metric/v1/common/common_tests.go
+++ b/gnocchi/metric/v1/common/common_tests.go
@@ -1,0 +1,16 @@
+package common
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+// TokenID is a fake Identity service token.
+const TokenID = client.TokenID
+
+// ServiceClient returns a generic service client for use in tests.
+func ServiceClient() *gophercloud.ServiceClient {
+	sc := client.ServiceClient()
+	sc.ResourceBase = sc.Endpoint + "v1/"
+	return sc
+}

--- a/gnocchi/testhelper/client/fake.go
+++ b/gnocchi/testhelper/client/fake.go
@@ -1,4 +1,4 @@
-package common
+package client
 
 import (
 	"github.com/gophercloud/gophercloud"


### PR DESCRIPTION
Add Gnocchi archive policy structure and list request.
Add unit tests and fake Gnocchi service client for tests.

The same command with Gnocchi CLI is done with:
`gnocchi archive-policy list`

For [#698](https://github.com/gophercloud/gophercloud/issues/698)

Links to the line numbers/files in the Gnocchi source code that support the
code in this PR:

https://github.com/gnocchixyz/gnocchi/blob/stable/4.1/gnocchi/rest/api.py#L333
https://github.com/gnocchixyz/gnocchi/blob/stable/4.1/gnocchi/indexer/sqlalchemy.py#L563
https://github.com/gnocchixyz/gnocchi/blob/stable/4.1/gnocchi/archive_policy.py#L29
  