### PR TITLE
Implement Gnocchi resource list

### DIFF
--- a/acceptance/gnocchi/metric/v1/resources_test.go
+++ b/acceptance/gnocchi/metric/v1/resources_test.go
@@ -1,3 +1,5 @@
+// +build acceptance metric resources
+
 package v1
 
 import (

--- a/acceptance/gnocchi/metric/v1/resources_test.go
+++ b/acceptance/gnocchi/metric/v1/resources_test.go
@@ -1,0 +1,32 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/acceptance/tools"
+	"github.com/gophercloud/utils/acceptance/clients"
+	"github.com/gophercloud/utils/gnocchi/metric/v1/resources"
+)
+
+func TestResourcesList(t *testing.T) {
+	client, err := clients.NewGnocchiV1Client()
+	if err != nil {
+		t.Fatalf("Unable to create a Gnocchi client: %v", err)
+	}
+
+	opts := resources.ListOpts{}
+	resourceType := ""
+	allPages, err := resources.List(client, opts, resourceType).AllPages()
+	if err != nil {
+		t.Fatalf("Unable to list resources: %v", err)
+	}
+
+	allResources, err := resources.ExtractResources(allPages)
+	if err != nil {
+		t.Fatalf("Unable to extract resources: %v", err)
+	}
+
+	for _, resource := range allResources {
+		tools.PrintResource(t, resource)
+	}
+}

--- a/gnocchi/metric/v1/resources/doc.go
+++ b/gnocchi/metric/v1/resources/doc.go
@@ -1,0 +1,25 @@
+/*
+Package resources provides the ability to retrieve resources through the Gnocchi API.
+
+Example of Listing resources
+
+	listOpts := resources.ListOpts{
+		Details: True,
+		ResourceType: "instance",
+	}
+
+	allPages, err := resources.List(gnocchiClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allResources, err := resources.ExtractResources(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, resource := range allResources {
+		fmt.Printf("%+v\n", resource)
+	}
+*/
+package resources

--- a/gnocchi/metric/v1/resources/doc.go
+++ b/gnocchi/metric/v1/resources/doc.go
@@ -3,12 +3,12 @@ Package resources provides the ability to retrieve resources through the Gnocchi
 
 Example of Listing resources
 
+	resourceType: "instance",
 	listOpts := resources.ListOpts{
 		Details: True,
-		ResourceType: "instance",
 	}
 
-	allPages, err := resources.List(gnocchiClient, listOpts).AllPages()
+	allPages, err := resources.List(gnocchiClient, listOpts, resourceType).AllPages()
 	if err != nil {
 		panic(err)
 	}

--- a/gnocchi/metric/v1/resources/requests.go
+++ b/gnocchi/metric/v1/resources/requests.go
@@ -50,6 +50,6 @@ func List(c *gophercloud.ServiceClient, opts ListOptsBuilder, resourceType strin
 		url += query
 	}
 	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
-		return ResourcePage{pagination.LinkedPageBase{PageResult: r}}
+		return ResourcePage{pagination.SinglePageBase(r)}
 	})
 }

--- a/gnocchi/metric/v1/resources/requests.go
+++ b/gnocchi/metric/v1/resources/requests.go
@@ -1,0 +1,55 @@
+package resources
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// ListOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type ListOptsBuilder interface {
+	ToResourceListQuery() (string, error)
+}
+
+// ListOpts allows the limiting and sorting of paginated collections through
+// the Gnocchi API.
+type ListOpts struct {
+	// Details allows to list resources with all attributes.
+	Details bool `q:"details"`
+
+	// Limit allows to limits count of resources in the response.
+	Limit int `q:"limit"`
+
+	// Marker is used for pagination.
+	Marker string `q:"marker"`
+
+	// SortKey allows to sort resources in the response by key.
+	SortKey string `q:"sort_key"`
+
+	// SortDir allows to set the direction of sorting.
+	// Can be `asc` or `desc`.
+	SortDir string `q:"sort_dir"`
+}
+
+// ToResourceListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToResourceListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List returns a Pager which allows you to iterate over a collection of
+// resources. It accepts a ListOpts struct, which allows you to limit and sort
+// the returned collection for a greater efficiency.
+func List(c *gophercloud.ServiceClient, opts ListOptsBuilder, resourceType string) pagination.Pager {
+	url := listURL(c, resourceType)
+	if opts != nil {
+		query, err := opts.ToResourceListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		return ResourcePage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}

--- a/gnocchi/metric/v1/resources/results.go
+++ b/gnocchi/metric/v1/resources/results.go
@@ -23,8 +23,7 @@ type Resource struct {
 	ID string `json:"id"`
 
 	// Metrics are entities that store aggregates.
-	// They are identified by an UUIDs.
-	Metrics []string `json:"metrics"`
+	Metrics map[string]string `json:"metrics"`
 
 	// OriginalResourceID is the orginal resource id. It can be different from the
 	// regular ID field.

--- a/gnocchi/metric/v1/resources/results.go
+++ b/gnocchi/metric/v1/resources/results.go
@@ -1,6 +1,8 @@
 package resources
 
-import "github.com/gophercloud/gophercloud/pagination"
+import (
+	"github.com/gophercloud/gophercloud/pagination"
+)
 
 // Resource is an entity representing anything in your infrastructure
 // that you will associate metric(s) with.
@@ -51,10 +53,14 @@ type Resource struct {
 	UserID string `json:"user_id"`
 }
 
-// ResourcePage is the page returned by a pager when traversing over a collection
-// of resources.
+// ResourcePage abstracts the raw results of making a List() request against
+// the Gnocchi API.
+//
+// As Gnocchi API may freely alter the response bodies of structures
+// returned to the client, you may only safely access the data provided through
+// the ExtractResources call.
 type ResourcePage struct {
-	pagination.LinkedPageBase
+	pagination.SinglePageBase
 }
 
 // IsEmpty checks whether a ResourcePage struct is empty.
@@ -63,9 +69,8 @@ func (r ResourcePage) IsEmpty() (bool, error) {
 	return len(is) == 0, err
 }
 
-// ExtractResources accepts a Page struct, specifically a ResourcePage struct,
-// and extracts the elements into a slice of Resource structs. In other words,
-// a generic collection is mapped into a relevant slice.
+// ExtractResources interprets the results of a single page from a List() call,
+// producing a slice of Resource structs.
 func ExtractResources(r pagination.Page) ([]Resource, error) {
 	var s []Resource
 	err := (r.(ResourcePage)).ExtractInto(&s)

--- a/gnocchi/metric/v1/resources/results.go
+++ b/gnocchi/metric/v1/resources/results.go
@@ -1,0 +1,96 @@
+package resources
+
+import "github.com/gophercloud/gophercloud/pagination"
+
+// Resource is an entity representing anything in your infrastructure
+// that you will associate metric(s) with.
+// It is identified by a unique ID and can contain attributes.
+type Resource struct {
+	// CreatedByProjectID contains the id of the Identity project that
+	// was used for a resource creation.
+	CreatedByProjectID string `json:"created_by_project_id"`
+
+	// CreatedByUserID contains the id of the Identity user
+	// that created the Gnocchi resource.
+	CreatedByUserID string `json:"created_by_user_id"`
+
+	// Creator shows who created the resource.
+	// Usually it contains concatenated string with values from
+	// "created_by_user_id" and "created_by_project_id" fields.
+	Creator string `json:"creator"`
+
+	// ID uniquely identifies the Gnocchi resource.
+	ID string `json:"id"`
+
+	// Metrics are entities that store aggregates.
+	// They are identified by an UUIDs.
+	Metrics []string `json:"metrics"`
+
+	// OriginalResourceID is the orginal resource id. It can be different from the
+	// regular ID field.
+	OriginalResourceID string `json:"original_resource_id"`
+
+	// ProjectID is the Identity project of the resource.
+	ProjectID string `json:"project_id"`
+
+	// RevisionStart is a staring timestamp of the current resource revision.
+	RevisionStart string `json:"revision_start"`
+
+	// RevisionEnd is an ending timestamp of the last resource revision.
+	RevisionEnd string `json:"revision_end"`
+
+	// StartedAt is a resource creation timestamp.
+	StartedAt string `json:"started_at"`
+
+	// Type is a type of the resource.
+	Type string `json:"type"`
+
+	// UserID is the Identity user of the resource.
+	UserID string `json:"user_id"`
+}
+
+// ResourcePage is the page returned by a pager when traversing over a collection
+// of resources.
+type ResourcePage struct {
+	pagination.LinkedPageBase
+}
+
+// NextPageURL is invoked when a paginated collection of resources has reached
+// the end of a page and the pager seeks to traverse over a new one.
+// In order to do this, it needs to construct the next page's URL.
+//
+// Gnocchi API doesn't provide special JSON with pagination links. Instead it expects
+// a new URL with a resource's id as a marker.
+func (r ResourcePage) NextPageURL() (string, error) {
+	var s []Resource
+
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+
+	lastResource := s[len(s)-1]
+	lastResourceID := lastResource.ID
+	nextPageURL := r.PageResult.URL.String() + "?marker=" + lastResourceID
+
+	return nextPageURL, nil
+}
+
+// IsEmpty checks whether a ResourcePage struct is empty.
+func (r ResourcePage) IsEmpty() (bool, error) {
+	is, err := ExtractResources(r)
+	return len(is) == 0, err
+}
+
+// ExtractResources accepts a Page struct, specifically a ResourcePage struct,
+// and extracts the elements into a slice of Resource structs. In other words,
+// a generic collection is mapped into a relevant slice.
+func ExtractResources(r pagination.Page) ([]Resource, error) {
+	var s []Resource
+	err := (r.(ResourcePage)).ExtractInto(&s)
+	if err != nil {
+		return nil, err
+	}
+
+	return s, err
+}

--- a/gnocchi/metric/v1/resources/results.go
+++ b/gnocchi/metric/v1/resources/results.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gophercloud/gophercloud/pagination"
 	"github.com/gophercloud/utils/gnocchi"
+	"github.com/gophercloud/utils/internal"
 )
 
 // Resource is an entity representing anything in your infrastructure
@@ -55,6 +56,10 @@ type Resource struct {
 
 	// UserID is the Identity user of the resource.
 	UserID string `json:"user_id"`
+
+	// Extra is a collection of keys and values that can be found in resources
+	// of different resource types.
+	Extra map[string]interface{} `json:"-"`
 }
 
 // UnmarshalJSON helps to unmarshal Resource fields into needed values.
@@ -62,6 +67,7 @@ func (r *Resource) UnmarshalJSON(b []byte) error {
 	type tmp Resource
 	var s struct {
 		tmp
+		Extra         map[string]interface{}          `json:"extra"`
 		RevisionStart gnocchi.JSONRFC3339NanoTimezone `json:"revision_start"`
 		RevisionEnd   gnocchi.JSONRFC3339NanoTimezone `json:"revision_end"`
 		StartedAt     gnocchi.JSONRFC3339NanoTimezone `json:"started_at"`
@@ -73,10 +79,30 @@ func (r *Resource) UnmarshalJSON(b []byte) error {
 	}
 	*r = Resource(s.tmp)
 
+	// Collect Gnocchi timestamps.
 	r.RevisionStart = time.Time(s.RevisionStart)
 	r.RevisionEnd = time.Time(s.RevisionEnd)
 	r.StartedAt = time.Time(s.StartedAt)
 	r.EndedAt = time.Time(s.EndedAt)
+
+	// Collect other resource fields
+	// and bundle them into Extra.
+	if s.Extra != nil {
+		r.Extra = s.Extra
+	} else {
+		var result interface{}
+		err := json.Unmarshal(b, &result)
+		if err != nil {
+			return err
+		}
+		if resultMap, ok := result.(map[string]interface{}); ok {
+			delete(resultMap, "revision_start")
+			delete(resultMap, "revision_end")
+			delete(resultMap, "started_at")
+			delete(resultMap, "ended_at")
+			r.Extra = internal.RemainingKeys(Resource{}, resultMap)
+		}
+	}
 
 	return err
 }

--- a/gnocchi/metric/v1/resources/results.go
+++ b/gnocchi/metric/v1/resources/results.go
@@ -55,27 +55,6 @@ type ResourcePage struct {
 	pagination.LinkedPageBase
 }
 
-// NextPageURL is invoked when a paginated collection of resources has reached
-// the end of a page and the pager seeks to traverse over a new one.
-// In order to do this, it needs to construct the next page's URL.
-//
-// Gnocchi API doesn't provide special JSON with pagination links. Instead it expects
-// a new URL with a resource's id as a marker.
-func (r ResourcePage) NextPageURL() (string, error) {
-	var s []Resource
-
-	err := r.ExtractInto(&s)
-	if err != nil {
-		return "", err
-	}
-
-	lastResource := s[len(s)-1]
-	lastResourceID := lastResource.ID
-	nextPageURL := r.PageResult.URL.String() + "?marker=" + lastResourceID
-
-	return nextPageURL, nil
-}
-
 // IsEmpty checks whether a ResourcePage struct is empty.
 func (r ResourcePage) IsEmpty() (bool, error) {
 	is, err := ExtractResources(r)

--- a/gnocchi/metric/v1/resources/results.go
+++ b/gnocchi/metric/v1/resources/results.go
@@ -42,6 +42,9 @@ type Resource struct {
 	// StartedAt is a resource creation timestamp.
 	StartedAt string `json:"started_at"`
 
+	// EndedAt is a timestamp of when the resource has ended.
+	EndedAt string `json:"ended_at"`
+
 	// Type is a type of the resource.
 	Type string `json:"type"`
 

--- a/gnocchi/metric/v1/resources/testing/doc.go
+++ b/gnocchi/metric/v1/resources/testing/doc.go
@@ -1,0 +1,2 @@
+// resources unit tests
+package testing

--- a/gnocchi/metric/v1/resources/testing/fixtures.go
+++ b/gnocchi/metric/v1/resources/testing/fixtures.go
@@ -12,6 +12,9 @@ const ResourceListResult = `[
         "created_by_project_id": "3d40ca37723449118987b9f288f4ae84",
         "created_by_user_id": "fdcfb420c09645e69e177a0bb1950884",
         "creator": "fdcfb420c09645e69e177a0bb1950884:3d40ca37723449118987b9f288f4ae84",
+        "display_name": "MyInstance00",
+        "flavor_name": "2CPU4G",
+        "host": "compute010",
         "ended_at": null,
         "id": "1f3a0724-1807-4bd1-81f9-ee18c8ff6ccc",
         "metrics": {
@@ -30,6 +33,7 @@ const ResourceListResult = `[
         "created_by_project_id": "3d40ca37723449118987b9f288f4ae84",
         "created_by_user_id": "fdcfb420c09645e69e177a0bb1950884",
         "creator": "fdcfb420c09645e69e177a0bb1950884:3d40ca37723449118987b9f288f4ae84",
+        "disk_device_name": "sdb",
         "ended_at": null,
         "id": "789a7f65-977d-40f4-beed-f717100125f5",
         "metrics": {
@@ -64,6 +68,11 @@ var Resource1 = resources.Resource{
 	EndedAt:            time.Time{},
 	Type:               "compute_instance",
 	UserID:             "bd5874d666624b24a9f01c128871e4ac",
+	Extra: map[string]interface{}{
+		"display_name": "MyInstance00",
+		"flavor_name":  "2CPU4G",
+		"host":         "compute010",
+	},
 }
 
 // Resource2 is an expected representation of a second resource from the ResourceListResult.
@@ -84,4 +93,7 @@ var Resource2 = resources.Resource{
 	EndedAt:            time.Time{},
 	Type:               "compute_instance_disk",
 	UserID:             "bd5874d666624b24a9f01c128871e4ac",
+	Extra: map[string]interface{}{
+		"disk_device_name": "sdb",
+	},
 }

--- a/gnocchi/metric/v1/resources/testing/fixtures.go
+++ b/gnocchi/metric/v1/resources/testing/fixtures.go
@@ -1,6 +1,8 @@
 package testing
 
 import (
+	"time"
+
 	"github.com/gophercloud/utils/gnocchi/metric/v1/resources"
 )
 
@@ -56,10 +58,10 @@ var Resource1 = resources.Resource{
 	},
 	OriginalResourceID: "1f3a0724-1807-4bd1-81f9-ee18c8ff6ccc",
 	ProjectID:          "4154f08883334e0494c41155c33c0fc9",
-	RevisionStart:      "2018-01-02T11:39:33.942419+00:00",
-	RevisionEnd:        "",
-	StartedAt:          "2018-01-02T11:39:33.942391+00:00",
-	EndedAt:            "",
+	RevisionStart:      time.Date(2018, 1, 2, 11, 39, 33, 942419000, time.UTC),
+	RevisionEnd:        time.Time{},
+	StartedAt:          time.Date(2018, 1, 2, 11, 39, 33, 942391000, time.UTC),
+	EndedAt:            time.Time{},
 	Type:               "compute_instance",
 	UserID:             "bd5874d666624b24a9f01c128871e4ac",
 }
@@ -76,10 +78,10 @@ var Resource2 = resources.Resource{
 	},
 	OriginalResourceID: "789a7f65-977d-40f4-beed-f717100125f5",
 	ProjectID:          "4154f08883334e0494c41155c33c0fc9",
-	RevisionStart:      "2018-01-03T11:44:31.155773+00:00",
-	RevisionEnd:        "",
-	StartedAt:          "2018-01-03T11:44:31.155732+00:00",
-	EndedAt:            "",
+	RevisionStart:      time.Date(2018, 1, 3, 11, 44, 31, 155773000, time.UTC),
+	RevisionEnd:        time.Time{},
+	StartedAt:          time.Date(2018, 1, 3, 11, 44, 31, 155732000, time.UTC),
+	EndedAt:            time.Time{},
 	Type:               "compute_instance_disk",
 	UserID:             "bd5874d666624b24a9f01c128871e4ac",
 }

--- a/gnocchi/metric/v1/resources/testing/fixtures.go
+++ b/gnocchi/metric/v1/resources/testing/fixtures.go
@@ -44,7 +44,7 @@ const ResourceListResult = `[
     }
 ]`
 
-// Resource1 is an expected representation of a first resource from ResourceListResult.
+// Resource1 is an expected representation of a first resource from the ResourceListResult.
 var Resource1 = resources.Resource{
 	CreatedByProjectID: "3d40ca37723449118987b9f288f4ae84",
 	CreatedByUserID:    "fdcfb420c09645e69e177a0bb1950884",
@@ -64,7 +64,7 @@ var Resource1 = resources.Resource{
 	UserID:             "bd5874d666624b24a9f01c128871e4ac",
 }
 
-// Resource2 is an expected representation of a second resource from ResourceListResult.
+// Resource2 is an expected representation of a second resource from the ResourceListResult.
 var Resource2 = resources.Resource{
 	CreatedByProjectID: "3d40ca37723449118987b9f288f4ae84",
 	CreatedByUserID:    "fdcfb420c09645e69e177a0bb1950884",

--- a/gnocchi/metric/v1/resources/testing/fixtures.go
+++ b/gnocchi/metric/v1/resources/testing/fixtures.go
@@ -1,0 +1,85 @@
+package testing
+
+import (
+	"github.com/gophercloud/utils/gnocchi/metric/v1/resources"
+)
+
+// ResourceListResult represents raw server response from a server to a list call.
+const ResourceListResult = `[
+    {
+        "created_by_project_id": "3d40ca37723449118987b9f288f4ae84",
+        "created_by_user_id": "fdcfb420c09645e69e177a0bb1950884",
+        "creator": "fdcfb420c09645e69e177a0bb1950884:3d40ca37723449118987b9f288f4ae84",
+        "ended_at": null,
+        "id": "1f3a0724-1807-4bd1-81f9-ee18c8ff6ccc",
+        "metrics": {
+            "cpu.delta": "2df1515e-6325-4d49-af0d-1052f6462fe4",
+            "memory.usage": "777a01d6-4694-49cb-b86a-5ba9fd4e609e"
+        },
+        "original_resource_id": "1f3a0724-1807-4bd1-81f9-ee18c8ff6ccc",
+        "project_id": "4154f08883334e0494c41155c33c0fc9",
+        "revision_end": null,
+        "revision_start": "2018-01-02T11:39:33.942419+00:00",
+        "started_at": "2018-01-02T11:39:33.942391+00:00",
+        "type": "compute_instance",
+        "user_id": "bd5874d666624b24a9f01c128871e4ac"
+    },
+    {
+        "created_by_project_id": "3d40ca37723449118987b9f288f4ae84",
+        "created_by_user_id": "fdcfb420c09645e69e177a0bb1950884",
+        "creator": "fdcfb420c09645e69e177a0bb1950884:3d40ca37723449118987b9f288f4ae84",
+        "ended_at": null,
+        "id": "789a7f65-977d-40f4-beed-f717100125f5",
+        "metrics": {
+            "disk.read.bytes.rate": "ed1bb76f-6ccc-4ad2-994c-dbb19ddccbae",
+            "disk.write.bytes.rate": "0a2da84d-4753-43f5-a65f-0f8d44d2766c"
+        },
+        "original_resource_id": "789a7f65-977d-40f4-beed-f717100125f5",
+        "project_id": "4154f08883334e0494c41155c33c0fc9",
+        "revision_end": null,
+        "revision_start": "2018-01-03T11:44:31.155773+00:00",
+        "started_at": "2018-01-03T11:44:31.155732+00:00",
+        "type": "compute_instance_disk",
+        "user_id": "bd5874d666624b24a9f01c128871e4ac"
+    }
+]`
+
+// Resource1 is an expected representation of a first resource from ResourceListResult.
+var Resource1 = resources.Resource{
+	CreatedByProjectID: "3d40ca37723449118987b9f288f4ae84",
+	CreatedByUserID:    "fdcfb420c09645e69e177a0bb1950884",
+	Creator:            "fdcfb420c09645e69e177a0bb1950884:3d40ca37723449118987b9f288f4ae84",
+	ID:                 "1f3a0724-1807-4bd1-81f9-ee18c8ff6ccc",
+	Metrics: map[string]string{
+		"cpu.delta":    "2df1515e-6325-4d49-af0d-1052f6462fe4",
+		"memory.usage": "777a01d6-4694-49cb-b86a-5ba9fd4e609e",
+	},
+	OriginalResourceID: "1f3a0724-1807-4bd1-81f9-ee18c8ff6ccc",
+	ProjectID:          "4154f08883334e0494c41155c33c0fc9",
+	RevisionStart:      "2018-01-02T11:39:33.942419+00:00",
+	RevisionEnd:        "",
+	StartedAt:          "2018-01-02T11:39:33.942391+00:00",
+	EndedAt:            "",
+	Type:               "compute_instance",
+	UserID:             "bd5874d666624b24a9f01c128871e4ac",
+}
+
+// Resource2 is an expected representation of a second resource from ResourceListResult.
+var Resource2 = resources.Resource{
+	CreatedByProjectID: "3d40ca37723449118987b9f288f4ae84",
+	CreatedByUserID:    "fdcfb420c09645e69e177a0bb1950884",
+	Creator:            "fdcfb420c09645e69e177a0bb1950884:3d40ca37723449118987b9f288f4ae84",
+	ID:                 "789a7f65-977d-40f4-beed-f717100125f5",
+	Metrics: map[string]string{
+		"disk.read.bytes.rate":  "ed1bb76f-6ccc-4ad2-994c-dbb19ddccbae",
+		"disk.write.bytes.rate": "0a2da84d-4753-43f5-a65f-0f8d44d2766c",
+	},
+	OriginalResourceID: "789a7f65-977d-40f4-beed-f717100125f5",
+	ProjectID:          "4154f08883334e0494c41155c33c0fc9",
+	RevisionStart:      "2018-01-03T11:44:31.155773+00:00",
+	RevisionEnd:        "",
+	StartedAt:          "2018-01-03T11:44:31.155732+00:00",
+	EndedAt:            "",
+	Type:               "compute_instance_disk",
+	UserID:             "bd5874d666624b24a9f01c128871e4ac",
+}

--- a/gnocchi/metric/v1/resources/testing/requests_test.go
+++ b/gnocchi/metric/v1/resources/testing/requests_test.go
@@ -1,0 +1,51 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/pagination"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	fake "github.com/gophercloud/utils/gnocchi/metric/v1/common"
+	"github.com/gophercloud/utils/gnocchi/metric/v1/resources"
+)
+
+func TestList(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v1/resource/generic", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, ResourceListResult)
+	})
+
+	count := 0
+
+	resources.List(fake.ServiceClient(), resources.ListOpts{}, "").EachPage(func(page pagination.Page) (bool, error) {
+		count++
+		actual, err := resources.ExtractResources(page)
+		if err != nil {
+			t.Errorf("Failed to extract resources: %v", err)
+			return false, nil
+		}
+
+		expected := []resources.Resource{
+			Resource1,
+			Resource2,
+		}
+
+		th.CheckDeepEquals(t, expected, actual)
+
+		return true, nil
+	})
+
+	if count != 1 {
+		t.Errorf("Expected 1 page, got %d", count)
+	}
+}

--- a/gnocchi/metric/v1/resources/testing/requests_test.go
+++ b/gnocchi/metric/v1/resources/testing/requests_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/gophercloud/gophercloud/pagination"
 	th "github.com/gophercloud/gophercloud/testhelper"
-	fake "github.com/gophercloud/utils/gnocchi/metric/v1/common"
 	"github.com/gophercloud/utils/gnocchi/metric/v1/resources"
+	fake "github.com/gophercloud/utils/gnocchi/testhelper/client"
 )
 
 func TestList(t *testing.T) {

--- a/gnocchi/metric/v1/resources/urls.go
+++ b/gnocchi/metric/v1/resources/urls.go
@@ -4,9 +4,13 @@ import "github.com/gophercloud/gophercloud"
 
 const resourcePath = "resource"
 
-func listURL(c *gophercloud.ServiceClient, resourceType string) string {
+func rootURL(c *gophercloud.ServiceClient, resourceType string) string {
 	if resourceType == "" {
 		resourceType = "generic"
 	}
 	return c.ServiceURL(resourcePath, resourceType)
+}
+
+func listURL(c *gophercloud.ServiceClient, resourceType string) string {
+	return rootURL(c, resourceType)
 }

--- a/gnocchi/metric/v1/resources/urls.go
+++ b/gnocchi/metric/v1/resources/urls.go
@@ -1,0 +1,12 @@
+package resources
+
+import "github.com/gophercloud/gophercloud"
+
+const resourcePath = "resource"
+
+func listURL(c *gophercloud.ServiceClient, resourceType string) string {
+	if resourceType == "" {
+		resourceType = "generic"
+	}
+	return c.ServiceURL(resourcePath, resourceType)
+}

--- a/gnocchi/results.go
+++ b/gnocchi/results.go
@@ -1,0 +1,33 @@
+package gnocchi
+
+import (
+	"bytes"
+	"encoding/json"
+	"time"
+)
+
+// RFC3339NanoTimezone describes a common timestamp format used by Gnocchi API responses.
+const RFC3339NanoTimezone = "2006-01-02T15:04:05.999999+00:00"
+
+// JSONRFC3339NanoTimezone is a type for Gnocchi timestamps.
+type JSONRFC3339NanoTimezone time.Time
+
+// UnmarshalJSON helps to unmarshal timestamps from Gnocchi responses to the
+// JSONRFC3339NanoTimezone type.
+func (jt *JSONRFC3339NanoTimezone) UnmarshalJSON(data []byte) error {
+	b := bytes.NewBuffer(data)
+	dec := json.NewDecoder(b)
+	var s string
+	if err := dec.Decode(&s); err != nil {
+		return err
+	}
+	if s == "" {
+		return nil
+	}
+	t, err := time.Parse(RFC3339NanoTimezone, s)
+	if err != nil {
+		return err
+	}
+	*jt = JSONRFC3339NanoTimezone(t)
+	return nil
+}

--- a/internal/pkg.go
+++ b/internal/pkg.go
@@ -1,0 +1,1 @@
+package internal

--- a/internal/testing/pkg.go
+++ b/internal/testing/pkg.go
@@ -1,0 +1,1 @@
+package testing

--- a/internal/testing/util_test.go
+++ b/internal/testing/util_test.go
@@ -1,0 +1,42 @@
+package testing
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/gophercloud/utils/internal"
+)
+
+func TestRemainingKeys(t *testing.T) {
+	type User struct {
+		UserID    string `json:"user_id"`
+		Username  string `json:"username"`
+		Location  string `json:"-"`
+		CreatedAt string `json:"-"`
+		Status    string
+		IsAdmin   bool
+	}
+
+	userResponse := map[string]interface{}{
+		"user_id":      "abcd1234",
+		"username":     "jdoe",
+		"location":     "Hawaii",
+		"created_at":   "2017-06-08T02:49:03.000000",
+		"status":       "active",
+		"is_admin":     "true",
+		"custom_field": "foo",
+	}
+
+	expected := map[string]interface{}{
+		"created_at":   "2017-06-08T02:49:03.000000",
+		"is_admin":     "true",
+		"custom_field": "foo",
+	}
+
+	actual := internal.RemainingKeys(User{}, userResponse)
+
+	isEqual := reflect.DeepEqual(expected, actual)
+	if !isEqual {
+		t.Fatalf("expected %s but got %s", expected, actual)
+	}
+}

--- a/internal/util.go
+++ b/internal/util.go
@@ -1,0 +1,34 @@
+package internal
+
+import (
+	"reflect"
+	"strings"
+)
+
+// RemainingKeys will inspect a struct and compare it to a map. Any struct
+// field that does not have a JSON tag that matches a key in the map or
+// a matching lower-case field in the map will be returned as an extra.
+//
+// This is useful for determining the extra fields returned in response bodies
+// for resources that can contain an arbitrary or dynamic number of fields.
+func RemainingKeys(s interface{}, m map[string]interface{}) (extras map[string]interface{}) {
+	extras = make(map[string]interface{})
+	for k, v := range m {
+		extras[k] = v
+	}
+
+	valueOf := reflect.ValueOf(s)
+	typeOf := reflect.TypeOf(s)
+	for i := 0; i < valueOf.NumField(); i++ {
+		field := typeOf.Field(i)
+
+		lowerField := strings.ToLower(field.Name)
+		delete(extras, lowerField)
+
+		if tagValue := field.Tag.Get("json"); tagValue != "" && tagValue != "-" {
+			delete(extras, tagValue)
+		}
+	}
+
+	return
+}


### PR DESCRIPTION
Add Gnocchi resource structure and list request.

The same command with Gnocchi CLI is done with:
`gnocchi resource list`

For [#698](https://github.com/gophercloud/gophercloud/issues/698)

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/gnocchixyz/gnocchi/blob/stable/4.1/gnocchi/rest/api.py#L1126
https://github.com/gnocchixyz/gnocchi/blob/stable/4.1/gnocchi/indexer/sqlalchemy.py#L988