### PR TITLE
Implement Gnocchi resource get

### DIFF
--- a/acceptance/gnocchi/metric/v1/resources_test.go
+++ b/acceptance/gnocchi/metric/v1/resources_test.go
@@ -17,7 +17,7 @@ func TestResourcesList(t *testing.T) {
 	}
 
 	opts := resources.ListOpts{}
-	resourceType := ""
+	resourceType := "generic"
 	allPages, err := resources.List(client, opts, resourceType).AllPages()
 	if err != nil {
 		t.Fatalf("Unable to list resources: %v", err)

--- a/gnocchi/metric/v1/resources/doc.go
+++ b/gnocchi/metric/v1/resources/doc.go
@@ -25,7 +25,7 @@ Example of Listing resources
 Example of Getting a resource
 
 	resourceID = "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55"
-	resourceType = ""
+	resourceType = "generic"
 	resource, err := resources.Get(gnocchiClient, resourceType, resourceID).Extract()
 	if err != nil {
 		panic(err)

--- a/gnocchi/metric/v1/resources/doc.go
+++ b/gnocchi/metric/v1/resources/doc.go
@@ -21,5 +21,15 @@ Example of Listing resources
 	for _, resource := range allResources {
 		fmt.Printf("%+v\n", resource)
 	}
+
+Example of Getting a resource
+
+	resourceID = "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55"
+	resourceType = ""
+	resource, err := resources.Get(gnocchiClient, resourceID, resourceType).Extract()
+	if err != nil {
+		panic(err)
+	}
+
 */
 package resources

--- a/gnocchi/metric/v1/resources/doc.go
+++ b/gnocchi/metric/v1/resources/doc.go
@@ -26,7 +26,7 @@ Example of Getting a resource
 
 	resourceID = "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55"
 	resourceType = ""
-	resource, err := resources.Get(gnocchiClient, resourceID, resourceType).Extract()
+	resource, err := resources.Get(gnocchiClient, resourceType, resourceID).Extract()
 	if err != nil {
 		panic(err)
 	}

--- a/gnocchi/metric/v1/resources/requests.go
+++ b/gnocchi/metric/v1/resources/requests.go
@@ -55,7 +55,7 @@ func List(c *gophercloud.ServiceClient, opts ListOptsBuilder, resourceType strin
 }
 
 // Get retrieves a specific Gnocchi resource based on its type and ID.
-func Get(c *gophercloud.ServiceClient, resourceID string, resourceType string) (r GetResult) {
-	_, r.Err = c.Get(getURL(c, resourceID, resourceType), &r.Body, nil)
+func Get(c *gophercloud.ServiceClient, resourceType string, resourceID string) (r GetResult) {
+	_, r.Err = c.Get(getURL(c, resourceType, resourceID), &r.Body, nil)
 	return
 }

--- a/gnocchi/metric/v1/resources/requests.go
+++ b/gnocchi/metric/v1/resources/requests.go
@@ -53,3 +53,9 @@ func List(c *gophercloud.ServiceClient, opts ListOptsBuilder, resourceType strin
 		return ResourcePage{pagination.SinglePageBase(r)}
 	})
 }
+
+// Get retrieves a specific Gnocchi resource based on its type and ID.
+func Get(c *gophercloud.ServiceClient, resourceID string, resourceType string) (r GetResult) {
+	_, r.Err = c.Get(getURL(c, resourceID, resourceType), &r.Body, nil)
+	return
+}

--- a/gnocchi/metric/v1/resources/results.go
+++ b/gnocchi/metric/v1/resources/results.go
@@ -52,7 +52,7 @@ type Resource struct {
 	EndedAt time.Time `json:"-"`
 
 	// EndedAt is a timestamp of when the resource has ended.
-	EndedAt string `json:"ended_at"`
+	EndedAt time.Time `json:"-"`
 
 	// Type is a type of the resource.
 	Type string `json:"type"`
@@ -106,6 +106,30 @@ func (r *Resource) UnmarshalJSON(b []byte) error {
 			r.Extra = internal.RemainingKeys(Resource{}, resultMap)
 		}
 	}
+
+	return err
+}
+
+// UnmarshalJSON helps to unmarshal Resource fields into needed values.
+func (r *Resource) UnmarshalJSON(b []byte) error {
+	type tmp Resource
+	var s struct {
+		tmp
+		RevisionStart gnocchi.JSONRFC3339NanoTimezone `json:"revision_start"`
+		RevisionEnd   gnocchi.JSONRFC3339NanoTimezone `json:"revision_end"`
+		StartedAt     gnocchi.JSONRFC3339NanoTimezone `json:"started_at"`
+		EndedAt       gnocchi.JSONRFC3339NanoTimezone `json:"ended_at"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*r = Resource(s.tmp)
+
+	r.RevisionStart = time.Time(s.RevisionStart)
+	r.RevisionEnd = time.Time(s.RevisionEnd)
+	r.StartedAt = time.Time(s.StartedAt)
+	r.EndedAt = time.Time(s.EndedAt)
 
 	return err
 }

--- a/gnocchi/metric/v1/resources/results.go
+++ b/gnocchi/metric/v1/resources/results.go
@@ -4,10 +4,28 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/pagination"
 	"github.com/gophercloud/utils/gnocchi"
 	"github.com/gophercloud/utils/internal"
 )
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract is a function that accepts a result and extracts a Gnocchi resource.
+func (r commonResult) Extract() (*Resource, error) {
+	var s *Resource
+	err := r.ExtractInto(&s)
+	return s, err
+}
+
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a Gnocchi resource.
+type GetResult struct {
+	commonResult
+}
 
 // Resource is an entity representing anything in your infrastructure
 // that you will associate metric(s) with.

--- a/gnocchi/metric/v1/resources/results.go
+++ b/gnocchi/metric/v1/resources/results.go
@@ -51,6 +51,9 @@ type Resource struct {
 	// EndedAt is a timestamp of when the resource has ended.
 	EndedAt time.Time `json:"-"`
 
+	// EndedAt is a timestamp of when the resource has ended.
+	EndedAt string `json:"ended_at"`
+
 	// Type is a type of the resource.
 	Type string `json:"type"`
 

--- a/gnocchi/metric/v1/resources/results.go
+++ b/gnocchi/metric/v1/resources/results.go
@@ -51,9 +51,6 @@ type Resource struct {
 	// EndedAt is a timestamp of when the resource has ended.
 	EndedAt time.Time `json:"-"`
 
-	// EndedAt is a timestamp of when the resource has ended.
-	EndedAt time.Time `json:"-"`
-
 	// Type is a type of the resource.
 	Type string `json:"type"`
 
@@ -115,6 +112,7 @@ func (r *Resource) UnmarshalJSON(b []byte) error {
 	type tmp Resource
 	var s struct {
 		tmp
+		Extra         map[string]interface{}          `json:"extra"`
 		RevisionStart gnocchi.JSONRFC3339NanoTimezone `json:"revision_start"`
 		RevisionEnd   gnocchi.JSONRFC3339NanoTimezone `json:"revision_end"`
 		StartedAt     gnocchi.JSONRFC3339NanoTimezone `json:"started_at"`
@@ -126,10 +124,30 @@ func (r *Resource) UnmarshalJSON(b []byte) error {
 	}
 	*r = Resource(s.tmp)
 
+	// Collect Gnocchi timestamps.
 	r.RevisionStart = time.Time(s.RevisionStart)
 	r.RevisionEnd = time.Time(s.RevisionEnd)
 	r.StartedAt = time.Time(s.StartedAt)
 	r.EndedAt = time.Time(s.EndedAt)
+
+	// Collect other resource fields
+	// and bundle them into Extra.
+	if s.Extra != nil {
+		r.Extra = s.Extra
+	} else {
+		var result interface{}
+		err := json.Unmarshal(b, &result)
+		if err != nil {
+			return err
+		}
+		if resultMap, ok := result.(map[string]interface{}); ok {
+			delete(resultMap, "revision_start")
+			delete(resultMap, "revision_end")
+			delete(resultMap, "started_at")
+			delete(resultMap, "ended_at")
+			r.Extra = internal.RemainingKeys(Resource{}, resultMap)
+		}
+	}
 
 	return err
 }

--- a/gnocchi/metric/v1/resources/results.go
+++ b/gnocchi/metric/v1/resources/results.go
@@ -125,51 +125,6 @@ func (r *Resource) UnmarshalJSON(b []byte) error {
 	return err
 }
 
-// UnmarshalJSON helps to unmarshal Resource fields into needed values.
-func (r *Resource) UnmarshalJSON(b []byte) error {
-	type tmp Resource
-	var s struct {
-		tmp
-		Extra         map[string]interface{}          `json:"extra"`
-		RevisionStart gnocchi.JSONRFC3339NanoTimezone `json:"revision_start"`
-		RevisionEnd   gnocchi.JSONRFC3339NanoTimezone `json:"revision_end"`
-		StartedAt     gnocchi.JSONRFC3339NanoTimezone `json:"started_at"`
-		EndedAt       gnocchi.JSONRFC3339NanoTimezone `json:"ended_at"`
-	}
-	err := json.Unmarshal(b, &s)
-	if err != nil {
-		return err
-	}
-	*r = Resource(s.tmp)
-
-	// Collect Gnocchi timestamps.
-	r.RevisionStart = time.Time(s.RevisionStart)
-	r.RevisionEnd = time.Time(s.RevisionEnd)
-	r.StartedAt = time.Time(s.StartedAt)
-	r.EndedAt = time.Time(s.EndedAt)
-
-	// Collect other resource fields
-	// and bundle them into Extra.
-	if s.Extra != nil {
-		r.Extra = s.Extra
-	} else {
-		var result interface{}
-		err := json.Unmarshal(b, &result)
-		if err != nil {
-			return err
-		}
-		if resultMap, ok := result.(map[string]interface{}); ok {
-			delete(resultMap, "revision_start")
-			delete(resultMap, "revision_end")
-			delete(resultMap, "started_at")
-			delete(resultMap, "ended_at")
-			r.Extra = internal.RemainingKeys(Resource{}, resultMap)
-		}
-	}
-
-	return err
-}
-
 // ResourcePage abstracts the raw results of making a List() request against
 // the Gnocchi API.
 //

--- a/gnocchi/metric/v1/resources/testing/fixtures.go
+++ b/gnocchi/metric/v1/resources/testing/fixtures.go
@@ -97,3 +97,27 @@ var Resource2 = resources.Resource{
 		"disk_device_name": "sdb",
 	},
 }
+
+// ResourceGetResult represents raw server response from a server to a get requrest.
+const ResourceGetResult = `
+{
+    "created_by_project_id": "3d40ca37723449118987b9f288f4ae84",
+    "created_by_user_id": "fdcfb420c09645e69e177a0bb1950884",
+    "creator": "fdcfb420c09645e69e177a0bb1950884:3d40ca37723449118987b9f288f4ae84",
+    "ended_at": null,
+    "id": "75274f99-faf6-4112-a6d5-2794cb07c789",
+    "metrics": {
+        "network.incoming.bytes.rate": "01b2953e-de74-448a-a305-c84440697933",
+        "network.outgoing.bytes.rate": "4ac0041b-3bf7-441d-a95a-d3e2f1691158",
+        "network.incoming.packets.rate": "5a64328e-8a7c-4c6a-99df-2e6d17440142",
+        "network.outgoing.packets.rate": "dc9f3198-155b-4b88-a92c-58a3853ce2b2"
+    },
+    "original_resource_id": "75274f99-faf6-4112-a6d5-2794cb07c789",
+    "project_id": "4154f08883334e0494c41155c33c0fc9",
+    "revision_end": null,
+    "revision_start": "2018-01-01T11:44:31.742031+00:00",
+    "started_at": "2018-01-01T11:44:31.742011+00:00",
+    "type": "compute_instance_network",
+    "user_id": "bd5874d666624b24a9f01c128871e4ac"
+}
+`

--- a/gnocchi/metric/v1/resources/testing/fixtures.go
+++ b/gnocchi/metric/v1/resources/testing/fixtures.go
@@ -104,6 +104,7 @@ const ResourceGetResult = `
     "created_by_project_id": "3d40ca37723449118987b9f288f4ae84",
     "created_by_user_id": "fdcfb420c09645e69e177a0bb1950884",
     "creator": "fdcfb420c09645e69e177a0bb1950884:3d40ca37723449118987b9f288f4ae84",
+    "iface_name": "eth0",
     "ended_at": null,
     "id": "75274f99-faf6-4112-a6d5-2794cb07c789",
     "metrics": {

--- a/gnocchi/metric/v1/resources/testing/requests_test.go
+++ b/gnocchi/metric/v1/resources/testing/requests_test.go
@@ -49,3 +49,40 @@ func TestList(t *testing.T) {
 		t.Errorf("Expected 1 page, got %d", count)
 	}
 }
+
+func TestGet(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v1/resource/compute_instance_network/75274f99-faf6-4112-a6d5-2794cb07c789", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, ResourceGetResult)
+	})
+
+	s, err := resources.Get(fake.ServiceClient(), "75274f99-faf6-4112-a6d5-2794cb07c789", "compute_instance_network").Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, s.CreatedByProjectID, "3d40ca37723449118987b9f288f4ae84")
+	th.AssertEquals(t, s.CreatedByUserID, "fdcfb420c09645e69e177a0bb1950884")
+	th.AssertEquals(t, s.Creator, "fdcfb420c09645e69e177a0bb1950884:3d40ca37723449118987b9f288f4ae84")
+	th.AssertEquals(t, s.ID, "75274f99-faf6-4112-a6d5-2794cb07c789")
+	th.AssertDeepEquals(t, s.Metrics, map[string]string{
+		"network.incoming.bytes.rate":   "01b2953e-de74-448a-a305-c84440697933",
+		"network.outgoing.bytes.rate":   "4ac0041b-3bf7-441d-a95a-d3e2f1691158",
+		"network.incoming.packets.rate": "5a64328e-8a7c-4c6a-99df-2e6d17440142",
+		"network.outgoing.packets.rate": "dc9f3198-155b-4b88-a92c-58a3853ce2b2",
+	})
+	th.AssertEquals(t, s.OriginalResourceID, "75274f99-faf6-4112-a6d5-2794cb07c789")
+	th.AssertEquals(t, s.ProjectID, "4154f08883334e0494c41155c33c0fc9")
+	th.AssertEquals(t, s.RevisionStart, "2018-01-01T11:44:31.742031+00:00")
+	th.AssertEquals(t, s.RevisionEnd, "")
+	th.AssertEquals(t, s.StartedAt, "2018-01-01T11:44:31.742011+00:00")
+	th.AssertEquals(t, s.EndedAt, "")
+	th.AssertEquals(t, s.Type, "compute_instance_network")
+	th.AssertEquals(t, s.UserID, "bd5874d666624b24a9f01c128871e4ac")
+}

--- a/gnocchi/metric/v1/resources/testing/requests_test.go
+++ b/gnocchi/metric/v1/resources/testing/requests_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/gophercloud/gophercloud/pagination"
 	th "github.com/gophercloud/gophercloud/testhelper"
@@ -79,10 +80,13 @@ func TestGet(t *testing.T) {
 	})
 	th.AssertEquals(t, s.OriginalResourceID, "75274f99-faf6-4112-a6d5-2794cb07c789")
 	th.AssertEquals(t, s.ProjectID, "4154f08883334e0494c41155c33c0fc9")
-	th.AssertEquals(t, s.RevisionStart, "2018-01-01T11:44:31.742031+00:00")
-	th.AssertEquals(t, s.RevisionEnd, "")
-	th.AssertEquals(t, s.StartedAt, "2018-01-01T11:44:31.742011+00:00")
-	th.AssertEquals(t, s.EndedAt, "")
+	th.AssertEquals(t, s.RevisionStart, time.Date(2018, 01, 01, 11, 44, 31, 742031000, time.UTC))
+	th.AssertEquals(t, s.RevisionEnd, time.Time{})
+	th.AssertEquals(t, s.StartedAt, time.Date(2018, 01, 01, 11, 44, 31, 742011000, time.UTC))
+	th.AssertEquals(t, s.EndedAt, time.Time{})
 	th.AssertEquals(t, s.Type, "compute_instance_network")
 	th.AssertEquals(t, s.UserID, "bd5874d666624b24a9f01c128871e4ac")
+	th.AssertDeepEquals(t, s.Extra, map[string]interface{}{
+		"iface_name": "eth0",
+	})
 }

--- a/gnocchi/metric/v1/resources/testing/requests_test.go
+++ b/gnocchi/metric/v1/resources/testing/requests_test.go
@@ -64,7 +64,7 @@ func TestGet(t *testing.T) {
 		fmt.Fprintf(w, ResourceGetResult)
 	})
 
-	s, err := resources.Get(fake.ServiceClient(), "75274f99-faf6-4112-a6d5-2794cb07c789", "compute_instance_network").Extract()
+	s, err := resources.Get(fake.ServiceClient(), "compute_instance_network", "75274f99-faf6-4112-a6d5-2794cb07c789").Extract()
 	th.AssertNoErr(t, err)
 
 	th.AssertEquals(t, s.CreatedByProjectID, "3d40ca37723449118987b9f288f4ae84")

--- a/gnocchi/metric/v1/resources/testing/requests_test.go
+++ b/gnocchi/metric/v1/resources/testing/requests_test.go
@@ -28,7 +28,7 @@ func TestList(t *testing.T) {
 
 	count := 0
 
-	resources.List(fake.ServiceClient(), resources.ListOpts{}, "").EachPage(func(page pagination.Page) (bool, error) {
+	resources.List(fake.ServiceClient(), resources.ListOpts{}, "generic").EachPage(func(page pagination.Page) (bool, error) {
 		count++
 		actual, err := resources.ExtractResources(page)
 		if err != nil {

--- a/gnocchi/metric/v1/resources/urls.go
+++ b/gnocchi/metric/v1/resources/urls.go
@@ -5,16 +5,10 @@ import "github.com/gophercloud/gophercloud"
 const resourcePath = "resource"
 
 func rootURL(c *gophercloud.ServiceClient, resourceType string) string {
-	if resourceType == "" {
-		resourceType = "generic"
-	}
 	return c.ServiceURL(resourcePath, resourceType)
 }
 
 func resourceURL(c *gophercloud.ServiceClient, resourceType, resourceID string) string {
-	if resourceType == "" {
-		resourceType = "generic"
-	}
 	return c.ServiceURL(resourcePath, resourceType, resourceID)
 }
 

--- a/gnocchi/metric/v1/resources/urls.go
+++ b/gnocchi/metric/v1/resources/urls.go
@@ -11,13 +11,17 @@ func rootURL(c *gophercloud.ServiceClient, resourceType string) string {
 	return c.ServiceURL(resourcePath, resourceType)
 }
 
-func listURL(c *gophercloud.ServiceClient, resourceType string) string {
-	return rootURL(c, resourceType)
-}
-
-func getURL(c *gophercloud.ServiceClient, resourceID string, resourceType string) string {
+func resourceURL(c *gophercloud.ServiceClient, resourceType, resourceID string) string {
 	if resourceType == "" {
 		resourceType = "generic"
 	}
 	return c.ServiceURL(resourcePath, resourceType, resourceID)
+}
+
+func listURL(c *gophercloud.ServiceClient, resourceType string) string {
+	return rootURL(c, resourceType)
+}
+
+func getURL(c *gophercloud.ServiceClient, resourceType, resourceID string) string {
+	return resourceURL(c, resourceType, resourceID)
 }

--- a/gnocchi/metric/v1/resources/urls.go
+++ b/gnocchi/metric/v1/resources/urls.go
@@ -14,3 +14,10 @@ func rootURL(c *gophercloud.ServiceClient, resourceType string) string {
 func listURL(c *gophercloud.ServiceClient, resourceType string) string {
 	return rootURL(c, resourceType)
 }
+
+func getURL(c *gophercloud.ServiceClient, resourceID string, resourceType string) string {
+	if resourceType == "" {
+		resourceType = "generic"
+	}
+	return c.ServiceURL(resourcePath, resourceType, resourceID)
+}


### PR DESCRIPTION
Add Gnocchi resource get request and unit test.

The same command with Gnocchi CLI is done with:
`gnocchi resource show`

For [#698](https://github.com/gophercloud/gophercloud/issues/698)

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/gnocchixyz/gnocchi/blob/stable/4.1/gnocchi/rest/api.py#L994
https://github.com/gnocchixyz/gnocchi/blob/stable/4.1/gnocchi/indexer/sqlalchemy.py#L936
