### PR TITLE
Implement Gnocchi service client

### DIFF
--- a/gnocchi/client.go
+++ b/gnocchi/client.go
@@ -1,0 +1,25 @@
+package gnocchi
+
+import (
+	"github.com/gophercloud/gophercloud"
+)
+
+func initClientOpts(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, clientType string) (*gophercloud.ServiceClient, error) {
+	sc := new(gophercloud.ServiceClient)
+	eo.ApplyDefaults(clientType)
+	url, err := client.EndpointLocator(eo)
+	if err != nil {
+		return sc, err
+	}
+	sc.ProviderClient = client
+	sc.Endpoint = url
+	sc.Type = clientType
+	return sc, nil
+}
+
+// NewGnocchiV1 creates a ServiceClient that may be used with the v1 Gnocchi package.
+func NewGnocchiV1(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
+	sc, err := initClientOpts(client, eo, "metric")
+	sc.ResourceBase = sc.Endpoint + "v1/"
+	return sc, err
+}


### PR DESCRIPTION
Add NewGnocchiV1 to work with Gnocchi v1 REST API.

For [#698](https://github.com/gophercloud/gophercloud/issues/698)

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:
https://github.com/gnocchixyz/python-gnocchiclient/blob/stable/4.0/gnocchiclient/v1/client.py#L41