### PR TITLE
Implement Gnocchi metric list

### DIFF
--- a/acceptance/gnocchi/metric/v1/metrics_test.go
+++ b/acceptance/gnocchi/metric/v1/metrics_test.go
@@ -1,0 +1,31 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/acceptance/tools"
+	"github.com/gophercloud/utils/acceptance/clients"
+	"github.com/gophercloud/utils/gnocchi/metric/v1/metrics"
+)
+
+func TestMetricsList(t *testing.T) {
+	client, err := clients.NewGnocchiV1Client()
+	if err != nil {
+		t.Fatalf("Unable to create a Gnocchi client: %v", err)
+	}
+
+	listOpts := metrics.ListOpts{}
+	allPages, err := metrics.List(client, listOpts).AllPages()
+	if err != nil {
+		t.Fatalf("Unable to list metrics: %v", err)
+	}
+
+	allMetrics, err := metrics.ExtractMetrics(allPages)
+	if err != nil {
+		t.Fatalf("Unable to extract metrics: %v", err)
+	}
+
+	for _, metric := range allMetrics {
+		tools.PrintResource(t, metric)
+	}
+}

--- a/acceptance/gnocchi/metric/v1/metrics_test.go
+++ b/acceptance/gnocchi/metric/v1/metrics_test.go
@@ -1,3 +1,5 @@
+// +build acceptance metric metrics
+
 package v1
 
 import (

--- a/gnocchi/metric/v1/metrics/doc.go
+++ b/gnocchi/metric/v1/metrics/doc.go
@@ -1,0 +1,24 @@
+/*
+Package metrics provides the ability to retrieve metrics through the Gnocchi API.
+
+Example of Listing metrics
+
+	listOpts := metrics.ListOpts{
+		Limit: 25,
+	}
+
+	allPages, err := metrics.List(gnocchiClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allMetrics, err := metrics.ExtractMetrics(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, metric := range allMetrics {
+		fmt.Printf("%+v\n", metric)
+	}
+*/
+package metrics

--- a/gnocchi/metric/v1/metrics/requests.go
+++ b/gnocchi/metric/v1/metrics/requests.go
@@ -47,6 +47,6 @@ func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 		url += query
 	}
 	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
-		return MetricPage{pagination.LinkedPageBase{PageResult: r}}
+		return MetricPage{pagination.SinglePageBase(r)}
 	})
 }

--- a/gnocchi/metric/v1/metrics/requests.go
+++ b/gnocchi/metric/v1/metrics/requests.go
@@ -26,6 +26,17 @@ type ListOpts struct {
 	// SortDir allows to set the direction of sorting.
 	// Can be `asc` or `desc`.
 	SortDir string `q:"sort_dir"`
+
+	// Creator shows who created the metric.
+	// Usually it contains concatenated string with values from
+	// "created_by_user_id" and "created_by_project_id" fields.
+	Creator string `json:"creator"`
+
+	// ProjectID is the Identity project of the metric.
+	ProjectID string `json:"project_id"`
+
+	// UserID is the Identity user of the metric.
+	UserID string `json:"user_id"`
 }
 
 // ToMetricListQuery formats a ListOpts into a query string.

--- a/gnocchi/metric/v1/metrics/requests.go
+++ b/gnocchi/metric/v1/metrics/requests.go
@@ -13,13 +13,18 @@ type ListOptsBuilder interface {
 
 // ListOpts allows the limiting and sorting of paginated collections through
 // the Gnocchi API.
-// SortKey allows you to sort by a particular metric attribute.
-// SortDir sets the direction, and is either `asc` or `desc`.
-// Marker and Limit are used for the pagination.
 type ListOpts struct {
-	Limit   int    `q:"limit"`
-	Marker  string `q:"marker"`
+	// Limit allows to limits count of metrics in the response.
+	Limit int `q:"limit"`
+
+	// Marker is used for pagination.
+	Marker string `q:"marker"`
+
+	// SortKey allows to sort metrics in the response by key.
 	SortKey string `q:"sort_key"`
+
+	// SortDir allows to set the direction of sorting.
+	// Can be `asc` or `desc`.
 	SortDir string `q:"sort_dir"`
 }
 
@@ -30,7 +35,7 @@ func (opts ListOpts) ToMetricListQuery() (string, error) {
 }
 
 // List returns a Pager which allows you to iterate over a collection of
-// metrics. It accepts a ListOpts struct, which allows you to filter and sort
+// metrics. It accepts a ListOpts struct, which allows you to limit and sort
 // the returned collection for a greater efficiency.
 func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(c)

--- a/gnocchi/metric/v1/metrics/requests.go
+++ b/gnocchi/metric/v1/metrics/requests.go
@@ -1,0 +1,47 @@
+package metrics
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// ListOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type ListOptsBuilder interface {
+	ToMetricListQuery() (string, error)
+}
+
+// ListOpts allows the limiting and sorting of paginated collections through
+// the Gnocchi API.
+// SortKey allows you to sort by a particular metric attribute.
+// SortDir sets the direction, and is either `asc` or `desc`.
+// Marker and Limit are used for the pagination.
+type ListOpts struct {
+	Limit   int    `q:"limit"`
+	Marker  string `q:"marker"`
+	SortKey string `q:"sort_key"`
+	SortDir string `q:"sort_dir"`
+}
+
+// ToMetricListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToMetricListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List returns a Pager which allows you to iterate over a collection of
+// metrics. It accepts a ListOpts struct, which allows you to filter and sort
+// the returned collection for a greater efficiency.
+func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(c)
+	if opts != nil {
+		query, err := opts.ToMetricListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		return MetricPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}

--- a/gnocchi/metric/v1/metrics/results.go
+++ b/gnocchi/metric/v1/metrics/results.go
@@ -48,7 +48,7 @@ type Metric struct {
 // MetricPage is the page returned by a pager when traversing over a collection
 // of metrics.
 type MetricPage struct {
-	pagination.LinkedPageBase
+	pagination.SinglePageBase
 }
 
 // IsEmpty checks whether a MetricPage struct is empty.
@@ -57,9 +57,8 @@ func (r MetricPage) IsEmpty() (bool, error) {
 	return len(is) == 0, err
 }
 
-// ExtractMetrics accepts a Page struct, specifically a MetricPage struct,
-// and extracts the elements into a slice of Metric structs. In other words,
-// a generic collection is mapped into a relevant slice.
+// ExtractMetrics interprets the results of a single page from a List() call,
+// producing a slice of Metric structs.
 func ExtractMetrics(r pagination.Page) ([]Metric, error) {
 	var s []Metric
 	err := (r.(MetricPage)).ExtractInto(&s)

--- a/gnocchi/metric/v1/metrics/results.go
+++ b/gnocchi/metric/v1/metrics/results.go
@@ -1,14 +1,9 @@
 package metrics
 
 import (
-	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/pagination"
 	"github.com/gophercloud/utils/gnocchi/metric/v1/archivepolicies"
 )
-
-type metricResult struct {
-	gophercloud.Result
-}
 
 // Metric is an entity storing aggregates identified by an UUID.
 // It can be attached to a resource using a name.

--- a/gnocchi/metric/v1/metrics/results.go
+++ b/gnocchi/metric/v1/metrics/results.go
@@ -51,27 +51,6 @@ type MetricPage struct {
 	pagination.LinkedPageBase
 }
 
-// NextPageURL is invoked when a paginated collection of metrics has reached
-// the end of a page and the pager seeks to traverse over a new one.
-// In order to do this, it needs to construct the next page's URL.
-//
-// Gnocchi API doesn't provide special JSON with pagination links. Instead it expects
-// a new URL with a metric's id as a marker.
-func (r MetricPage) NextPageURL() (string, error) {
-	var s []Metric
-
-	err := r.ExtractInto(&s)
-	if err != nil {
-		return "", err
-	}
-
-	lastMetric := s[len(s)-1]
-	lastMetricID := lastMetric.ID
-	nextPageURL := r.PageResult.URL.String() + "?marker=" + lastMetricID
-
-	return nextPageURL, nil
-}
-
 // IsEmpty checks whether a MetricPage struct is empty.
 func (r MetricPage) IsEmpty() (bool, error) {
 	is, err := ExtractMetrics(r)

--- a/gnocchi/metric/v1/metrics/results.go
+++ b/gnocchi/metric/v1/metrics/results.go
@@ -14,6 +14,12 @@ type Metric struct {
 	// storage policy of a metric.
 	ArchivePolicy archivepolicies.ArchivePolicy `json:"archive_policy"`
 
+	// ArchivePolicyName is a name of the Gnocchi archive policy that describes
+	// the aggregate storage policy of a metric.
+	// Usually that field is not empty if a Metric struct is a result
+	// from a create request.
+	ArchivePolicyName string `json:"archive_policy_name"`
+
 	// CreatedByProjectID contains the id of the Identity project that
 	// was used for a metric creation.
 	CreatedByProjectID string `json:"created_by_project_id"`

--- a/gnocchi/metric/v1/metrics/results.go
+++ b/gnocchi/metric/v1/metrics/results.go
@@ -20,7 +20,7 @@ type Metric struct {
 	ArchivePolicy archivepolicies.ArchivePolicy `json:"archive_policy"`
 
 	// CreatedByProjectID contains the id of the Identity project that
-	// were used for metric creation.
+	// was used for a metric creation.
 	CreatedByProjectID string `json:"created_by_project_id"`
 
 	// CreatedByUserID contains the id of the Identity user
@@ -29,7 +29,7 @@ type Metric struct {
 
 	// Creator shows who created the metric.
 	// Usually it contains concatenated string with values from
-	// "created_by_project_id" and "created_by_user_id" fields.
+	// "created_by_user_id" and "created_by_project_id" fields.
 	Creator string `json:"creator"`
 
 	// ID uniquely identifies the Gnocchi metric.

--- a/gnocchi/metric/v1/metrics/results.go
+++ b/gnocchi/metric/v1/metrics/results.go
@@ -1,0 +1,92 @@
+package metrics
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+	"github.com/gophercloud/utils/gnocchi/metric/v1/archivepolicies"
+)
+
+type metricResult struct {
+	gophercloud.Result
+}
+
+// Metric is an entity storing aggregates identified by an UUID.
+// It can be attached to a resource using a name.
+// How a metric stores its aggregates is defined by the archive policy
+// it is associated to.
+type Metric struct {
+	// ArchivePolicy is a Gnocchi archive policy that describes the aggregate
+	// storage policy of a metric.
+	ArchivePolicy archivepolicies.ArchivePolicy `json:"archive_policy"`
+
+	// CreatedByProjectID contains the id of the Identity project that
+	// were used for metric creation.
+	CreatedByProjectID string `json:"created_by_project_id"`
+
+	// CreatedByUserID contains the id of the Identity user
+	// that created the Gnocchi metric.
+	CreatedByUserID string `json:"created_by_user_id"`
+
+	// Creator shows who created the metric.
+	// Usually it contains concatenated string with values from
+	// "created_by_project_id" and "created_by_user_id" fields.
+	Creator string `json:"creator"`
+
+	// ID uniquely identifies the Gnocchi metric.
+	ID string `json:"id"`
+
+	// Name is a human-readable name for the Gnocchi metric.
+	Name string `json:"name"`
+
+	// ResourceID identifies the associated Gnocchi resource of the metric.
+	ResourceID string `json:"resource_id"`
+
+	// Unit is a unit of measurement for measures of that Gnocchi metric.
+	Unit string `json:"unit"`
+}
+
+// MetricPage is the page returned by a pager when traversing over a collection
+// of metrics.
+type MetricPage struct {
+	pagination.LinkedPageBase
+}
+
+// NextPageURL is invoked when a paginated collection of metrics has reached
+// the end of a page and the pager seeks to traverse over a new one.
+// In order to do this, it needs to construct the next page's URL.
+//
+// Gnocchi API doesn't provide special JSON with pagination links. Instead it expects
+// a new URL with a metric's id as a marker.
+func (r MetricPage) NextPageURL() (string, error) {
+	var s []Metric
+
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+
+	lastMetric := s[len(s)-1]
+	lastMetricID := lastMetric.ID
+	nextPageURL := r.PageResult.URL.String() + "?marker=" + lastMetricID
+
+	return nextPageURL, nil
+}
+
+// IsEmpty checks whether a MetricPage struct is empty.
+func (r MetricPage) IsEmpty() (bool, error) {
+	is, err := ExtractMetrics(r)
+	return len(is) == 0, err
+}
+
+// ExtractMetrics accepts a Page struct, specifically a MetricPage struct,
+// and extracts the elements into a slice of Metric structs. In other words,
+// a generic collection is mapped into a relevant slice.
+func ExtractMetrics(r pagination.Page) ([]Metric, error) {
+	var s []Metric
+	err := (r.(MetricPage)).ExtractInto(&s)
+	if err != nil {
+		return nil, err
+	}
+
+	return s, err
+}

--- a/gnocchi/metric/v1/metrics/testing/doc.go
+++ b/gnocchi/metric/v1/metrics/testing/doc.go
@@ -1,0 +1,2 @@
+// metrics unit tests
+package testing

--- a/gnocchi/metric/v1/metrics/testing/fixtures.go
+++ b/gnocchi/metric/v1/metrics/testing/fixtures.go
@@ -72,7 +72,7 @@ const MetricsListResult = `[
     }
 ]`
 
-// Metric1 is an expected representation of first metric from MetricsListResult.
+// Metric1 is an expected representation of a first metric from the MetricsListResult.
 var Metric1 = metrics.Metric{
 	ArchivePolicy: archivepolicies.ArchivePolicy{
 		AggregationMethods: []string{
@@ -108,7 +108,7 @@ var Metric1 = metrics.Metric{
 	Unit:               "MB",
 }
 
-// Metric2 is an expected representation of first metric from MetricsListResult.
+// Metric2 is an expected representation of a second metric from the MetricsListResult.
 var Metric2 = metrics.Metric{
 	ArchivePolicy: archivepolicies.ArchivePolicy{
 		AggregationMethods: []string{

--- a/gnocchi/metric/v1/metrics/testing/fixtures.go
+++ b/gnocchi/metric/v1/metrics/testing/fixtures.go
@@ -5,33 +5,33 @@ import (
 	"github.com/gophercloud/utils/gnocchi/metric/v1/metrics"
 )
 
-// MetricsListResult represents raw server response from a server to a list call.
+// MetricsListResult represents a raw server response from a server to a list call.
 const MetricsListResult = `[
     {
         "archive_policy": {
-            "aggregation_methods": [
-                "max",
-                "min"
-            ],
-            "back_window": 0,
-            "definition": [
-                {
-                    "granularity": "1:00:00",
-                    "points": 2304,
-                    "timespan": "96 days, 0:00:00"
-                },
-                {
-                    "granularity": "0:05:00",
-                    "points": 9216,
-                    "timespan": "32 days, 0:00:00"
-                },
-                {
-                    "granularity": "1 day, 0:00:00",
-                    "points": 400,
-                    "timespan": "400 days, 0:00:00"
-                }
-            ],
-            "name": "precise"
+        "aggregation_methods": [
+            "max",
+            "min"
+        ],
+        "back_window": 0,
+        "definition": [
+            {
+                "granularity": "1:00:00",
+                "points": 2304,
+                "timespan": "96 days, 0:00:00"
+            },
+            {
+                "granularity": "0:05:00",
+                "points": 9216,
+                "timespan": "32 days, 0:00:00"
+            },
+            {
+                "granularity": "1 day, 0:00:00",
+                "points": 400,
+                "timespan": "400 days, 0:00:00"
+            }
+        ],
+        "name": "precise"
         },
         "created_by_project_id": "e9dc821ca664406e981820a477e9a761",
         "created_by_user_id": "a23c5b98d42d4df3b961e54d5167eb6d",
@@ -80,7 +80,7 @@ var Metric1 = metrics.Metric{
 			"min",
 		},
 		BackWindow: 0,
-		Definitions: []archivepolicies.ArchivePolicyDefinition{
+		Definition: []archivepolicies.ArchivePolicyDefinition{
 			{
 				Granularity: "1:00:00",
 				Points:      2304,
@@ -116,7 +116,7 @@ var Metric2 = metrics.Metric{
 			"sum",
 		},
 		BackWindow: 12,
-		Definitions: []archivepolicies.ArchivePolicyDefinition{
+		Definition: []archivepolicies.ArchivePolicyDefinition{
 			{
 				Granularity: "1:00:00",
 				Points:      2160,

--- a/gnocchi/metric/v1/metrics/testing/fixtures.go
+++ b/gnocchi/metric/v1/metrics/testing/fixtures.go
@@ -1,0 +1,140 @@
+package testing
+
+import (
+	"github.com/gophercloud/utils/gnocchi/metric/v1/archivepolicies"
+	"github.com/gophercloud/utils/gnocchi/metric/v1/metrics"
+)
+
+// MetricsListResult represents raw server response from a server to a list call.
+const MetricsListResult = `[
+    {
+        "archive_policy": {
+            "aggregation_methods": [
+                "max",
+                "min"
+            ],
+            "back_window": 0,
+            "definition": [
+                {
+                    "granularity": "1:00:00",
+                    "points": 2304,
+                    "timespan": "96 days, 0:00:00"
+                },
+                {
+                    "granularity": "0:05:00",
+                    "points": 9216,
+                    "timespan": "32 days, 0:00:00"
+                },
+                {
+                    "granularity": "1 day, 0:00:00",
+                    "points": 400,
+                    "timespan": "400 days, 0:00:00"
+                }
+            ],
+            "name": "precise"
+			},
+			"created_by_project_id": "e9dc821ca664406e981820a477e9a761",
+			"created_by_user_id": "a23c5b98d42d4df3b961e54d5167eb6d",
+			"creator": "a23c5b98d42d4df3b961e54d5167eb6d:e9dc821ca664406e981820a477e9a761",
+			"id": "777a01d6-4694-49cb-b86a-5ba9fd4e609e",
+			"name": "memory.usage",
+			"resource_id": "1f3a0724-1807-4bd1-81f9-ee18c8ff6ccc",
+			"unit": "MB"
+    },
+    {
+        "archive_policy": {
+            "aggregation_methods": [
+                "mean",
+                "sum"
+            ],
+            "back_window": 12,
+            "definition": [
+                {
+                    "granularity": "1:00:00",
+                    "points": 2160,
+                    "timespan": "90 days, 0:00:00"
+                },
+                {
+                    "granularity": "1 day, 0:00:00",
+                    "points": 200,
+                    "timespan": "200 days, 0:00:00"
+                }
+            ],
+        "name": "not_so_precise"
+        },
+        "created_by_project_id": "c6b68a6b413648b0a0eb191bf3222f4d",
+        "created_by_user_id": "cb072aacdb494419aeeba5f1c62d1a65",
+        "creator": "cb072aacdb494419aeeba5f1c62d1a65:c6b68a6b413648b0a0eb191bf3222f4d",
+        "id": "6dbc97c5-bfdf-47a2-b184-02e7fa348d21",
+        "name": "cpu_util",
+        "resource_id": "c5dc0c47-f43c-425c-a82f-44d61ee91175",
+        "unit": "%"
+    }
+]`
+
+// Metric1 is an expected representation of first metric from MetricsListResult.
+var Metric1 = metrics.Metric{
+	archivepolicies.ArchivePolicy{
+		AggregationMethods: []string{
+			"max",
+			"min",
+		},
+		BackWindow: 0,
+		Definitions: []archivepolicies.ArchivePolicyDefinition{
+			{
+				Granularity: "1:00:00",
+				Points:      2304,
+				TimeSpan:    "96 days, 0:00:00",
+			},
+			{
+				Granularity: "0:05:00",
+				Points:      9216,
+				TimeSpan:    "32 days, 0:00:00",
+			},
+			{
+				Granularity: "1 day, 0:00:00",
+				Points:      400,
+				TimeSpan:    "400 days, 0:00:00",
+			},
+		},
+		Name: "precise",
+	},
+	CreatedByProjectID: "e9dc821ca664406e981820a477e9a761",
+	CreatedByUserID:    "a23c5b98d42d4df3b961e54d5167eb6d",
+	Creator:            "a23c5b98d42d4df3b961e54d5167eb6d:e9dc821ca664406e981820a477e9a761",
+	ID:                 "777a01d6-4694-49cb-b86a-5ba9fd4e609e",
+	Name:               "memory.usage",
+	ResourceID:         "1f3a0724-1807-4bd1-81f9-ee18c8ff6ccc",
+	Unit:               "MB",
+}
+
+// Metric2 is an expected representation of first metric from MetricsListResult.
+var Metric2 = metrics.Metric{
+	archivepolicies.ArchivePolicy{
+		AggregationMethods: []string{
+			"mean",
+			"sum",
+		},
+		BackWindow: 0,
+		Definitions: []archivepolicies.ArchivePolicyDefinition{
+			{
+				Granularity: "1:00:00",
+				Points:      2160,
+				TimeSpan:    "90 days, 0:00:00",
+			},
+			{
+				Granularity: "1 day, 0:00:00",
+				Points:      200,
+				TimeSpan:    "200 days, 0:00:00",
+			},
+		},
+		Name: "not_so_precise",
+	},
+	CreatedByProjectID: "c6b68a6b413648b0a0eb191bf3222f4d",
+	CreatedByUserID:    "cb072aacdb494419aeeba5f1c62d1a65",
+	Creator:            "cb072aacdb494419aeeba5f1c62d1a65:c6b68a6b413648b0a0eb191bf3222f4d",
+	ID:                 "6dbc97c5-bfdf-47a2-b184-02e7fa348d21",
+	Name:               "cpu_util",
+	ResourceID:         "c5dc0c47-f43c-425c-a82f-44d61ee91175",
+	Unit:               "%",
+}

--- a/gnocchi/metric/v1/metrics/testing/fixtures.go
+++ b/gnocchi/metric/v1/metrics/testing/fixtures.go
@@ -32,14 +32,14 @@ const MetricsListResult = `[
                 }
             ],
             "name": "precise"
-			},
-			"created_by_project_id": "e9dc821ca664406e981820a477e9a761",
-			"created_by_user_id": "a23c5b98d42d4df3b961e54d5167eb6d",
-			"creator": "a23c5b98d42d4df3b961e54d5167eb6d:e9dc821ca664406e981820a477e9a761",
-			"id": "777a01d6-4694-49cb-b86a-5ba9fd4e609e",
-			"name": "memory.usage",
-			"resource_id": "1f3a0724-1807-4bd1-81f9-ee18c8ff6ccc",
-			"unit": "MB"
+        },
+        "created_by_project_id": "e9dc821ca664406e981820a477e9a761",
+        "created_by_user_id": "a23c5b98d42d4df3b961e54d5167eb6d",
+        "creator": "a23c5b98d42d4df3b961e54d5167eb6d:e9dc821ca664406e981820a477e9a761",
+        "id": "777a01d6-4694-49cb-b86a-5ba9fd4e609e",
+        "name": "memory.usage",
+        "resource_id": "1f3a0724-1807-4bd1-81f9-ee18c8ff6ccc",
+        "unit": "MB"
     },
     {
         "archive_policy": {
@@ -60,21 +60,21 @@ const MetricsListResult = `[
                     "timespan": "200 days, 0:00:00"
                 }
             ],
-        "name": "not_so_precise"
+            "name": "not_so_precise"
         },
         "created_by_project_id": "c6b68a6b413648b0a0eb191bf3222f4d",
         "created_by_user_id": "cb072aacdb494419aeeba5f1c62d1a65",
         "creator": "cb072aacdb494419aeeba5f1c62d1a65:c6b68a6b413648b0a0eb191bf3222f4d",
         "id": "6dbc97c5-bfdf-47a2-b184-02e7fa348d21",
-        "name": "cpu_util",
+        "name": "cpu.delta",
         "resource_id": "c5dc0c47-f43c-425c-a82f-44d61ee91175",
-        "unit": "%"
+        "unit": "ns"
     }
 ]`
 
 // Metric1 is an expected representation of first metric from MetricsListResult.
 var Metric1 = metrics.Metric{
-	archivepolicies.ArchivePolicy{
+	ArchivePolicy: archivepolicies.ArchivePolicy{
 		AggregationMethods: []string{
 			"max",
 			"min",
@@ -110,12 +110,12 @@ var Metric1 = metrics.Metric{
 
 // Metric2 is an expected representation of first metric from MetricsListResult.
 var Metric2 = metrics.Metric{
-	archivepolicies.ArchivePolicy{
+	ArchivePolicy: archivepolicies.ArchivePolicy{
 		AggregationMethods: []string{
 			"mean",
 			"sum",
 		},
-		BackWindow: 0,
+		BackWindow: 12,
 		Definitions: []archivepolicies.ArchivePolicyDefinition{
 			{
 				Granularity: "1:00:00",
@@ -134,7 +134,7 @@ var Metric2 = metrics.Metric{
 	CreatedByUserID:    "cb072aacdb494419aeeba5f1c62d1a65",
 	Creator:            "cb072aacdb494419aeeba5f1c62d1a65:c6b68a6b413648b0a0eb191bf3222f4d",
 	ID:                 "6dbc97c5-bfdf-47a2-b184-02e7fa348d21",
-	Name:               "cpu_util",
+	Name:               "cpu.delta",
 	ResourceID:         "c5dc0c47-f43c-425c-a82f-44d61ee91175",
-	Unit:               "%",
+	Unit:               "ns",
 }

--- a/gnocchi/metric/v1/metrics/testing/requests_test.go
+++ b/gnocchi/metric/v1/metrics/testing/requests_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/gophercloud/gophercloud/pagination"
 	th "github.com/gophercloud/gophercloud/testhelper"
-	fake "github.com/gophercloud/utils/gnocchi/metric/v1/common"
 	"github.com/gophercloud/utils/gnocchi/metric/v1/metrics"
+	fake "github.com/gophercloud/utils/gnocchi/testhelper/client"
 )
 
 func TestList(t *testing.T) {

--- a/gnocchi/metric/v1/metrics/testing/requests_test.go
+++ b/gnocchi/metric/v1/metrics/testing/requests_test.go
@@ -1,0 +1,51 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/pagination"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	fake "github.com/gophercloud/utils/gnocchi/metric/v1/common"
+	"github.com/gophercloud/utils/gnocchi/metric/v1/metrics"
+)
+
+func TestList(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v1/metrics", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, MetricsListResult)
+	})
+
+	count := 0
+
+	metrics.List(fake.ServiceClient(), metrics.ListOpts{}).EachPage(func(page pagination.Page) (bool, error) {
+		count++
+		actual, err := metrics.ExtractMetrics(page)
+		if err != nil {
+			t.Errorf("Failed to extract metrics: %v", err)
+			return false, nil
+		}
+
+		expected := []metrics.Metric{
+			Metric1,
+			Metric2,
+		}
+
+		th.CheckDeepEquals(t, expected, actual)
+
+		return true, nil
+	})
+
+	if count != 1 {
+		t.Errorf("Expected 1 page, got %d", count)
+	}
+}

--- a/gnocchi/metric/v1/metrics/testing/requests_test.go
+++ b/gnocchi/metric/v1/metrics/testing/requests_test.go
@@ -15,7 +15,7 @@ func TestList(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 
-	th.Mux.HandleFunc("/v1/metrics", func(w http.ResponseWriter, r *http.Request) {
+	th.Mux.HandleFunc("/v1/metric", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "GET")
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 

--- a/gnocchi/metric/v1/metrics/urls.go
+++ b/gnocchi/metric/v1/metrics/urls.go
@@ -1,0 +1,13 @@
+package metrics
+
+import "github.com/gophercloud/gophercloud"
+
+const resourcePath = "metric"
+
+func rootURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL(resourcePath)
+}
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return rootURL(c)
+}


### PR DESCRIPTION
Add Gnocchi metric structure and list request.

The same command with Gnocchi CLI is done with:
`gnocchi metric list`

For [#698](https://github.com/gophercloud/gophercloud/issues/698)

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/gnocchixyz/gnocchi/blob/stable/4.1/gnocchi/rest/api.py#L447
https://github.com/gnocchixyz/gnocchi/blob/stable/4.1/gnocchi/indexer/sqlalchemy.py#L689

  