### PR TITLE
Implement Gnocchi metric get

### DIFF
--- a/gnocchi/metric/v1/metrics/doc.go
+++ b/gnocchi/metric/v1/metrics/doc.go
@@ -20,5 +20,13 @@ Example of Listing metrics
 	for _, metric := range allMetrics {
 		fmt.Printf("%+v\n", metric)
 	}
+
+Example of Getting a metric
+
+	metricID = "9e5a6441-1044-4181-b66e-34e180753040"
+	metric, err := metrics.Get(gnocchiClient, metricID).Extract()
+	if err != nil {
+		panic(err)
+	}
 */
 package metrics

--- a/gnocchi/metric/v1/metrics/requests.go
+++ b/gnocchi/metric/v1/metrics/requests.go
@@ -61,3 +61,9 @@ func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 		return MetricPage{pagination.SinglePageBase(r)}
 	})
 }
+
+// Get retrieves a specific Gnocchi metric based on its id.
+func Get(c *gophercloud.ServiceClient, metricID string) (r GetResult) {
+	_, r.Err = c.Get(getURL(c, metricID), &r.Body, nil)
+	return
+}

--- a/gnocchi/metric/v1/metrics/results.go
+++ b/gnocchi/metric/v1/metrics/results.go
@@ -1,9 +1,28 @@
 package metrics
 
 import (
+	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/pagination"
 	"github.com/gophercloud/utils/gnocchi/metric/v1/archivepolicies"
+	"github.com/gophercloud/utils/gnocchi/metric/v1/resources"
 )
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract is a function that accepts a result and extracts a Gnocchi metric.
+func (r commonResult) Extract() (*Metric, error) {
+	var s *Metric
+	err := r.ExtractInto(&s)
+	return s, err
+}
+
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a metric.
+type GetResult struct {
+	commonResult
+}
 
 // Metric is an entity storing aggregates identified by an UUID.
 // It can be attached to a resource using a name.
@@ -41,6 +60,9 @@ type Metric struct {
 
 	// ResourceID identifies the associated Gnocchi resource of the metric.
 	ResourceID string `json:"resource_id"`
+
+	// Resource is a Gnocchi resource representation.
+	Resource resources.Resource `json:"resource"`
 
 	// Unit is a unit of measurement for measures of that Gnocchi metric.
 	Unit string `json:"unit"`

--- a/gnocchi/metric/v1/metrics/testing/fixtures.go
+++ b/gnocchi/metric/v1/metrics/testing/fixtures.go
@@ -138,3 +138,49 @@ var Metric2 = metrics.Metric{
 	ResourceID:         "c5dc0c47-f43c-425c-a82f-44d61ee91175",
 	Unit:               "ns",
 }
+
+// MetricGetResult represents a raw server response from a server to a get request.
+const MetricGetResult = `
+{
+    "archive_policy": {
+        "aggregation_methods": [
+            "mean",
+            "sum"
+        ],
+        "back_window": 12,
+        "definition": [
+            {
+                "granularity": "1:00:00",
+                "points": 2160,
+                "timespan": "90 days, 0:00:00"
+            },
+            {
+                "granularity": "1 day, 0:00:00",
+                "points": 200,
+                "timespan": "200 days, 0:00:00"
+            }
+        ],
+        "name": "not_so_precise"
+    },
+        "created_by_project_id": "c6b68a6b413648b0a0eb191bf3222f4d",
+        "created_by_user_id": "cb072aacdb494419aeeba5f1c62d1a65",
+        "creator": "cb072aacdb494419aeeba5f1c62d1a65:c6b68a6b413648b0a0eb191bf3222f4d",
+        "id": "0ddf61cf-3747-4f75-bf13-13c28ff03ae3",
+        "name": "network.incoming.packets.rate",
+        "resource": {
+            "created_by_project_id": "c6b68a6b413648b0a0eb191bf3222f4d",
+            "created_by_user_id": "cb072aacdb494419aeeba5f1c62d1a65",
+            "creator": "cb072aacdb494419aeeba5f1c62d1a65:c6b68a6b413648b0a0eb191bf3222f4d",
+            "ended_at": null,
+            "id": "75274f99-faf6-4112-a6d5-2794cb07c789",
+            "original_resource_id": "75274f99-faf6-4112-a6d5-2794cb07c789",
+            "project_id": "4154f08883334e0494c41155c33c0fc9",
+            "revision_end": null,
+            "revision_start": "2018-01-08T00:59:33.767815+00:00",
+            "started_at": "2018-01-08T00:59:33.767795+00:00",
+            "type": "compute_instance_network",
+            "user_id": "bd5874d666624b24a9f01c128871e4ac"
+        },
+        "unit": "packet/s"
+}
+`

--- a/gnocchi/metric/v1/metrics/testing/fixtures.go
+++ b/gnocchi/metric/v1/metrics/testing/fixtures.go
@@ -9,29 +9,29 @@ import (
 const MetricsListResult = `[
     {
         "archive_policy": {
-        "aggregation_methods": [
-            "max",
-            "min"
-        ],
-        "back_window": 0,
-        "definition": [
-            {
-                "granularity": "1:00:00",
-                "points": 2304,
-                "timespan": "96 days, 0:00:00"
-            },
-            {
-                "granularity": "0:05:00",
-                "points": 9216,
-                "timespan": "32 days, 0:00:00"
-            },
-            {
-                "granularity": "1 day, 0:00:00",
-                "points": 400,
-                "timespan": "400 days, 0:00:00"
-            }
-        ],
-        "name": "precise"
+            "aggregation_methods": [
+                "max",
+                "min"
+            ],
+            "back_window": 0,
+            "definition": [
+                {
+                    "granularity": "1:00:00",
+                    "points": 2304,
+                    "timespan": "96 days, 0:00:00"
+                },
+                {
+                    "granularity": "0:05:00",
+                    "points": 9216,
+                    "timespan": "32 days, 0:00:00"
+                },
+                {
+                    "granularity": "1 day, 0:00:00",
+                    "points": 400,
+                    "timespan": "400 days, 0:00:00"
+                }
+            ],
+            "name": "precise"
         },
         "created_by_project_id": "e9dc821ca664406e981820a477e9a761",
         "created_by_user_id": "a23c5b98d42d4df3b961e54d5167eb6d",
@@ -162,25 +162,25 @@ const MetricGetResult = `
         ],
         "name": "not_so_precise"
     },
+    "created_by_project_id": "c6b68a6b413648b0a0eb191bf3222f4d",
+    "created_by_user_id": "cb072aacdb494419aeeba5f1c62d1a65",
+    "creator": "cb072aacdb494419aeeba5f1c62d1a65:c6b68a6b413648b0a0eb191bf3222f4d",
+    "id": "0ddf61cf-3747-4f75-bf13-13c28ff03ae3",
+    "name": "network.incoming.packets.rate",
+    "resource": {
         "created_by_project_id": "c6b68a6b413648b0a0eb191bf3222f4d",
         "created_by_user_id": "cb072aacdb494419aeeba5f1c62d1a65",
         "creator": "cb072aacdb494419aeeba5f1c62d1a65:c6b68a6b413648b0a0eb191bf3222f4d",
-        "id": "0ddf61cf-3747-4f75-bf13-13c28ff03ae3",
-        "name": "network.incoming.packets.rate",
-        "resource": {
-            "created_by_project_id": "c6b68a6b413648b0a0eb191bf3222f4d",
-            "created_by_user_id": "cb072aacdb494419aeeba5f1c62d1a65",
-            "creator": "cb072aacdb494419aeeba5f1c62d1a65:c6b68a6b413648b0a0eb191bf3222f4d",
-            "ended_at": null,
-            "id": "75274f99-faf6-4112-a6d5-2794cb07c789",
-            "original_resource_id": "75274f99-faf6-4112-a6d5-2794cb07c789",
-            "project_id": "4154f08883334e0494c41155c33c0fc9",
-            "revision_end": null,
-            "revision_start": "2018-01-08T00:59:33.767815+00:00",
-            "started_at": "2018-01-08T00:59:33.767795+00:00",
-            "type": "compute_instance_network",
-            "user_id": "bd5874d666624b24a9f01c128871e4ac"
-        },
-        "unit": "packet/s"
+        "ended_at": null,
+        "id": "75274f99-faf6-4112-a6d5-2794cb07c789",
+        "original_resource_id": "75274f99-faf6-4112-a6d5-2794cb07c789",
+        "project_id": "4154f08883334e0494c41155c33c0fc9",
+        "revision_end": null,
+        "revision_start": "2018-01-08T00:59:33.767815+00:00",
+        "started_at": "2018-01-08T00:59:33.767795+00:00",
+        "type": "compute_instance_network",
+        "user_id": "bd5874d666624b24a9f01c128871e4ac"
+    },
+    "unit": "packet/s"
 }
 `

--- a/gnocchi/metric/v1/metrics/testing/requests_test.go
+++ b/gnocchi/metric/v1/metrics/testing/requests_test.go
@@ -9,6 +9,8 @@ import (
 	th "github.com/gophercloud/gophercloud/testhelper"
 	"github.com/gophercloud/utils/gnocchi/metric/v1/metrics"
 	fake "github.com/gophercloud/utils/gnocchi/testhelper/client"
+	"github.com/gophercloud/utils/gnocchi/metric/v1/archivepolicies"
+	"github.com/gophercloud/utils/gnocchi/metric/v1/resources"
 )
 
 func TestList(t *testing.T) {
@@ -48,4 +50,63 @@ func TestList(t *testing.T) {
 	if count != 1 {
 		t.Errorf("Expected 1 page, got %d", count)
 	}
+}
+
+func TestGet(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v1/metric/0ddf61cf-3747-4f75-bf13-13c28ff03ae3", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, MetricGetResult)
+	})
+
+	s, err := metrics.Get(fake.ServiceClient(), "0ddf61cf-3747-4f75-bf13-13c28ff03ae3").Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertDeepEquals(t, s.ArchivePolicy, archivepolicies.ArchivePolicy{
+		AggregationMethods: []string{
+			"mean",
+			"sum",
+		},
+		BackWindow: 12,
+		Definition: archivepolicies.ArchivePolicyDefinition{
+			{
+				Granularity: "1:00:00",
+				Points: 2160,
+				TimeSpan: "90 days, 0:00:00",
+			},
+			{
+				Granularity: "1 day, 0:00:00",
+				Points: 200,
+				TimeSpan: "200 days, 0:00:00",
+			}
+		},
+		Name: "not_so_precise",
+	})
+	th.AssertEquals(t, s.CreatedByProjectID, "c6b68a6b413648b0a0eb191bf3222f4d")
+	th.AssertEquals(t, s.CreatedByUserID, "cb072aacdb494419aeeba5f1c62d1a65")
+	th.AssertEquals(t, s.Creator, "cb072aacdb494419aeeba5f1c62d1a65:c6b68a6b413648b0a0eb191bf3222f4d")
+	th.AssertEquals(t, s.ID, "0ddf61cf-3747-4f75-bf13-13c28ff03ae3")
+	th.AssertEquals(t, s.Name, "network.incoming.packets.rate")
+	th.AssertDeepEquals(t, s.Resource, resources.Resource{
+		CreatedByProjectID: "c6b68a6b413648b0a0eb191bf3222f4d",
+		CreatedByUserID: "cb072aacdb494419aeeba5f1c62d1a65",
+		Creator: "cb072aacdb494419aeeba5f1c62d1a65:c6b68a6b413648b0a0eb191bf3222f4d",
+		ID: "75274f99-faf6-4112-a6d5-2794cb07c789",
+		OriginalResourceID: "75274f99-faf6-4112-a6d5-2794cb07c789",
+		ProjectID: "4154f08883334e0494c41155c33c0fc9",
+		RevisionStart: "2018-01-08T00:59:33.767815+00:00",
+		RevisionEnd: "",
+		StartedAt: "2018-01-08T00:59:33.767795+00:00",
+		EndedAt: "",
+		Type: "compute_instance_network",
+		UserID: "bd5874d666624b24a9f01c128871e4ac",
+	})
+	th.AssertEquals(t, s.Unit, "packet/s")
 }

--- a/gnocchi/metric/v1/metrics/testing/requests_test.go
+++ b/gnocchi/metric/v1/metrics/testing/requests_test.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/gophercloud/gophercloud/pagination"
 	th "github.com/gophercloud/gophercloud/testhelper"
-	"github.com/gophercloud/utils/gnocchi/metric/v1/metrics"
-	fake "github.com/gophercloud/utils/gnocchi/testhelper/client"
 	"github.com/gophercloud/utils/gnocchi/metric/v1/archivepolicies"
+	"github.com/gophercloud/utils/gnocchi/metric/v1/metrics"
 	"github.com/gophercloud/utils/gnocchi/metric/v1/resources"
+	fake "github.com/gophercloud/utils/gnocchi/testhelper/client"
 )
 
 func TestList(t *testing.T) {
@@ -75,11 +75,7 @@ func TestGet(t *testing.T) {
 			"sum",
 		},
 		BackWindow: 12,
-<<<<<<< HEAD
-		Definition: archivepolicies.ArchivePolicyDefinition{
-=======
-		Definitions: []archivepolicies.ArchivePolicyDefinition{
->>>>>>> Fix Gnocchi metrics unit tests
+		Definition: []archivepolicies.ArchivePolicyDefinition{
 			{
 				Granularity: "1:00:00",
 				Points:      2160,

--- a/gnocchi/metric/v1/metrics/testing/requests_test.go
+++ b/gnocchi/metric/v1/metrics/testing/requests_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/gophercloud/gophercloud/pagination"
 	th "github.com/gophercloud/gophercloud/testhelper"
@@ -101,12 +102,13 @@ func TestGet(t *testing.T) {
 		ID:                 "75274f99-faf6-4112-a6d5-2794cb07c789",
 		OriginalResourceID: "75274f99-faf6-4112-a6d5-2794cb07c789",
 		ProjectID:          "4154f08883334e0494c41155c33c0fc9",
-		RevisionStart:      "2018-01-08T00:59:33.767815+00:00",
-		RevisionEnd:        "",
-		StartedAt:          "2018-01-08T00:59:33.767795+00:00",
-		EndedAt:            "",
+		RevisionStart:      time.Date(2018, 1, 8, 00, 59, 33, 767815000, time.UTC),
+		RevisionEnd:        time.Time{},
+		StartedAt:          time.Date(2018, 1, 8, 00, 59, 33, 767795000, time.UTC),
+		EndedAt:            time.Time{},
 		Type:               "compute_instance_network",
 		UserID:             "bd5874d666624b24a9f01c128871e4ac",
+		Extra:              map[string]interface{}{},
 	})
 	th.AssertEquals(t, s.Unit, "packet/s")
 }

--- a/gnocchi/metric/v1/metrics/testing/requests_test.go
+++ b/gnocchi/metric/v1/metrics/testing/requests_test.go
@@ -75,17 +75,21 @@ func TestGet(t *testing.T) {
 			"sum",
 		},
 		BackWindow: 12,
+<<<<<<< HEAD
 		Definition: archivepolicies.ArchivePolicyDefinition{
+=======
+		Definitions: []archivepolicies.ArchivePolicyDefinition{
+>>>>>>> Fix Gnocchi metrics unit tests
 			{
 				Granularity: "1:00:00",
-				Points: 2160,
-				TimeSpan: "90 days, 0:00:00",
+				Points:      2160,
+				TimeSpan:    "90 days, 0:00:00",
 			},
 			{
 				Granularity: "1 day, 0:00:00",
-				Points: 200,
-				TimeSpan: "200 days, 0:00:00",
-			}
+				Points:      200,
+				TimeSpan:    "200 days, 0:00:00",
+			},
 		},
 		Name: "not_so_precise",
 	})
@@ -96,17 +100,17 @@ func TestGet(t *testing.T) {
 	th.AssertEquals(t, s.Name, "network.incoming.packets.rate")
 	th.AssertDeepEquals(t, s.Resource, resources.Resource{
 		CreatedByProjectID: "c6b68a6b413648b0a0eb191bf3222f4d",
-		CreatedByUserID: "cb072aacdb494419aeeba5f1c62d1a65",
-		Creator: "cb072aacdb494419aeeba5f1c62d1a65:c6b68a6b413648b0a0eb191bf3222f4d",
-		ID: "75274f99-faf6-4112-a6d5-2794cb07c789",
+		CreatedByUserID:    "cb072aacdb494419aeeba5f1c62d1a65",
+		Creator:            "cb072aacdb494419aeeba5f1c62d1a65:c6b68a6b413648b0a0eb191bf3222f4d",
+		ID:                 "75274f99-faf6-4112-a6d5-2794cb07c789",
 		OriginalResourceID: "75274f99-faf6-4112-a6d5-2794cb07c789",
-		ProjectID: "4154f08883334e0494c41155c33c0fc9",
-		RevisionStart: "2018-01-08T00:59:33.767815+00:00",
-		RevisionEnd: "",
-		StartedAt: "2018-01-08T00:59:33.767795+00:00",
-		EndedAt: "",
-		Type: "compute_instance_network",
-		UserID: "bd5874d666624b24a9f01c128871e4ac",
+		ProjectID:          "4154f08883334e0494c41155c33c0fc9",
+		RevisionStart:      "2018-01-08T00:59:33.767815+00:00",
+		RevisionEnd:        "",
+		StartedAt:          "2018-01-08T00:59:33.767795+00:00",
+		EndedAt:            "",
+		Type:               "compute_instance_network",
+		UserID:             "bd5874d666624b24a9f01c128871e4ac",
 	})
 	th.AssertEquals(t, s.Unit, "packet/s")
 }

--- a/gnocchi/metric/v1/metrics/urls.go
+++ b/gnocchi/metric/v1/metrics/urls.go
@@ -4,10 +4,18 @@ import "github.com/gophercloud/gophercloud"
 
 const resourcePath = "metric"
 
+func resourceURL(c *gophercloud.ServiceClient, metricID string) string {
+	return c.ServiceURL(resourcePath, metricID)
+}
+
 func rootURL(c *gophercloud.ServiceClient) string {
 	return c.ServiceURL(resourcePath)
 }
 
 func listURL(c *gophercloud.ServiceClient) string {
 	return rootURL(c)
+}
+
+func getURL(c *gophercloud.ServiceClient, metricID string) string {
+	return resourceURL(c, metricID)
 }


### PR DESCRIPTION
Add Gnocchi metric get request and unit test.

The same command with Gnocchi CLI is done with:
`gnocchi metric show`

For [#698](https://github.com/gophercloud/gophercloud/issues/698)

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/gnocchixyz/gnocchi/blob/stable/4.1/gnocchi/rest/api.py#L1836
https://github.com/gnocchixyz/gnocchi/blob/stable/4.1/gnocchi/indexer/__init__.py#L41