### PR TITLE
Implement Gnocchi resource creation

### DIFF
--- a/acceptance/gnocchi/metric/v1/resources.go
+++ b/acceptance/gnocchi/metric/v1/resources.go
@@ -13,7 +13,7 @@ func CreateResource(t *testing.T, client *gophercloud.ServiceClient) (*resources
 	createOpts := resources.CreateOpts{
 		ID: "00000000-0000-dead-beef-111111111111",
 	}
-	resourceType := ""
+	resourceType := "generic"
 	t.Logf("Attempting to create a Gnocchi resource")
 
 	resource, err := resources.Create(client, resourceType, createOpts).Extract()

--- a/acceptance/gnocchi/metric/v1/resources.go
+++ b/acceptance/gnocchi/metric/v1/resources.go
@@ -5,13 +5,19 @@ import (
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/utils/gnocchi/metric/v1/resources"
+	"github.com/satori/go.uuid"
 )
 
 // CreateResource will create Gnocchi resource. An error will be returned if the
 // resource could not be created.
 func CreateResource(t *testing.T, client *gophercloud.ServiceClient) (*resources.Resource, error) {
+	id, err := uuid.NewV4()
+	if err != nil {
+		return nil, err
+	}
+
 	createOpts := resources.CreateOpts{
-		ID: "00000000-0000-dead-beef-111111111111",
+		ID: id.String(),
 	}
 	resourceType := "generic"
 	t.Logf("Attempting to create a Gnocchi resource")

--- a/acceptance/gnocchi/metric/v1/resources.go
+++ b/acceptance/gnocchi/metric/v1/resources.go
@@ -2,31 +2,41 @@ package v1
 
 import (
 	"testing"
+	"time"
 
 	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/acceptance/tools"
 	"github.com/gophercloud/utils/gnocchi/metric/v1/resources"
 	"github.com/satori/go.uuid"
 )
 
-// CreateResource will create Gnocchi resource. An error will be returned if the
-// resource could not be created.
-func CreateResource(t *testing.T, client *gophercloud.ServiceClient) (*resources.Resource, error) {
+// CreateGenericResource will create a Gnocchi resource with a generic type.
+// An error will be returned if the resource could not be created.
+func CreateGenericResource(t *testing.T, client *gophercloud.ServiceClient) (*resources.Resource, error) {
 	id, err := uuid.NewV4()
 	if err != nil {
 		return nil, err
 	}
 
+	randomDay := tools.RandomInt(1, 100)
+	now := time.Now().UTC().AddDate(0, 0, -randomDay)
 	createOpts := resources.CreateOpts{
-		ID: id.String(),
+		ID:        id.String(),
+		StartedAt: &now,
+		Metrics: map[string]interface{}{
+			"cpu.delta": map[string]string{
+				"archive_policy_name": "medium",
+			},
+		},
 	}
 	resourceType := "generic"
-	t.Logf("Attempting to create a Gnocchi resource")
+	t.Logf("Attempting to create a generic Gnocchi resource")
 
 	resource, err := resources.Create(client, resourceType, createOpts).Extract()
 	if err != nil {
 		return nil, err
 	}
 
-	t.Logf("Successfully created the Gnocchi resource.")
+	t.Logf("Successfully created the generic Gnocchi resource.")
 	return resource, nil
 }

--- a/acceptance/gnocchi/metric/v1/resources.go
+++ b/acceptance/gnocchi/metric/v1/resources.go
@@ -1,0 +1,26 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/utils/gnocchi/metric/v1/resources"
+)
+
+// CreateResource will create Gnocchi resource. An error will be returned if the
+// resource could not be created.
+func CreateResource(t *testing.T, client *gophercloud.ServiceClient) (*resources.Resource, error) {
+	createOpts := resources.CreateOpts{
+		ID: "00000000-0000-dead-beef-111111111111",
+	}
+	resourceType := ""
+	t.Logf("Attempting to create a Gnocchi resource")
+
+	resource, err := resources.Create(client, resourceType, createOpts).Extract()
+	if err != nil {
+		return nil, err
+	}
+
+	t.Logf("Successfully created the Gnocchi resource.")
+	return resource, nil
+}

--- a/acceptance/gnocchi/metric/v1/resources_test.go
+++ b/acceptance/gnocchi/metric/v1/resources_test.go
@@ -10,6 +10,20 @@ import (
 	"github.com/gophercloud/utils/gnocchi/metric/v1/resources"
 )
 
+func TestResourcesCRUD(t *testing.T) {
+	client, err := clients.NewGnocchiV1Client()
+	if err != nil {
+		t.Fatalf("Unable to create a Gnocchi client: %v", err)
+	}
+
+	resource, err := CreateResource(t, client)
+	if err != nil {
+		t.Fatalf("Unable to create Gnocchi resource: %v", err)
+	}
+
+	tools.PrintResource(t, resource)
+}
+
 func TestResourcesList(t *testing.T) {
 	client, err := clients.NewGnocchiV1Client()
 	if err != nil {

--- a/acceptance/gnocchi/metric/v1/resources_test.go
+++ b/acceptance/gnocchi/metric/v1/resources_test.go
@@ -16,12 +16,12 @@ func TestResourcesCRUD(t *testing.T) {
 		t.Fatalf("Unable to create a Gnocchi client: %v", err)
 	}
 
-	resource, err := CreateResource(t, client)
+	genericResource, err := CreateGenericResource(t, client)
 	if err != nil {
-		t.Fatalf("Unable to create Gnocchi resource: %v", err)
+		t.Fatalf("Unable to create a generic Gnocchi resource: %v", err)
 	}
 
-	tools.PrintResource(t, resource)
+	tools.PrintResource(t, genericResource)
 }
 
 func TestResourcesList(t *testing.T) {

--- a/gnocchi/metric/v1/metrics/testing/requests_test.go
+++ b/gnocchi/metric/v1/metrics/testing/requests_test.go
@@ -108,7 +108,7 @@ func TestGet(t *testing.T) {
 		EndedAt:            time.Time{},
 		Type:               "compute_instance_network",
 		UserID:             "bd5874d666624b24a9f01c128871e4ac",
-		Extra:              map[string]interface{}{},
+		ExtraAttributes:    map[string]interface{}{},
 	})
 	th.AssertEquals(t, s.Unit, "packet/s")
 }

--- a/gnocchi/metric/v1/resources/doc.go
+++ b/gnocchi/metric/v1/resources/doc.go
@@ -35,8 +35,6 @@ Example of Creating a resource without a metric
 
 	createOpts := resources.CreateOpts{
 		ID: "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",
-		ProjectID: "4154f088-8333-4e04-94c4-1155c33c0fc9",
-		UserID: "bd5874d6-6662-4b24-a9f01c128871e4ac",
 	}
 	resourceType = ""
 	resource, err := resources.Create(gnocchiClient, createOpts, resourceType).Extract()
@@ -49,7 +47,6 @@ Example of Creating a resource with links to some existing metrics
 	createOpts := resources.CreateOpts{
 		ID: "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",
 		ProjectID: "4154f088-8333-4e04-94c4-1155c33c0fc9",
-		UserID: "bd5874d6-6662-4b24-a9f01c128871e4ac",
 		Metrics: map[string]interface{}{
 			"disk.read.bytes.rate": "ed1bb76f-6ccc-4ad2-994c-dbb19ddccbae",
 			"disk.write.bytes.rate": "0a2da84d-4753-43f5-a65f-0f8d44d2766c",

--- a/gnocchi/metric/v1/resources/doc.go
+++ b/gnocchi/metric/v1/resources/doc.go
@@ -42,13 +42,13 @@ Example of Creating a resource without a metric
 		panic(err)
 	}
 
-Example of Creating a resource with links to some existing metrics with an ending timestamp of the resource
+Example of Creating a resource with links to some existing metrics with a starting timestamp of the resource
 
-	endedAt := time.Date(2018, 1, 4, 10, 0, 0, 0, time.UTC)
+	startedAt := time.Date(2018, 1, 4, 10, 0, 0, 0, time.UTC)
 	createOpts := resources.CreateOpts{
 		ID: "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",
 		ProjectID: "4154f088-8333-4e04-94c4-1155c33c0fc9",
-		EndedAt: &endedAt,
+		StartedAt: &startedAt,
 		Metrics: map[string]interface{}{
 			"disk.read.bytes.rate": "ed1bb76f-6ccc-4ad2-994c-dbb19ddccbae",
 			"disk.write.bytes.rate": "0a2da84d-4753-43f5-a65f-0f8d44d2766c",

--- a/gnocchi/metric/v1/resources/doc.go
+++ b/gnocchi/metric/v1/resources/doc.go
@@ -44,7 +44,7 @@ Example of Creating a resource without a metric
 
 Example of Creating a resource with links to some existing metrics with an ending timestamp of the resource
 
-	endedAt := time.Time(2018, 1, 10, 21, 0, 0, 0, time.UTC)
+	endedAt := time.Date(2018, 1, 4, 10, 0, 0, 0, time.UTC)
 	createOpts := resources.CreateOpts{
 		ID: "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",
 		ProjectID: "4154f088-8333-4e04-94c4-1155c33c0fc9",

--- a/gnocchi/metric/v1/resources/doc.go
+++ b/gnocchi/metric/v1/resources/doc.go
@@ -36,7 +36,7 @@ Example of Creating a resource without a metric
 	createOpts := resources.CreateOpts{
 		ID: "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",
 		ProjectID: "4154f088-8333-4e04-94c4-1155c33c0fc9",
-		UserID: "bd5874d666624b24a9f01c128871e4ac",
+		UserID: "bd5874d6-6662-4b24-a9f01c128871e4ac",
 	}
 	resourceType = ""
 	resource, err := resources.Create(gnocchiClient, createOpts, resourceType).Extract()
@@ -49,8 +49,8 @@ Example of Creating a resource with links to some existing metrics
 	createOpts := resources.CreateOpts{
 		ID: "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",
 		ProjectID: "4154f088-8333-4e04-94c4-1155c33c0fc9",
-		UserID: "bd5874d666624b24a9f01c128871e4ac",
-		Metrics: map[string]string{
+		UserID: "bd5874d6-6662-4b24-a9f01c128871e4ac",
+		Metrics: map[string]interface{}{
 			"disk.read.bytes.rate": "ed1bb76f-6ccc-4ad2-994c-dbb19ddccbae",
 			"disk.write.bytes.rate": "0a2da84d-4753-43f5-a65f-0f8d44d2766c",
 		},
@@ -66,8 +66,8 @@ Example of Creating a resource and a metric a the same time
 	createOpts := resources.CreateOpts{
 		ID: "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",
 		ProjectID: "4154f088-8333-4e04-94c4-1155c33c0fc9",
-		UserID: "bd5874d666624b24a9f01c128871e4ac",
-		Metrics: map[string]map[string]string{
+		UserID: "bd5874d6-6662-4b24-a9f01c128871e4ac",
+		Metrics: map[string]interface{}{
 			"cpu.delta": map[string]string{
 				"archive_policy_name": "medium",
 			},

--- a/gnocchi/metric/v1/resources/doc.go
+++ b/gnocchi/metric/v1/resources/doc.go
@@ -31,11 +31,10 @@ Example of Getting a resource
 		panic(err)
 	}
 
-Example of Creating a resource without a metric with a string timestamp for the starting time
+Example of Creating a resource without a metric
 
 	createOpts := resources.CreateOpts{
 		ID: "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",
-		StartedAtString: "2018-01-09T22:15:00+00:00",
 	}
 	resourceType = "generic"
 	resource, err := resources.Create(gnocchiClient, createOpts, resourceType).Extract()
@@ -43,14 +42,13 @@ Example of Creating a resource without a metric with a string timestamp for the 
 		panic(err)
 	}
 
-Example of Creating a resource with links to some existing metrics with
-a Go standard time format for the ending time
+Example of Creating a resource with links to some existing metrics with an ending timestamp of the resource
 
 	endedAt := time.Time(2018, 1, 10, 21, 0, 0, 0, time.UTC)
 	createOpts := resources.CreateOpts{
 		ID: "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",
 		ProjectID: "4154f088-8333-4e04-94c4-1155c33c0fc9",
-		EndedAtTimeStamp: &endedAt,
+		EndedAt: &endedAt,
 		Metrics: map[string]interface{}{
 			"disk.read.bytes.rate": "ed1bb76f-6ccc-4ad2-994c-dbb19ddccbae",
 			"disk.write.bytes.rate": "0a2da84d-4753-43f5-a65f-0f8d44d2766c",

--- a/gnocchi/metric/v1/resources/doc.go
+++ b/gnocchi/metric/v1/resources/doc.go
@@ -31,10 +31,11 @@ Example of Getting a resource
 		panic(err)
 	}
 
-Example of Creating a resource without a metric
+Example of Creating a resource without a metric with a string timestamp for the starting time
 
 	createOpts := resources.CreateOpts{
 		ID: "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",
+		StartedAtString: "2018-01-09T22:15:00+00:00",
 	}
 	resourceType = "generic"
 	resource, err := resources.Create(gnocchiClient, createOpts, resourceType).Extract()
@@ -42,11 +43,14 @@ Example of Creating a resource without a metric
 		panic(err)
 	}
 
-Example of Creating a resource with links to some existing metrics
+Example of Creating a resource with links to some existing metrics with
+a Go standard time format for the ending time
 
+	endedAt := time.Time(2018, 1, 10, 21, 0, 0, 0, time.UTC)
 	createOpts := resources.CreateOpts{
 		ID: "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",
 		ProjectID: "4154f088-8333-4e04-94c4-1155c33c0fc9",
+		EndedAtTimeStamp: &endedAt,
 		Metrics: map[string]interface{}{
 			"disk.read.bytes.rate": "ed1bb76f-6ccc-4ad2-994c-dbb19ddccbae",
 			"disk.write.bytes.rate": "0a2da84d-4753-43f5-a65f-0f8d44d2766c",

--- a/gnocchi/metric/v1/resources/doc.go
+++ b/gnocchi/metric/v1/resources/doc.go
@@ -36,7 +36,7 @@ Example of Creating a resource without a metric
 	createOpts := resources.CreateOpts{
 		ID: "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",
 	}
-	resourceType = ""
+	resourceType = "generic"
 	resource, err := resources.Create(gnocchiClient, createOpts, resourceType).Extract()
 	if err != nil {
 		panic(err)

--- a/gnocchi/metric/v1/resources/doc.go
+++ b/gnocchi/metric/v1/resources/doc.go
@@ -37,7 +37,7 @@ Example of Creating a resource without a metric
 		ID: "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",
 	}
 	resourceType = "generic"
-	resource, err := resources.Create(gnocchiClient, createOpts, resourceType).Extract()
+	resource, err := resources.Create(gnocchiClient, resourceType, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -55,7 +55,7 @@ Example of Creating a resource with links to some existing metrics with an endin
 		},
 	}
 	resourceType = "compute_instance_disk"
-	resource, err := resources.Create(gnocchiClient, createOpts, resourceType).Extract()
+	resource, err := resources.Create(gnocchiClient, resourceType, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -73,7 +73,7 @@ Example of Creating a resource and a metric a the same time
 		},
 	}
 	resourceType = "compute_instance"
-	resource, err := resources.Create(gnocchiClient, createOpts, resourceType).Extract()
+	resource, err := resources.Create(gnocchiClient, resourceType, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}

--- a/gnocchi/metric/v1/resources/doc.go
+++ b/gnocchi/metric/v1/resources/doc.go
@@ -31,5 +31,52 @@ Example of Getting a resource
 		panic(err)
 	}
 
+Example of Creating a resource without a metric
+
+	createOpts := resources.CreateOpts{
+		ID: "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",
+		ProjectID: "4154f088-8333-4e04-94c4-1155c33c0fc9",
+		UserID: "bd5874d666624b24a9f01c128871e4ac",
+	}
+	resourceType = ""
+	resource, err := resources.Create(gnocchiClient, createOpts, resourceType).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example of Creating a resource with links to some existing metrics
+
+	createOpts := resources.CreateOpts{
+		ID: "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",
+		ProjectID: "4154f088-8333-4e04-94c4-1155c33c0fc9",
+		UserID: "bd5874d666624b24a9f01c128871e4ac",
+		Metrics: map[string]string{
+			"disk.read.bytes.rate": "ed1bb76f-6ccc-4ad2-994c-dbb19ddccbae",
+			"disk.write.bytes.rate": "0a2da84d-4753-43f5-a65f-0f8d44d2766c",
+		},
+	}
+	resourceType = "compute_instance_disk"
+	resource, err := resources.Create(gnocchiClient, createOpts, resourceType).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example of Creating a resource and a metric a the same time
+
+	createOpts := resources.CreateOpts{
+		ID: "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",
+		ProjectID: "4154f088-8333-4e04-94c4-1155c33c0fc9",
+		UserID: "bd5874d666624b24a9f01c128871e4ac",
+		Metrics: map[string]map[string]string{
+			"cpu.delta": map[string]string{
+				"archive_policy_name": "medium",
+			},
+		},
+	}
+	resourceType = "compute_instance"
+	resource, err := resources.Create(gnocchiClient, createOpts, resourceType).Extract()
+	if err != nil {
+		panic(err)
+	}
 */
 package resources

--- a/gnocchi/metric/v1/resources/requests.go
+++ b/gnocchi/metric/v1/resources/requests.go
@@ -59,3 +59,65 @@ func Get(c *gophercloud.ServiceClient, resourceType string, resourceID string) (
 	_, r.Err = c.Get(getURL(c, resourceType, resourceID), &r.Body, nil)
 	return
 }
+
+// CreateOptsBuilder allows to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToResourceCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts specifies parameters of a new Gnocchi resource.
+type CreateOpts struct {
+	// CreatedByProjectID contains the id of the Identity project that
+	// was used for a resource creation.
+	CreatedByProjectID string `json:"created_by_project_id,omitempty"`
+
+	// CreatedByUserID contains the id of the Identity user
+	// that created the Gnocchi resource.
+	CreatedByUserID string `json:"created_by_user_id,omitempty"`
+
+	// Creator shows who created the resource.
+	// Usually it contains concatenated string with values from
+	// "created_by_user_id" and "created_by_project_id" fields.
+	Creator string `json:"creator,omitempty"`
+
+	// ID uniquely identifies the Gnocchi resource.
+	ID string `json:"id"`
+
+	// OriginalResourceID is the orginal resource id. It can be different from the
+	// regular ID field.
+	OriginalResourceID string `json:"original_resource_id,omitempty"`
+
+	// ProjectID is the Identity project of the resource.
+	ProjectID string `json:"project_id"`
+
+	// UserID is the Identity user of the resource.
+	UserID string `json:"user_id"`
+
+	// StartedAt is a resource creation timestamp.
+	StartedAt string `json:"started_at,omitempty"`
+
+	// EndedAt is a timestamp of when the resource has ended.
+	EndedAt string `json:"ended_at,omitempty"`
+
+	// Type is a type of the resource.
+	Type string `json:"type,omitempty"`
+}
+
+// ToResourceCreateMap constructs a request body from CreateOpts.
+func (opts CreateOpts) ToResourceCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "")
+}
+
+// Create requests the creation of a new Gnocchi resource on the server.
+func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder, resourceType string) (r CreateResult) {
+	b, err := opts.ToResourceCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(createURL(client, resourceType), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{201},
+	})
+	return
+}

--- a/gnocchi/metric/v1/resources/requests.go
+++ b/gnocchi/metric/v1/resources/requests.go
@@ -102,19 +102,11 @@ type CreateOpts struct {
 	// UserID is the Identity user of the resource.
 	UserID string `json:"user_id,omitempty"`
 
-	// StartedAtTimeStamp is a resource creation timestamp. It's contents will be converted into the string
-	// and then transferred to the private "startedAt" field.
-	StartedAtTimeStamp *time.Time `json:"-"`
+	// StartedAt is a resource creation timestamp.
+	StartedAt *time.Time `json:"-"`
 
-	// StartedAtString is a string representation of the "StartedAt" field.
-	StartedAtString string `json:"started_at,omitempty"`
-
-	// EndedAtTimeStamp is a timestamp of when the resource has ended. It's contents will be converted into the string
-	// and then transferred to the private "endedAt" field.
-	EndedAtTimeStamp *time.Time `json:"-"`
-
-	// EndedAtString is a string representation of the "EndedAt" field.
-	EndedAtString string `json:"ended_at,omitempty"`
+	// EndedAt is a timestamp of when the resource has ended.
+	EndedAt *time.Time `json:"-"`
 
 	// ExtraAttributes is a collection of keys and values that can be found in resources
 	// of different resource types.
@@ -123,19 +115,17 @@ type CreateOpts struct {
 
 // ToResourceCreateMap constructs a request body from CreateOpts.
 func (opts CreateOpts) ToResourceCreateMap() (map[string]interface{}, error) {
-	if opts.StartedAtTimeStamp != nil {
-		opts.StartedAtString = opts.StartedAtTimeStamp.Format(gnocchi.RFC3339NanoTimezone)
-		opts.StartedAtTimeStamp = nil
-	}
-
-	if opts.EndedAtTimeStamp != nil {
-		opts.EndedAtString = opts.EndedAtTimeStamp.Format(gnocchi.RFC3339NanoTimezone)
-		opts.EndedAtTimeStamp = nil
-	}
-
 	b, err := gophercloud.BuildRequestBody(opts, "")
 	if err != nil {
 		return nil, err
+	}
+
+	if opts.StartedAt != nil {
+		b["started_at"] = opts.StartedAt.Format(gnocchi.RFC3339NanoTimezone)
+	}
+
+	if opts.EndedAt != nil {
+		b["ended_at"] = opts.EndedAt.Format(gnocchi.RFC3339NanoTimezone)
 	}
 
 	if opts.ExtraAttributes != nil {

--- a/gnocchi/metric/v1/resources/requests.go
+++ b/gnocchi/metric/v1/resources/requests.go
@@ -71,30 +71,13 @@ type CreateOptsBuilder interface {
 
 // CreateOpts specifies parameters of a new Gnocchi resource.
 type CreateOpts struct {
-	// CreatedByProjectID contains the id of the Identity project that
-	// was used for a resource creation.
-	CreatedByProjectID string `json:"created_by_project_id,omitempty"`
-
-	// CreatedByUserID contains the id of the Identity user
-	// that created the Gnocchi resource.
-	CreatedByUserID string `json:"created_by_user_id,omitempty"`
-
-	// Creator shows who created the resource.
-	// Usually it contains concatenated string with values from
-	// "created_by_user_id" and "created_by_project_id" fields.
-	Creator string `json:"creator,omitempty"`
+	// ID uniquely identifies the Gnocchi resource.
+	ID string `json:"id"`
 
 	// Metrics field can be used to link existing metrics in the resource
 	// or to create metrics with the resource at the same time to save
 	// some requests.
 	Metrics map[string]interface{} `json:"metrics,omitempty"`
-
-	// ID uniquely identifies the Gnocchi resource.
-	ID string `json:"id"`
-
-	// OriginalResourceID is the orginal resource id. It can be different from the
-	// regular ID field.
-	OriginalResourceID string `json:"original_resource_id,omitempty"`
 
 	// ProjectID is the Identity project of the resource.
 	ProjectID string `json:"project_id,omitempty"`

--- a/gnocchi/metric/v1/resources/requests.go
+++ b/gnocchi/metric/v1/resources/requests.go
@@ -81,23 +81,23 @@ type CreateOpts struct {
 	// "created_by_user_id" and "created_by_project_id" fields.
 	Creator string `json:"creator,omitempty"`
 
-	// Metrics field can be used to link an existing metric in the resource
-	// or to create a metric with the resource at the same time to save
+	// Metrics field can be used to link existing metrics in the resource
+	// or to create metrics with the resource at the same time to save
 	// some requests.
-	Metrics map[string]interface{} `json:"metrics"`
+	Metrics map[string]interface{} `json:"metrics,omitempty"`
 
 	// ID uniquely identifies the Gnocchi resource.
-	ID string `json:"id"`
+	ID string `json:"id,omitempty"`
 
 	// OriginalResourceID is the orginal resource id. It can be different from the
 	// regular ID field.
 	OriginalResourceID string `json:"original_resource_id,omitempty"`
 
 	// ProjectID is the Identity project of the resource.
-	ProjectID string `json:"project_id"`
+	ProjectID string `json:"project_id,omitempty"`
 
 	// UserID is the Identity user of the resource.
-	UserID string `json:"user_id"`
+	UserID string `json:"user_id,omitempty"`
 
 	// StartedAt is a resource creation timestamp.
 	StartedAt string `json:"started_at,omitempty"`
@@ -112,7 +112,7 @@ func (opts CreateOpts) ToResourceCreateMap() (map[string]interface{}, error) {
 }
 
 // Create requests the creation of a new Gnocchi resource on the server.
-func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder, resourceType string) (r CreateResult) {
+func Create(client *gophercloud.ServiceClient, resourceType string, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToResourceCreateMap()
 	if err != nil {
 		r.Err = err

--- a/gnocchi/metric/v1/resources/requests.go
+++ b/gnocchi/metric/v1/resources/requests.go
@@ -1,8 +1,11 @@
 package resources
 
 import (
+	"time"
+
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/pagination"
+	"github.com/gophercloud/utils/gnocchi"
 )
 
 // ListOptsBuilder allows extensions to add additional parameters to the
@@ -99,11 +102,19 @@ type CreateOpts struct {
 	// UserID is the Identity user of the resource.
 	UserID string `json:"user_id,omitempty"`
 
-	// StartedAt is a resource creation timestamp.
-	StartedAt string `json:"started_at,omitempty"`
+	// StartedAtTimeStamp is a resource creation timestamp. It's contents will be converted into the string
+	// and then transferred to the private "startedAt" field.
+	StartedAtTimeStamp *time.Time `json:"-"`
 
-	// EndedAt is a timestamp of when the resource has ended.
-	EndedAt string `json:"ended_at,omitempty"`
+	// StartedAtString is a string representation of the "StartedAt" field.
+	StartedAtString string `json:"started_at,omitempty"`
+
+	// EndedAtTimeStamp is a timestamp of when the resource has ended. It's contents will be converted into the string
+	// and then transferred to the private "endedAt" field.
+	EndedAtTimeStamp *time.Time `json:"-"`
+
+	// EndedAtString is a string representation of the "EndedAt" field.
+	EndedAtString string `json:"ended_at,omitempty"`
 
 	// ExtraAttributes is a collection of keys and values that can be found in resources
 	// of different resource types.
@@ -112,6 +123,16 @@ type CreateOpts struct {
 
 // ToResourceCreateMap constructs a request body from CreateOpts.
 func (opts CreateOpts) ToResourceCreateMap() (map[string]interface{}, error) {
+	if opts.StartedAtTimeStamp != nil {
+		opts.StartedAtString = opts.StartedAtTimeStamp.Format(gnocchi.RFC3339NanoTimezone)
+		opts.StartedAtTimeStamp = nil
+	}
+
+	if opts.EndedAtTimeStamp != nil {
+		opts.EndedAtString = opts.EndedAtTimeStamp.Format(gnocchi.RFC3339NanoTimezone)
+		opts.EndedAtTimeStamp = nil
+	}
+
 	b, err := gophercloud.BuildRequestBody(opts, "")
 	if err != nil {
 		return nil, err

--- a/gnocchi/metric/v1/resources/requests.go
+++ b/gnocchi/metric/v1/resources/requests.go
@@ -81,6 +81,11 @@ type CreateOpts struct {
 	// "created_by_user_id" and "created_by_project_id" fields.
 	Creator string `json:"creator,omitempty"`
 
+	// Metrics field can be used to link an existing metric in the resource
+	// or to create a metric with the resource at the same time to save
+	// some requests.
+	Metrics map[string]interface{} `json:"metrics"`
+
 	// ID uniquely identifies the Gnocchi resource.
 	ID string `json:"id"`
 
@@ -99,9 +104,6 @@ type CreateOpts struct {
 
 	// EndedAt is a timestamp of when the resource has ended.
 	EndedAt string `json:"ended_at,omitempty"`
-
-	// Type is a type of the resource.
-	Type string `json:"type,omitempty"`
 }
 
 // ToResourceCreateMap constructs a request body from CreateOpts.

--- a/gnocchi/metric/v1/resources/requests.go
+++ b/gnocchi/metric/v1/resources/requests.go
@@ -87,7 +87,7 @@ type CreateOpts struct {
 	Metrics map[string]interface{} `json:"metrics,omitempty"`
 
 	// ID uniquely identifies the Gnocchi resource.
-	ID string `json:"id,omitempty"`
+	ID string `json:"id"`
 
 	// OriginalResourceID is the orginal resource id. It can be different from the
 	// regular ID field.

--- a/gnocchi/metric/v1/resources/requests.go
+++ b/gnocchi/metric/v1/resources/requests.go
@@ -104,11 +104,26 @@ type CreateOpts struct {
 
 	// EndedAt is a timestamp of when the resource has ended.
 	EndedAt string `json:"ended_at,omitempty"`
+
+	// ExtraAttributes is a collection of keys and values that can be found in resources
+	// of different resource types.
+	ExtraAttributes map[string]interface{} `json:"-"`
 }
 
 // ToResourceCreateMap constructs a request body from CreateOpts.
 func (opts CreateOpts) ToResourceCreateMap() (map[string]interface{}, error) {
-	return gophercloud.BuildRequestBody(opts, "")
+	b, err := gophercloud.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	if opts.ExtraAttributes != nil {
+		for key, value := range opts.ExtraAttributes {
+			b[key] = value
+		}
+	}
+
+	return b, nil
 }
 
 // Create requests the creation of a new Gnocchi resource on the server.

--- a/gnocchi/metric/v1/resources/results.go
+++ b/gnocchi/metric/v1/resources/results.go
@@ -70,7 +70,7 @@ type Resource struct {
 	EndedAt time.Time `json:"-"`
 
 	// EndedAt is a timestamp of when the resource has ended.
-	EndedAt string `json:"ended_at"`
+	EndedAt time.Time `json:"-"`
 
 	// Type is a type of the resource.
 	Type string `json:"type"`
@@ -124,6 +124,30 @@ func (r *Resource) UnmarshalJSON(b []byte) error {
 			r.Extra = internal.RemainingKeys(Resource{}, resultMap)
 		}
 	}
+
+	return err
+}
+
+// UnmarshalJSON helps to unmarshal Resource fields into needed values.
+func (r *Resource) UnmarshalJSON(b []byte) error {
+	type tmp Resource
+	var s struct {
+		tmp
+		RevisionStart gnocchi.JSONRFC3339NanoTimezone `json:"revision_start"`
+		RevisionEnd   gnocchi.JSONRFC3339NanoTimezone `json:"revision_end"`
+		StartedAt     gnocchi.JSONRFC3339NanoTimezone `json:"started_at"`
+		EndedAt       gnocchi.JSONRFC3339NanoTimezone `json:"ended_at"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*r = Resource(s.tmp)
+
+	r.RevisionStart = time.Time(s.RevisionStart)
+	r.RevisionEnd = time.Time(s.RevisionEnd)
+	r.StartedAt = time.Time(s.StartedAt)
+	r.EndedAt = time.Time(s.EndedAt)
 
 	return err
 }

--- a/gnocchi/metric/v1/resources/results.go
+++ b/gnocchi/metric/v1/resources/results.go
@@ -91,7 +91,7 @@ func (r *Resource) UnmarshalJSON(b []byte) error {
 	type tmp Resource
 	var s struct {
 		tmp
-		ExtraAttributes map[string]interface{}          `json:"extra"`
+		ExtraAttributes map[string]interface{}          `json:"extra_attributes"`
 		RevisionStart   gnocchi.JSONRFC3339NanoTimezone `json:"revision_start"`
 		RevisionEnd     gnocchi.JSONRFC3339NanoTimezone `json:"revision_end"`
 		StartedAt       gnocchi.JSONRFC3339NanoTimezone `json:"started_at"`

--- a/gnocchi/metric/v1/resources/results.go
+++ b/gnocchi/metric/v1/resources/results.go
@@ -75,9 +75,6 @@ type Resource struct {
 	// EndedAt is a timestamp of when the resource has ended.
 	EndedAt time.Time `json:"-"`
 
-	// EndedAt is a timestamp of when the resource has ended.
-	EndedAt string `json:"ended_at"`
-
 	// Type is a type of the resource.
 	Type string `json:"type"`
 

--- a/gnocchi/metric/v1/resources/results.go
+++ b/gnocchi/metric/v1/resources/results.go
@@ -69,9 +69,6 @@ type Resource struct {
 	// EndedAt is a timestamp of when the resource has ended.
 	EndedAt time.Time `json:"-"`
 
-	// EndedAt is a timestamp of when the resource has ended.
-	EndedAt time.Time `json:"-"`
-
 	// Type is a type of the resource.
 	Type string `json:"type"`
 
@@ -133,6 +130,7 @@ func (r *Resource) UnmarshalJSON(b []byte) error {
 	type tmp Resource
 	var s struct {
 		tmp
+		Extra         map[string]interface{}          `json:"extra"`
 		RevisionStart gnocchi.JSONRFC3339NanoTimezone `json:"revision_start"`
 		RevisionEnd   gnocchi.JSONRFC3339NanoTimezone `json:"revision_end"`
 		StartedAt     gnocchi.JSONRFC3339NanoTimezone `json:"started_at"`
@@ -144,10 +142,30 @@ func (r *Resource) UnmarshalJSON(b []byte) error {
 	}
 	*r = Resource(s.tmp)
 
+	// Collect Gnocchi timestamps.
 	r.RevisionStart = time.Time(s.RevisionStart)
 	r.RevisionEnd = time.Time(s.RevisionEnd)
 	r.StartedAt = time.Time(s.StartedAt)
 	r.EndedAt = time.Time(s.EndedAt)
+
+	// Collect other resource fields
+	// and bundle them into Extra.
+	if s.Extra != nil {
+		r.Extra = s.Extra
+	} else {
+		var result interface{}
+		err := json.Unmarshal(b, &result)
+		if err != nil {
+			return err
+		}
+		if resultMap, ok := result.(map[string]interface{}); ok {
+			delete(resultMap, "revision_start")
+			delete(resultMap, "revision_end")
+			delete(resultMap, "started_at")
+			delete(resultMap, "ended_at")
+			r.Extra = internal.RemainingKeys(Resource{}, resultMap)
+		}
+	}
 
 	return err
 }

--- a/gnocchi/metric/v1/resources/results.go
+++ b/gnocchi/metric/v1/resources/results.go
@@ -27,6 +27,12 @@ type GetResult struct {
 	commonResult
 }
 
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a Gnocchi resource.
+type CreateResult struct {
+	commonResult
+}
+
 // Resource is an entity representing anything in your infrastructure
 // that you will associate metric(s) with.
 // It is identified by a unique ID and can contain attributes.

--- a/gnocchi/metric/v1/resources/results.go
+++ b/gnocchi/metric/v1/resources/results.go
@@ -69,6 +69,9 @@ type Resource struct {
 	// EndedAt is a timestamp of when the resource has ended.
 	EndedAt time.Time `json:"-"`
 
+	// EndedAt is a timestamp of when the resource has ended.
+	EndedAt string `json:"ended_at"`
+
 	// Type is a type of the resource.
 	Type string `json:"type"`
 

--- a/gnocchi/metric/v1/resources/results.go
+++ b/gnocchi/metric/v1/resources/results.go
@@ -125,51 +125,6 @@ func (r *Resource) UnmarshalJSON(b []byte) error {
 	return err
 }
 
-// UnmarshalJSON helps to unmarshal Resource fields into needed values.
-func (r *Resource) UnmarshalJSON(b []byte) error {
-	type tmp Resource
-	var s struct {
-		tmp
-		Extra         map[string]interface{}          `json:"extra"`
-		RevisionStart gnocchi.JSONRFC3339NanoTimezone `json:"revision_start"`
-		RevisionEnd   gnocchi.JSONRFC3339NanoTimezone `json:"revision_end"`
-		StartedAt     gnocchi.JSONRFC3339NanoTimezone `json:"started_at"`
-		EndedAt       gnocchi.JSONRFC3339NanoTimezone `json:"ended_at"`
-	}
-	err := json.Unmarshal(b, &s)
-	if err != nil {
-		return err
-	}
-	*r = Resource(s.tmp)
-
-	// Collect Gnocchi timestamps.
-	r.RevisionStart = time.Time(s.RevisionStart)
-	r.RevisionEnd = time.Time(s.RevisionEnd)
-	r.StartedAt = time.Time(s.StartedAt)
-	r.EndedAt = time.Time(s.EndedAt)
-
-	// Collect other resource fields
-	// and bundle them into Extra.
-	if s.Extra != nil {
-		r.Extra = s.Extra
-	} else {
-		var result interface{}
-		err := json.Unmarshal(b, &result)
-		if err != nil {
-			return err
-		}
-		if resultMap, ok := result.(map[string]interface{}); ok {
-			delete(resultMap, "revision_start")
-			delete(resultMap, "revision_end")
-			delete(resultMap, "started_at")
-			delete(resultMap, "ended_at")
-			r.Extra = internal.RemainingKeys(Resource{}, resultMap)
-		}
-	}
-
-	return err
-}
-
 // ResourcePage abstracts the raw results of making a List() request against
 // the Gnocchi API.
 //

--- a/gnocchi/metric/v1/resources/results.go
+++ b/gnocchi/metric/v1/resources/results.go
@@ -81,9 +81,9 @@ type Resource struct {
 	// UserID is the Identity user of the resource.
 	UserID string `json:"user_id"`
 
-	// Extra is a collection of keys and values that can be found in resources
+	// ExtraAttributes is a collection of keys and values that can be found in resources
 	// of different resource types.
-	Extra map[string]interface{} `json:"-"`
+	ExtraAttributes map[string]interface{} `json:"-"`
 }
 
 // UnmarshalJSON helps to unmarshal Resource fields into needed values.
@@ -91,11 +91,11 @@ func (r *Resource) UnmarshalJSON(b []byte) error {
 	type tmp Resource
 	var s struct {
 		tmp
-		Extra         map[string]interface{}          `json:"extra"`
-		RevisionStart gnocchi.JSONRFC3339NanoTimezone `json:"revision_start"`
-		RevisionEnd   gnocchi.JSONRFC3339NanoTimezone `json:"revision_end"`
-		StartedAt     gnocchi.JSONRFC3339NanoTimezone `json:"started_at"`
-		EndedAt       gnocchi.JSONRFC3339NanoTimezone `json:"ended_at"`
+		ExtraAttributes map[string]interface{}          `json:"extra"`
+		RevisionStart   gnocchi.JSONRFC3339NanoTimezone `json:"revision_start"`
+		RevisionEnd     gnocchi.JSONRFC3339NanoTimezone `json:"revision_end"`
+		StartedAt       gnocchi.JSONRFC3339NanoTimezone `json:"started_at"`
+		EndedAt         gnocchi.JSONRFC3339NanoTimezone `json:"ended_at"`
 	}
 	err := json.Unmarshal(b, &s)
 	if err != nil {
@@ -111,8 +111,8 @@ func (r *Resource) UnmarshalJSON(b []byte) error {
 
 	// Collect other resource fields
 	// and bundle them into Extra.
-	if s.Extra != nil {
-		r.Extra = s.Extra
+	if s.ExtraAttributes != nil {
+		r.ExtraAttributes = s.ExtraAttributes
 	} else {
 		var result interface{}
 		err := json.Unmarshal(b, &result)
@@ -124,7 +124,7 @@ func (r *Resource) UnmarshalJSON(b []byte) error {
 			delete(resultMap, "revision_end")
 			delete(resultMap, "started_at")
 			delete(resultMap, "ended_at")
-			r.Extra = internal.RemainingKeys(Resource{}, resultMap)
+			r.ExtraAttributes = internal.RemainingKeys(Resource{}, resultMap)
 		}
 	}
 

--- a/gnocchi/metric/v1/resources/testing/fixtures.go
+++ b/gnocchi/metric/v1/resources/testing/fixtures.go
@@ -132,36 +132,6 @@ const ResourceCreateWithoutMetricsRequest = `
 }
 `
 
-// ResourceCreateLinkMetricsRequest represents a request to create a resource with linked metrics.
-const ResourceCreateLinkMetricsRequest = `
-{
-    "id": "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",
-    "project_id": "4154f088-8333-4e04-94c4-1155c33c0fc9",
-    "user_id": "bd5874d6-6662-4b24-a9f01c128871e4ac",
-    "started_at": "2018-01-02T23:23:34+00:00",
-    "ended_at": "2018-01-04T10:00:12+00:00",
-    "metrics": {
-        "network.incoming.bytes.rate": "01b2953e-de74-448a-a305-c84440697933",
-        "network.outgoing.bytes.rate": "dc9f3198-155b-4b88-a92c-58a3853ce2b2"
-    }
-}
-`
-
-// ResourceCreateWithMetricsRequest represents a request to simultaneously create a resource with metrics.
-const ResourceCreateWithMetricsRequest = `
-{
-    "id": "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",
-    "project_id": "4154f088-8333-4e04-94c4-1155c33c0fc9",
-    "user_id": "bd5874d6-6662-4b24-a9f01c128871e4ac",
-    "ended_at": "2018-01-09T20:00:00+00:00",
-    "metrics": {
-        "disk.write.bytes.rate": {
-            "archive_policy_name": "high"
-        }
-    }
-}
-`
-
 // ResourceCreateWithoutMetricsResult represents a raw server responce to the ResourceCreateNoMetricsRequest.
 const ResourceCreateWithoutMetricsResult = `
 {
@@ -178,6 +148,21 @@ const ResourceCreateWithoutMetricsResult = `
     "started_at": "2018-01-03T11:44:31.155732+00:00",
     "type": "generic",
     "user_id": "bd5874d6-6662-4b24-a9f01c128871e4ac"
+}
+`
+
+// ResourceCreateLinkMetricsRequest represents a request to create a resource with linked metrics.
+const ResourceCreateLinkMetricsRequest = `
+{
+    "id": "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",
+    "project_id": "4154f088-8333-4e04-94c4-1155c33c0fc9",
+    "user_id": "bd5874d6-6662-4b24-a9f01c128871e4ac",
+    "started_at": "2018-01-02T23:23:34+00:00",
+    "ended_at": "2018-01-04T10:00:12+00:00",
+    "metrics": {
+        "network.incoming.bytes.rate": "01b2953e-de74-448a-a305-c84440697933",
+        "network.outgoing.bytes.rate": "dc9f3198-155b-4b88-a92c-58a3853ce2b2"
+    }
 }
 `
 
@@ -200,6 +185,21 @@ const ResourceCreateLinkMetricsResult = `
     "started_at": "2018-01-02T23:23:34+00:00",
     "type": "compute_instance_network",
     "user_id": "bd5874d6-6662-4b24-a9f01c128871e4ac"
+}
+`
+
+// ResourceCreateWithMetricsRequest represents a request to simultaneously create a resource with metrics.
+const ResourceCreateWithMetricsRequest = `
+{
+    "id": "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",
+    "project_id": "4154f088-8333-4e04-94c4-1155c33c0fc9",
+    "user_id": "bd5874d6-6662-4b24-a9f01c128871e4ac",
+    "ended_at": "2018-01-09T20:00:00+00:00",
+    "metrics": {
+        "disk.write.bytes.rate": {
+            "archive_policy_name": "high"
+        }
+    }
 }
 `
 

--- a/gnocchi/metric/v1/resources/testing/fixtures.go
+++ b/gnocchi/metric/v1/resources/testing/fixtures.go
@@ -138,8 +138,8 @@ const ResourceCreateLinkMetricsRequest = `
     "id": "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",
     "project_id": "4154f088-8333-4e04-94c4-1155c33c0fc9",
     "user_id": "bd5874d6-6662-4b24-a9f01c128871e4ac",
-    "started_at": "2018-01-02 23:23:34",
-    "ended_at": "2018-01-04 10:00:12",
+    "started_at": "2018-01-02T23:23:34+00:00",
+    "ended_at": "2018-01-04T10:00:12+00:00",
     "metrics": {
         "network.incoming.bytes.rate": "01b2953e-de74-448a-a305-c84440697933",
         "network.outgoing.bytes.rate": "dc9f3198-155b-4b88-a92c-58a3853ce2b2"
@@ -153,6 +153,7 @@ const ResourceCreateWithMetricsRequest = `
     "id": "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",
     "project_id": "4154f088-8333-4e04-94c4-1155c33c0fc9",
     "user_id": "bd5874d6-6662-4b24-a9f01c128871e4ac",
+    "ended_at": "2018-01-09T20:00:00+00:00",
     "metrics": {
         "disk.write.bytes.rate": {
             "archive_policy_name": "high"
@@ -208,7 +209,7 @@ const ResourceCreateWithMetricsResult = `
     "created_by_project_id": "3d40ca37-7234-4911-8987b9f288f4ae84",
     "created_by_user_id": "fdcfb420-c096-45e6-9e177a0bb1950884",
     "creator": "fdcfb420-c096-45e6-9e177a0bb1950884:3d40ca37-7234-4911-8987b9f288f4ae84",
-    "ended_at": null,
+    "ended_at": "2018-01-09T20:00:00+00:00",
     "id": "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",
     "metrics": {
         "disk.write.bytes.rate": "0a2da84d-4753-43f5-a65f-0f8d44d2766c"

--- a/gnocchi/metric/v1/resources/testing/fixtures.go
+++ b/gnocchi/metric/v1/resources/testing/fixtures.go
@@ -68,7 +68,7 @@ var Resource1 = resources.Resource{
 	EndedAt:            time.Time{},
 	Type:               "compute_instance",
 	UserID:             "bd5874d666624b24a9f01c128871e4ac",
-	Extra: map[string]interface{}{
+	ExtraAttributes: map[string]interface{}{
 		"display_name": "MyInstance00",
 		"flavor_name":  "2CPU4G",
 		"host":         "compute010",
@@ -93,7 +93,7 @@ var Resource2 = resources.Resource{
 	EndedAt:            time.Time{},
 	Type:               "compute_instance_disk",
 	UserID:             "bd5874d666624b24a9f01c128871e4ac",
-	Extra: map[string]interface{}{
+	ExtraAttributes: map[string]interface{}{
 		"disk_device_name": "sdb",
 	},
 }

--- a/gnocchi/metric/v1/resources/testing/fixtures.go
+++ b/gnocchi/metric/v1/resources/testing/fixtures.go
@@ -122,3 +122,103 @@ const ResourceGetResult = `
     "user_id": "bd5874d666624b24a9f01c128871e4ac"
 }
 `
+
+// ResourceCreateWithoutMetricsRequest represents a request to create a resource without metrics.
+const ResourceCreateWithoutMetricsRequest = `
+{
+    "id": "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",
+    "project_id": "4154f088-8333-4e04-94c4-1155c33c0fc9",
+    "user_id": "bd5874d6-6662-4b24-a9f01c128871e4ac"
+}
+`
+
+// ResourceCreateLinkMetricsRequest represents a request to create a resource with linked metrics.
+const ResourceCreateLinkMetricsRequest = `
+{
+    "id": "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",
+    "project_id": "4154f088-8333-4e04-94c4-1155c33c0fc9",
+    "user_id": "bd5874d6-6662-4b24-a9f01c128871e4ac",
+    "started_at": "2018-01-02 23:23:34",
+    "ended_at": "2018-01-04 10:00:12",
+    "metrics": {
+        "network.incoming.bytes.rate": "01b2953e-de74-448a-a305-c84440697933",
+        "network.outgoing.bytes.rate": "dc9f3198-155b-4b88-a92c-58a3853ce2b2"
+    }
+}
+`
+
+// ResourceCreateWithMetricsRequest represents a request to simultaneously create a resource with metrics.
+const ResourceCreateWithMetricsRequest = `
+{
+    "id": "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",
+    "project_id": "4154f088-8333-4e04-94c4-1155c33c0fc9",
+    "user_id": "bd5874d6-6662-4b24-a9f01c128871e4ac",
+    "metrics": {
+        "disk.write.bytes.rate": {
+            "archive_policy_name": "high"
+        }
+    }
+}
+`
+
+// ResourceCreateWithoutMetricsResult represents a raw server responce to the ResourceCreateNoMetricsRequest.
+const ResourceCreateWithoutMetricsResult = `
+{
+    "created_by_project_id": "3d40ca37-7234-4911-8987b9f288f4ae84",
+    "created_by_user_id": "fdcfb420-c096-45e6-9e177a0bb1950884",
+    "creator": "fdcfb420-c096-45e6-9e177a0bb1950884:3d40ca37-7234-4911-8987b9f288f4ae84",
+    "ended_at": null,
+    "id": "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",
+    "metrics": {},
+    "original_resource_id": "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",
+    "project_id": "4154f088-8333-4e04-94c4-1155c33c0fc9",
+    "revision_end": null,
+    "revision_start": "2018-01-03T11:44:31.155773+00:00",
+    "started_at": "2018-01-03T11:44:31.155732+00:00",
+    "type": "generic",
+    "user_id": "bd5874d6-6662-4b24-a9f01c128871e4ac"
+}
+`
+
+// ResourceCreateLinkMetricsResult represents a raw server responce to the ResourceCreateLinkMetricsRequest.
+const ResourceCreateLinkMetricsResult = `
+{
+    "created_by_project_id": "3d40ca37-7234-4911-8987b9f288f4ae84",
+    "created_by_user_id": "fdcfb420-c096-45e6-9e177a0bb1950884",
+    "creator": "fdcfb420-c096-45e6-9e177a0bb1950884:3d40ca37-7234-4911-8987b9f288f4ae84",
+    "ended_at": "2018-01-04T10:00:12+00:00",
+    "id": "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",
+    "metrics": {
+        "network.incoming.bytes.rate": "01b2953e-de74-448a-a305-c84440697933",
+        "network.outgoing.bytes.rate": "dc9f3198-155b-4b88-a92c-58a3853ce2b2"
+    },
+    "original_resource_id": "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",
+    "project_id": "4154f088-8333-4e04-94c4-1155c33c0fc9",
+    "revision_end": null,
+    "revision_start": "2018-01-02T23:23:34.155813+00:00",
+    "started_at": "2018-01-02T23:23:34+00:00",
+    "type": "compute_instance_network",
+    "user_id": "bd5874d6-6662-4b24-a9f01c128871e4ac"
+}
+`
+
+// ResourceCreateWithMetricsResult represents a raw server responce to the ResourceCreateWithMetricsRequest.
+const ResourceCreateWithMetricsResult = `
+{
+    "created_by_project_id": "3d40ca37-7234-4911-8987b9f288f4ae84",
+    "created_by_user_id": "fdcfb420-c096-45e6-9e177a0bb1950884",
+    "creator": "fdcfb420-c096-45e6-9e177a0bb1950884:3d40ca37-7234-4911-8987b9f288f4ae84",
+    "ended_at": null,
+    "id": "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",
+    "metrics": {
+        "disk.write.bytes.rate": "0a2da84d-4753-43f5-a65f-0f8d44d2766c"
+    },
+    "original_resource_id": "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",
+    "project_id": "4154f088-8333-4e04-94c4-1155c33c0fc9",
+    "revision_end": null,
+    "revision_start": "2018-01-02T23:23:34.155813+00:00",
+    "started_at": "2018-01-02T23:23:34.155773+00:00",
+    "type": "compute_instance_disk",
+    "user_id": "bd5874d6-6662-4b24-a9f01c128871e4ac"
+}
+`

--- a/gnocchi/metric/v1/resources/testing/fixtures.go
+++ b/gnocchi/metric/v1/resources/testing/fixtures.go
@@ -187,7 +187,6 @@ const ResourceCreateLinkMetricsResult = `
     "created_by_project_id": "3d40ca37-7234-4911-8987b9f288f4ae84",
     "created_by_user_id": "fdcfb420-c096-45e6-9e177a0bb1950884",
     "creator": "fdcfb420-c096-45e6-9e177a0bb1950884:3d40ca37-7234-4911-8987b9f288f4ae84",
-    "ended_at": "2018-01-04T10:00:12+00:00",
     "id": "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",
     "metrics": {
         "network.incoming.bytes.rate": "01b2953e-de74-448a-a305-c84440697933",
@@ -197,6 +196,7 @@ const ResourceCreateLinkMetricsResult = `
     "project_id": "4154f088-8333-4e04-94c4-1155c33c0fc9",
     "revision_end": null,
     "revision_start": "2018-01-02T23:23:34.155813+00:00",
+    "ended_at": "2018-01-04T10:00:12+00:00",
     "started_at": "2018-01-02T23:23:34+00:00",
     "type": "compute_instance_network",
     "user_id": "bd5874d6-6662-4b24-a9f01c128871e4ac"
@@ -209,7 +209,6 @@ const ResourceCreateWithMetricsResult = `
     "created_by_project_id": "3d40ca37-7234-4911-8987b9f288f4ae84",
     "created_by_user_id": "fdcfb420-c096-45e6-9e177a0bb1950884",
     "creator": "fdcfb420-c096-45e6-9e177a0bb1950884:3d40ca37-7234-4911-8987b9f288f4ae84",
-    "ended_at": "2018-01-09T20:00:00+00:00",
     "id": "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",
     "metrics": {
         "disk.write.bytes.rate": "0a2da84d-4753-43f5-a65f-0f8d44d2766c"
@@ -218,6 +217,7 @@ const ResourceCreateWithMetricsResult = `
     "project_id": "4154f088-8333-4e04-94c4-1155c33c0fc9",
     "revision_end": null,
     "revision_start": "2018-01-02T23:23:34.155813+00:00",
+    "ended_at": "2018-01-09T20:00:00+00:00",
     "started_at": "2018-01-02T23:23:34.155773+00:00",
     "type": "compute_instance_disk",
     "user_id": "bd5874d6-6662-4b24-a9f01c128871e4ac"

--- a/gnocchi/metric/v1/resources/testing/requests_test.go
+++ b/gnocchi/metric/v1/resources/testing/requests_test.go
@@ -148,12 +148,14 @@ func TestCreateLinkMetrics(t *testing.T) {
 		fmt.Fprintf(w, ResourceCreateLinkMetricsResult)
 	})
 
+	startedAt := time.Date(2018, 1, 2, 23, 23, 34, 0, time.UTC)
+	endedAt := time.Date(2018, 1, 4, 10, 00, 12, 0, time.UTC)
 	opts := resources.CreateOpts{
-		ID:        "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",
-		ProjectID: "4154f088-8333-4e04-94c4-1155c33c0fc9",
-		UserID:    "bd5874d6-6662-4b24-a9f01c128871e4ac",
-		StartedAt: "2018-01-02 23:23:34",
-		EndedAt:   "2018-01-04 10:00:12",
+		ID:                 "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",
+		ProjectID:          "4154f088-8333-4e04-94c4-1155c33c0fc9",
+		UserID:             "bd5874d6-6662-4b24-a9f01c128871e4ac",
+		StartedAtTimeStamp: &startedAt,
+		EndedAtTimeStamp:   &endedAt,
 		Metrics: map[string]interface{}{
 			"network.incoming.bytes.rate": "01b2953e-de74-448a-a305-c84440697933",
 			"network.outgoing.bytes.rate": "dc9f3198-155b-4b88-a92c-58a3853ce2b2",
@@ -198,9 +200,10 @@ func TestCreateWithMetrics(t *testing.T) {
 	})
 
 	opts := resources.CreateOpts{
-		ID:        "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",
-		ProjectID: "4154f088-8333-4e04-94c4-1155c33c0fc9",
-		UserID:    "bd5874d6-6662-4b24-a9f01c128871e4ac",
+		ID:            "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",
+		ProjectID:     "4154f088-8333-4e04-94c4-1155c33c0fc9",
+		UserID:        "bd5874d6-6662-4b24-a9f01c128871e4ac",
+		EndedAtString: "2018-01-09T20:00:00+00:00",
 		Metrics: map[string]interface{}{
 			"disk.write.bytes.rate": map[string]string{
 				"archive_policy_name": "high",
@@ -222,7 +225,7 @@ func TestCreateWithMetrics(t *testing.T) {
 	th.AssertEquals(t, s.RevisionStart, time.Date(2018, 1, 2, 23, 23, 34, 155813000, time.UTC))
 	th.AssertEquals(t, s.RevisionEnd, time.Time{})
 	th.AssertEquals(t, s.StartedAt, time.Date(2018, 1, 2, 23, 23, 34, 155773000, time.UTC))
-	th.AssertEquals(t, s.EndedAt, time.Time{})
+	th.AssertEquals(t, s.EndedAt, time.Date(2018, 1, 9, 20, 00, 00, 0, time.UTC))
 	th.AssertEquals(t, s.Type, "compute_instance_disk")
 	th.AssertEquals(t, s.UserID, "bd5874d6-6662-4b24-a9f01c128871e4ac")
 }

--- a/gnocchi/metric/v1/resources/testing/requests_test.go
+++ b/gnocchi/metric/v1/resources/testing/requests_test.go
@@ -113,7 +113,7 @@ func TestCreateWithoutMetrics(t *testing.T) {
 		ProjectID: "4154f088-8333-4e04-94c4-1155c33c0fc9",
 		UserID:    "bd5874d6-6662-4b24-a9f01c128871e4ac",
 	}
-	s, err := resources.Create(fake.ServiceClient(), "", opts).Extract()
+	s, err := resources.Create(fake.ServiceClient(), "generic", opts).Extract()
 	th.AssertNoErr(t, err)
 
 	th.AssertEquals(t, s.CreatedByProjectID, "3d40ca37-7234-4911-8987b9f288f4ae84")

--- a/gnocchi/metric/v1/resources/testing/requests_test.go
+++ b/gnocchi/metric/v1/resources/testing/requests_test.go
@@ -86,7 +86,7 @@ func TestGet(t *testing.T) {
 	th.AssertEquals(t, s.EndedAt, time.Time{})
 	th.AssertEquals(t, s.Type, "compute_instance_network")
 	th.AssertEquals(t, s.UserID, "bd5874d666624b24a9f01c128871e4ac")
-	th.AssertDeepEquals(t, s.Extra, map[string]interface{}{
+	th.AssertDeepEquals(t, s.ExtraAttributes, map[string]interface{}{
 		"iface_name": "eth0",
 	})
 }

--- a/gnocchi/metric/v1/resources/testing/requests_test.go
+++ b/gnocchi/metric/v1/resources/testing/requests_test.go
@@ -151,11 +151,11 @@ func TestCreateLinkMetrics(t *testing.T) {
 	startedAt := time.Date(2018, 1, 2, 23, 23, 34, 0, time.UTC)
 	endedAt := time.Date(2018, 1, 4, 10, 00, 12, 0, time.UTC)
 	opts := resources.CreateOpts{
-		ID:                 "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",
-		ProjectID:          "4154f088-8333-4e04-94c4-1155c33c0fc9",
-		UserID:             "bd5874d6-6662-4b24-a9f01c128871e4ac",
-		StartedAtTimeStamp: &startedAt,
-		EndedAtTimeStamp:   &endedAt,
+		ID:        "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",
+		ProjectID: "4154f088-8333-4e04-94c4-1155c33c0fc9",
+		UserID:    "bd5874d6-6662-4b24-a9f01c128871e4ac",
+		StartedAt: &startedAt,
+		EndedAt:   &endedAt,
 		Metrics: map[string]interface{}{
 			"network.incoming.bytes.rate": "01b2953e-de74-448a-a305-c84440697933",
 			"network.outgoing.bytes.rate": "dc9f3198-155b-4b88-a92c-58a3853ce2b2",
@@ -199,11 +199,12 @@ func TestCreateWithMetrics(t *testing.T) {
 		fmt.Fprintf(w, ResourceCreateWithMetricsResult)
 	})
 
+	endedAt := time.Date(2018, 1, 9, 20, 0, 0, 0, time.UTC)
 	opts := resources.CreateOpts{
-		ID:            "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",
-		ProjectID:     "4154f088-8333-4e04-94c4-1155c33c0fc9",
-		UserID:        "bd5874d6-6662-4b24-a9f01c128871e4ac",
-		EndedAtString: "2018-01-09T20:00:00+00:00",
+		ID:        "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",
+		ProjectID: "4154f088-8333-4e04-94c4-1155c33c0fc9",
+		UserID:    "bd5874d6-6662-4b24-a9f01c128871e4ac",
+		EndedAt:   &endedAt,
 		Metrics: map[string]interface{}{
 			"disk.write.bytes.rate": map[string]string{
 				"archive_policy_name": "high",

--- a/gnocchi/metric/v1/resources/urls.go
+++ b/gnocchi/metric/v1/resources/urls.go
@@ -19,3 +19,7 @@ func listURL(c *gophercloud.ServiceClient, resourceType string) string {
 func getURL(c *gophercloud.ServiceClient, resourceType, resourceID string) string {
 	return resourceURL(c, resourceType, resourceID)
 }
+
+func createURL(c *gophercloud.ServiceClient, resourceType string) string {
+	return rootURL(c, resourceType)
+}


### PR DESCRIPTION
Add Gnocchi resource create request with tests and documentation.

The same command with Gnocchi CLI is done with:
`gnocchi resource create`

For [#698](https://github.com/gophercloud/gophercloud/issues/698)

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/gnocchixyz/gnocchi/blob/stable/4.1/gnocchi/rest/api.py#L1092
https://github.com/gnocchixyz/gnocchi/blob/stable/4.1/gnocchi/indexer/sqlalchemy.py#L745