### PR TITLE
Implement Gnocchi resource update

### DIFF
--- a/acceptance/gnocchi/metric/v1/resources_test.go
+++ b/acceptance/gnocchi/metric/v1/resources_test.go
@@ -22,6 +22,16 @@ func TestResourcesCRUD(t *testing.T) {
 	}
 
 	tools.PrintResource(t, genericResource)
+
+	updateOpts := &resources.UpdateOpts{
+		StartedAt: "2018-01-01T01:01:01",
+	}
+	newGenericResource, err := resources.Update(client, genericResource.Type, genericResource.ID, updateOpts).Extract()
+	if err != nil {
+		t.Fatalf("Unable to update the generic Gnocchi resource: %v", err)
+	}
+
+	tools.PrintResource(t, newGenericResource)
 }
 
 func TestResourcesList(t *testing.T) {

--- a/acceptance/gnocchi/metric/v1/resources_test.go
+++ b/acceptance/gnocchi/metric/v1/resources_test.go
@@ -4,6 +4,7 @@ package v1
 
 import (
 	"testing"
+	"time"
 
 	"github.com/gophercloud/gophercloud/acceptance/tools"
 	"github.com/gophercloud/utils/acceptance/clients"
@@ -23,9 +24,11 @@ func TestResourcesCRUD(t *testing.T) {
 
 	tools.PrintResource(t, genericResource)
 
+	newStartedAt := time.Date(2018, 1, 1, 1, 1, 0, 0, time.UTC)
 	updateOpts := &resources.UpdateOpts{
-		StartedAt: "2018-01-01T01:01:01",
+		StartedAt: &newStartedAt,
 	}
+	t.Logf("Attempting to update a resource %s", genericResource.ID)
 	newGenericResource, err := resources.Update(client, genericResource.Type, genericResource.ID, updateOpts).Extract()
 	if err != nil {
 		t.Fatalf("Unable to update the generic Gnocchi resource: %v", err)

--- a/acceptance/gnocchi/metric/v1/resources_test.go
+++ b/acceptance/gnocchi/metric/v1/resources_test.go
@@ -25,8 +25,10 @@ func TestResourcesCRUD(t *testing.T) {
 	tools.PrintResource(t, genericResource)
 
 	newStartedAt := time.Date(2018, 1, 1, 1, 1, 0, 0, time.UTC)
+	newMetrics := map[string]interface{}{}
 	updateOpts := &resources.UpdateOpts{
 		StartedAt: &newStartedAt,
+		Metrics:   &newMetrics,
 	}
 	t.Logf("Attempting to update a resource %s", genericResource.ID)
 	newGenericResource, err := resources.Update(client, genericResource.Type, genericResource.ID, updateOpts).Extract()

--- a/gnocchi/metric/v1/resources/doc.go
+++ b/gnocchi/metric/v1/resources/doc.go
@@ -31,10 +31,11 @@ Example of Getting a resource
 		panic(err)
 	}
 
-Example of Creating a resource without a metric
+Example of Creating a resource without a metric with a string timestamp for the starting time
 
 	createOpts := resources.CreateOpts{
 		ID: "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",
+		StartedAtString: "2018-01-09T22:15:00+00:00",
 	}
 	resourceType = "generic"
 	resource, err := resources.Create(gnocchiClient, resourceType, createOpts).Extract()

--- a/gnocchi/metric/v1/resources/doc.go
+++ b/gnocchi/metric/v1/resources/doc.go
@@ -31,11 +31,10 @@ Example of Getting a resource
 		panic(err)
 	}
 
-Example of Creating a resource without a metric with a string timestamp for the starting time
+Example of Creating a resource without a metric
 
 	createOpts := resources.CreateOpts{
 		ID: "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",
-		StartedAtString: "2018-01-09T22:15:00+00:00",
 	}
 	resourceType = "generic"
 	resource, err := resources.Create(gnocchiClient, resourceType, createOpts).Extract()

--- a/gnocchi/metric/v1/resources/doc.go
+++ b/gnocchi/metric/v1/resources/doc.go
@@ -92,11 +92,13 @@ Example of Updating a resource
 
 Example of Updating a resource and associating an existing metric to it
 
-	updateOpts := resources.UpdateOpts{
-		EndedAt: "2018-01-16 12:00:00",
-		Metrics: map[string]interface{}{
+	endedAt := time.Date(2018, 1, 16, 12, 0, 0, 0, time.UTC)
+	metrics := map[string]interface{}{
 			"disk.write.bytes.rate": "0a2da84d-4753-43f5-a65f-0f8d44d2766c",
-		},
+	}
+	updateOpts := resources.UpdateOpts{
+		EndedAt: &endedAt,
+		Metrics: &metrics,
 	}
 	resourceType = "compute_instance_disk"
 	resourceID = "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55"
@@ -107,12 +109,13 @@ Example of Updating a resource and associating an existing metric to it
 
 Example of Updating a resource and creating an associated metric at the same time
 
-	updateOpts := resources.UpdateOpts{
-		Metrics: map[string]interface{}{
-			"cpu.delta": map[string]string{
-				"archive_policy_name": "medium",
-			},
+	metrics := map[string]interface{}{
+		"cpu.delta": map[string]string{
+			"archive_policy_name": "medium",
 		},
+	}
+	updateOpts := resources.UpdateOpts{
+		Metrics: &metrics,
 	}
 	resourceType = "compute_instance"
 	resourceID = "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55"

--- a/gnocchi/metric/v1/resources/doc.go
+++ b/gnocchi/metric/v1/resources/doc.go
@@ -77,5 +77,48 @@ Example of Creating a resource and a metric a the same time
 	if err != nil {
 		panic(err)
 	}
+
+Example of Updating a resource
+
+	updateOpts := resources.UpdateOpts{
+		ProjectID: "4154f08883334e0494c41155c33c0fc9",
+	}
+	resourceType = "generic"
+	resourceID = "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55"
+	resource, err := resources.Update(gnocchiClient, resourceType, resourceID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example of Updating a resource and associating an existing metric to it
+
+	updateOpts := resources.UpdateOpts{
+		EndedAt: "2018-01-16 12:00:00",
+		Metrics: map[string]interface{}{
+			"disk.write.bytes.rate": "0a2da84d-4753-43f5-a65f-0f8d44d2766c",
+		},
+	}
+	resourceType = "compute_instance_disk"
+	resourceID = "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55"
+	resource, err := resources.Update(gnocchiClient, resourceType, resourceID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example of Updating a resource and creating an associated metric at the same time
+
+	updateOpts := resources.UpdateOpts{
+		Metrics: map[string]interface{}{
+			"cpu.delta": map[string]string{
+				"archive_policy_name": "medium",
+			},
+		},
+	}
+	resourceType = "compute_instance"
+	resourceID = "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55"
+	resource, err := resources.Update(gnocchiClient, resourceType, resourceID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
 */
 package resources

--- a/gnocchi/metric/v1/resources/requests.go
+++ b/gnocchi/metric/v1/resources/requests.go
@@ -157,6 +157,10 @@ type UpdateOpts struct {
 
 	// EndedAt is a timestamp of when the resource has ended.
 	EndedAt *time.Time `json:"-"`
+
+	// ExtraAttributes is a collection of keys and values that can be found in resources
+	// of different resource types.
+	ExtraAttributes map[string]interface{} `json:"-"`
 }
 
 // ToResourceUpdateMap builds a request body from UpdateOpts.
@@ -172,6 +176,12 @@ func (opts UpdateOpts) ToResourceUpdateMap() (map[string]interface{}, error) {
 
 	if opts.EndedAt != nil {
 		b["ended_at"] = opts.EndedAt.Format(gnocchi.RFC3339NanoTimezone)
+	}
+
+	if opts.ExtraAttributes != nil {
+		for key, value := range opts.ExtraAttributes {
+			b[key] = value
+		}
 	}
 
 	return b, nil

--- a/gnocchi/metric/v1/resources/requests.go
+++ b/gnocchi/metric/v1/resources/requests.go
@@ -72,7 +72,7 @@ type CreateOptsBuilder interface {
 // CreateOpts specifies parameters of a new Gnocchi resource.
 type CreateOpts struct {
 	// ID uniquely identifies the Gnocchi resource.
-	ID string `json:"id,omitempty"`
+	ID string `json:"id"`
 
 	// Metrics field can be used to link existing metrics in the resource
 	// or to create metrics with the resource at the same time to save
@@ -98,16 +98,6 @@ type CreateOpts struct {
 
 // ToResourceCreateMap constructs a request body from CreateOpts.
 func (opts CreateOpts) ToResourceCreateMap() (map[string]interface{}, error) {
-	if opts.StartedAtTimeStamp != nil {
-		opts.StartedAtString = opts.StartedAtTimeStamp.Format(gnocchi.RFC3339NanoTimezone)
-		opts.StartedAtTimeStamp = nil
-	}
-
-	if opts.EndedAtTimeStamp != nil {
-		opts.EndedAtString = opts.EndedAtTimeStamp.Format(gnocchi.RFC3339NanoTimezone)
-		opts.EndedAtTimeStamp = nil
-	}
-
 	b, err := gophercloud.BuildRequestBody(opts, "")
 	if err != nil {
 		return nil, err

--- a/gnocchi/metric/v1/resources/requests.go
+++ b/gnocchi/metric/v1/resources/requests.go
@@ -98,6 +98,16 @@ type CreateOpts struct {
 
 // ToResourceCreateMap constructs a request body from CreateOpts.
 func (opts CreateOpts) ToResourceCreateMap() (map[string]interface{}, error) {
+	if opts.StartedAtTimeStamp != nil {
+		opts.StartedAtString = opts.StartedAtTimeStamp.Format(gnocchi.RFC3339NanoTimezone)
+		opts.StartedAtTimeStamp = nil
+	}
+
+	if opts.EndedAtTimeStamp != nil {
+		opts.EndedAtString = opts.EndedAtTimeStamp.Format(gnocchi.RFC3339NanoTimezone)
+		opts.EndedAtTimeStamp = nil
+	}
+
 	b, err := gophercloud.BuildRequestBody(opts, "")
 	if err != nil {
 		return nil, err

--- a/gnocchi/metric/v1/resources/requests.go
+++ b/gnocchi/metric/v1/resources/requests.go
@@ -153,15 +153,28 @@ type UpdateOpts struct {
 	UserID string `json:"user_id,omitempty"`
 
 	// StartedAt is a resource creation timestamp.
-	StartedAt string `json:"started_at,omitempty"`
+	StartedAt *time.Time `json:"-"`
 
 	// EndedAt is a timestamp of when the resource has ended.
-	EndedAt string `json:"ended_at,omitempty"`
+	EndedAt *time.Time `json:"-"`
 }
 
 // ToResourceUpdateMap builds a request body from UpdateOpts.
 func (opts UpdateOpts) ToResourceUpdateMap() (map[string]interface{}, error) {
-	return gophercloud.BuildRequestBody(opts, "")
+	b, err := gophercloud.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	if opts.StartedAt != nil {
+		b["started_at"] = opts.StartedAt.Format(gnocchi.RFC3339NanoTimezone)
+	}
+
+	if opts.EndedAt != nil {
+		b["ended_at"] = opts.EndedAt.Format(gnocchi.RFC3339NanoTimezone)
+	}
+
+	return b, nil
 }
 
 // Update accepts a UpdateOpts struct and updates an existing Gnocchi resource using the

--- a/gnocchi/metric/v1/resources/requests.go
+++ b/gnocchi/metric/v1/resources/requests.go
@@ -72,7 +72,7 @@ type CreateOptsBuilder interface {
 // CreateOpts specifies parameters of a new Gnocchi resource.
 type CreateOpts struct {
 	// ID uniquely identifies the Gnocchi resource.
-	ID string `json:"id"`
+	ID string `json:"id" required:"true"`
 
 	// Metrics field can be used to link existing metrics in the resource
 	// or to create metrics with the resource at the same time to save

--- a/gnocchi/metric/v1/resources/requests.go
+++ b/gnocchi/metric/v1/resources/requests.go
@@ -144,7 +144,7 @@ type UpdateOpts struct {
 	// Metrics field can be used to link existing metrics in the resource
 	// or to create metrics and update the resource at the same time to save
 	// some requests.
-	Metrics map[string]interface{} `json:"metrics,omitempty"`
+	Metrics *map[string]interface{} `json:"metrics,omitempty"`
 
 	// ProjectID is the Identity project of the resource.
 	ProjectID string `json:"project_id,omitempty"`

--- a/gnocchi/metric/v1/resources/requests.go
+++ b/gnocchi/metric/v1/resources/requests.go
@@ -72,7 +72,7 @@ type CreateOptsBuilder interface {
 // CreateOpts specifies parameters of a new Gnocchi resource.
 type CreateOpts struct {
 	// ID uniquely identifies the Gnocchi resource.
-	ID string `json:"id"`
+	ID string `json:"id,omitempty"`
 
 	// Metrics field can be used to link existing metrics in the resource
 	// or to create metrics with the resource at the same time to save

--- a/gnocchi/metric/v1/resources/requests.go
+++ b/gnocchi/metric/v1/resources/requests.go
@@ -132,3 +132,48 @@ func Create(client *gophercloud.ServiceClient, resourceType string, opts CreateO
 	})
 	return
 }
+
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
+type UpdateOptsBuilder interface {
+	ToResourceUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts represents options used to update a network.
+type UpdateOpts struct {
+	// Metrics field can be used to link existing metrics in the resource
+	// or to create metrics and update the resource at the same time to save
+	// some requests.
+	Metrics map[string]interface{} `json:"metrics,omitempty"`
+
+	// ProjectID is the Identity project of the resource.
+	ProjectID string `json:"project_id,omitempty"`
+
+	// UserID is the Identity user of the resource.
+	UserID string `json:"user_id,omitempty"`
+
+	// StartedAt is a resource creation timestamp.
+	StartedAt string `json:"started_at,omitempty"`
+
+	// EndedAt is a timestamp of when the resource has ended.
+	EndedAt string `json:"ended_at,omitempty"`
+}
+
+// ToResourceUpdateMap builds a request body from UpdateOpts.
+func (opts UpdateOpts) ToResourceUpdateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "")
+}
+
+// Update accepts a UpdateOpts struct and updates an existing Gnocchi resource using the
+// values provided.
+func Update(c *gophercloud.ServiceClient, resourceType, resourceID string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToResourceUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Patch(updateURL(c, resourceType, resourceID), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}

--- a/gnocchi/metric/v1/resources/results.go
+++ b/gnocchi/metric/v1/resources/results.go
@@ -75,6 +75,9 @@ type Resource struct {
 	// EndedAt is a timestamp of when the resource has ended.
 	EndedAt time.Time `json:"-"`
 
+	// EndedAt is a timestamp of when the resource has ended.
+	EndedAt string `json:"ended_at"`
+
 	// Type is a type of the resource.
 	Type string `json:"type"`
 

--- a/gnocchi/metric/v1/resources/results.go
+++ b/gnocchi/metric/v1/resources/results.go
@@ -75,9 +75,6 @@ type Resource struct {
 	// EndedAt is a timestamp of when the resource has ended.
 	EndedAt time.Time `json:"-"`
 
-	// EndedAt is a timestamp of when the resource has ended.
-	EndedAt time.Time `json:"-"`
-
 	// Type is a type of the resource.
 	Type string `json:"type"`
 
@@ -139,6 +136,7 @@ func (r *Resource) UnmarshalJSON(b []byte) error {
 	type tmp Resource
 	var s struct {
 		tmp
+		Extra         map[string]interface{}          `json:"extra"`
 		RevisionStart gnocchi.JSONRFC3339NanoTimezone `json:"revision_start"`
 		RevisionEnd   gnocchi.JSONRFC3339NanoTimezone `json:"revision_end"`
 		StartedAt     gnocchi.JSONRFC3339NanoTimezone `json:"started_at"`
@@ -150,10 +148,30 @@ func (r *Resource) UnmarshalJSON(b []byte) error {
 	}
 	*r = Resource(s.tmp)
 
+	// Collect Gnocchi timestamps.
 	r.RevisionStart = time.Time(s.RevisionStart)
 	r.RevisionEnd = time.Time(s.RevisionEnd)
 	r.StartedAt = time.Time(s.StartedAt)
 	r.EndedAt = time.Time(s.EndedAt)
+
+	// Collect other resource fields
+	// and bundle them into Extra.
+	if s.Extra != nil {
+		r.Extra = s.Extra
+	} else {
+		var result interface{}
+		err := json.Unmarshal(b, &result)
+		if err != nil {
+			return err
+		}
+		if resultMap, ok := result.(map[string]interface{}); ok {
+			delete(resultMap, "revision_start")
+			delete(resultMap, "revision_end")
+			delete(resultMap, "started_at")
+			delete(resultMap, "ended_at")
+			r.Extra = internal.RemainingKeys(Resource{}, resultMap)
+		}
+	}
 
 	return err
 }

--- a/gnocchi/metric/v1/resources/results.go
+++ b/gnocchi/metric/v1/resources/results.go
@@ -75,9 +75,6 @@ type Resource struct {
 	// EndedAt is a timestamp of when the resource has ended.
 	EndedAt time.Time `json:"-"`
 
-	// EndedAt is a timestamp of when the resource has ended.
-	EndedAt string `json:"ended_at"`
-
 	// Type is a type of the resource.
 	Type string `json:"type"`
 

--- a/gnocchi/metric/v1/resources/results.go
+++ b/gnocchi/metric/v1/resources/results.go
@@ -131,51 +131,6 @@ func (r *Resource) UnmarshalJSON(b []byte) error {
 	return err
 }
 
-// UnmarshalJSON helps to unmarshal Resource fields into needed values.
-func (r *Resource) UnmarshalJSON(b []byte) error {
-	type tmp Resource
-	var s struct {
-		tmp
-		Extra         map[string]interface{}          `json:"extra"`
-		RevisionStart gnocchi.JSONRFC3339NanoTimezone `json:"revision_start"`
-		RevisionEnd   gnocchi.JSONRFC3339NanoTimezone `json:"revision_end"`
-		StartedAt     gnocchi.JSONRFC3339NanoTimezone `json:"started_at"`
-		EndedAt       gnocchi.JSONRFC3339NanoTimezone `json:"ended_at"`
-	}
-	err := json.Unmarshal(b, &s)
-	if err != nil {
-		return err
-	}
-	*r = Resource(s.tmp)
-
-	// Collect Gnocchi timestamps.
-	r.RevisionStart = time.Time(s.RevisionStart)
-	r.RevisionEnd = time.Time(s.RevisionEnd)
-	r.StartedAt = time.Time(s.StartedAt)
-	r.EndedAt = time.Time(s.EndedAt)
-
-	// Collect other resource fields
-	// and bundle them into Extra.
-	if s.Extra != nil {
-		r.Extra = s.Extra
-	} else {
-		var result interface{}
-		err := json.Unmarshal(b, &result)
-		if err != nil {
-			return err
-		}
-		if resultMap, ok := result.(map[string]interface{}); ok {
-			delete(resultMap, "revision_start")
-			delete(resultMap, "revision_end")
-			delete(resultMap, "started_at")
-			delete(resultMap, "ended_at")
-			r.Extra = internal.RemainingKeys(Resource{}, resultMap)
-		}
-	}
-
-	return err
-}
-
 // ResourcePage abstracts the raw results of making a List() request against
 // the Gnocchi API.
 //

--- a/gnocchi/metric/v1/resources/results.go
+++ b/gnocchi/metric/v1/resources/results.go
@@ -14,12 +14,6 @@ type commonResult struct {
 	gophercloud.Result
 }
 
-// UpdateResult represents the result of an update operation. Call its Extract
-// method to interpret it as a Gnocchi resource.
-type UpdateResult struct {
-	commonResult
-}
-
 // Extract is a function that accepts a result and extracts a Gnocchi resource.
 func (r commonResult) Extract() (*Resource, error) {
 	var s *Resource
@@ -36,6 +30,12 @@ type GetResult struct {
 // CreateResult represents the result of a create operation. Call its Extract
 // method to interpret it as a Gnocchi resource.
 type CreateResult struct {
+	commonResult
+}
+
+// UpdateResult represents the result of an update operation. Call its Extract
+// method to interpret it as a Gnocchi resource.
+type UpdateResult struct {
 	commonResult
 }
 

--- a/gnocchi/metric/v1/resources/results.go
+++ b/gnocchi/metric/v1/resources/results.go
@@ -14,6 +14,12 @@ type commonResult struct {
 	gophercloud.Result
 }
 
+// UpdateResult represents the result of an update operation. Call its Extract
+// method to interpret it as a Gnocchi resource.
+type UpdateResult struct {
+	commonResult
+}
+
 // Extract is a function that accepts a result and extracts a Gnocchi resource.
 func (r commonResult) Extract() (*Resource, error) {
 	var s *Resource

--- a/gnocchi/metric/v1/resources/results.go
+++ b/gnocchi/metric/v1/resources/results.go
@@ -76,7 +76,7 @@ type Resource struct {
 	EndedAt time.Time `json:"-"`
 
 	// EndedAt is a timestamp of when the resource has ended.
-	EndedAt string `json:"ended_at"`
+	EndedAt time.Time `json:"-"`
 
 	// Type is a type of the resource.
 	Type string `json:"type"`
@@ -130,6 +130,30 @@ func (r *Resource) UnmarshalJSON(b []byte) error {
 			r.ExtraAttributes = internal.RemainingKeys(Resource{}, resultMap)
 		}
 	}
+
+	return err
+}
+
+// UnmarshalJSON helps to unmarshal Resource fields into needed values.
+func (r *Resource) UnmarshalJSON(b []byte) error {
+	type tmp Resource
+	var s struct {
+		tmp
+		RevisionStart gnocchi.JSONRFC3339NanoTimezone `json:"revision_start"`
+		RevisionEnd   gnocchi.JSONRFC3339NanoTimezone `json:"revision_end"`
+		StartedAt     gnocchi.JSONRFC3339NanoTimezone `json:"started_at"`
+		EndedAt       gnocchi.JSONRFC3339NanoTimezone `json:"ended_at"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*r = Resource(s.tmp)
+
+	r.RevisionStart = time.Time(s.RevisionStart)
+	r.RevisionEnd = time.Time(s.RevisionEnd)
+	r.StartedAt = time.Time(s.StartedAt)
+	r.EndedAt = time.Time(s.EndedAt)
 
 	return err
 }

--- a/gnocchi/metric/v1/resources/testing/fixtures.go
+++ b/gnocchi/metric/v1/resources/testing/fixtures.go
@@ -227,7 +227,7 @@ const ResourceCreateWithMetricsResult = `
 // ResourceUpdateLinkMetricsRequest represents a request to update a resource and link some existing metrics.
 const ResourceUpdateLinkMetricsRequest = `
 {
-    "ended_at":"2018-01-14T13:00:00",
+    "ended_at":"2018-01-14T13:00:00+00:00",
     "metrics": {
         "network.incoming.bytes.rate": "01b2953e-de74-448a-a305-c84440697933"
     }
@@ -258,7 +258,7 @@ const ResourceUpdateLinkMetricsResponse = `
 // ResourceUpdateCreateMetricsRequest represents a request to update a resource and link some existing metrics.
 const ResourceUpdateCreateMetricsRequest = `
 {
-    "started_at":"2018-01-12T11:00:00",
+    "started_at":"2018-01-12T11:00:00+00:00",
     "metrics": {
         "disk.read.bytes.rate": {
             "archive_policy_name": "low"

--- a/gnocchi/metric/v1/resources/testing/fixtures.go
+++ b/gnocchi/metric/v1/resources/testing/fixtures.go
@@ -223,3 +223,67 @@ const ResourceCreateWithMetricsResult = `
     "user_id": "bd5874d6-6662-4b24-a9f01c128871e4ac"
 }
 `
+
+// ResourceUpdateLinkMetricsRequest represents a request to update a resource and link some existing metrics.
+const ResourceUpdateLinkMetricsRequest = `
+{
+    "ended_at":"2018-01-14T13:00:00",
+    "metrics": {
+        "network.incoming.bytes.rate": "01b2953e-de74-448a-a305-c84440697933"
+    }
+}
+`
+
+// ResourceUpdateCreateMetricsRequest represents a request to update a resource and link some existing metrics.
+const ResourceUpdateCreateMetricsRequest = `
+{
+    "started_at":"2018-01-12T11:00:00",
+    "metrics": {
+        "disk.read.bytes.rate": {
+            "archive_policy_name": "low"
+        }
+    }
+}
+`
+
+// ResourceUpdateLinkMetricsResponse represents a raw server responce to the ResourceUpdateLinkMetricsRequest.
+const ResourceUpdateLinkMetricsResponse = `
+{
+    "created_by_project_id": "3d40ca37-7234-4911-8987b9f288f4ae84",
+    "created_by_user_id": "fdcfb420-c096-45e6-9e177a0bb1950884",
+    "creator": "fdcfb420-c096-45e6-9e177a0bb1950884:3d40ca37-7234-4911-8987b9f288f4ae84",
+    "ended_at": "2018-01-14T13:00:00+00:00",
+    "id": "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",
+    "project_id": "4154f088-8333-4e04-94c4-1155c33c0fc9",
+    "original_resource_id": "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",
+    "revision_end": null,
+    "metrics": {
+        "network.incoming.bytes.rate": "01b2953e-de74-448a-a305-c84440697933"
+    },
+    "revision_start": "2018-01-12T13:44:34.742031+00:00",
+    "started_at": "2018-01-12T13:44:34.742011+00:00",
+    "type": "compute_instance_network",
+    "user_id": "bd5874d6-6662-4b24-a9f01c128871e4ac"
+}
+`
+
+// ResourceUpdateCreateMetricsResponse represents a raw server responce to the ResourceUpdateLinkMetricsRequest.
+const ResourceUpdateCreateMetricsResponse = `
+{
+    "created_by_project_id": "3d40ca37-7234-4911-8987b9f288f4ae84",
+    "created_by_user_id": "fdcfb420-c096-45e6-9e177a0bb1950884",
+    "creator": "fdcfb420-c096-45e6-9e177a0bb1950884:3d40ca37-7234-4911-8987b9f288f4ae84",
+    "ended_at": null,
+    "id": "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",
+    "project_id": "4154f088-8333-4e04-94c4-1155c33c0fc9",
+    "original_resource_id": "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",
+    "revision_end": null,
+    "metrics": {
+        "disk.read.bytes.rate": "ed1bb76f-6ccc-4ad2-994c-dbb19ddccbae"
+    },
+    "revision_start": "2018-01-12T12:00:34.742031+00:00",
+    "started_at": "2018-01-12T11:00:00+00:00",
+    "type": "compute_instance_disk",
+    "user_id": "bd5874d6-6662-4b24-a9f01c128871e4ac"
+}
+`

--- a/gnocchi/metric/v1/resources/testing/fixtures.go
+++ b/gnocchi/metric/v1/resources/testing/fixtures.go
@@ -234,18 +234,6 @@ const ResourceUpdateLinkMetricsRequest = `
 }
 `
 
-// ResourceUpdateCreateMetricsRequest represents a request to update a resource and link some existing metrics.
-const ResourceUpdateCreateMetricsRequest = `
-{
-    "started_at":"2018-01-12T11:00:00",
-    "metrics": {
-        "disk.read.bytes.rate": {
-            "archive_policy_name": "low"
-        }
-    }
-}
-`
-
 // ResourceUpdateLinkMetricsResponse represents a raw server responce to the ResourceUpdateLinkMetricsRequest.
 const ResourceUpdateLinkMetricsResponse = `
 {
@@ -264,6 +252,18 @@ const ResourceUpdateLinkMetricsResponse = `
     "started_at": "2018-01-12T13:44:34.742011+00:00",
     "type": "compute_instance_network",
     "user_id": "bd5874d6-6662-4b24-a9f01c128871e4ac"
+}
+`
+
+// ResourceUpdateCreateMetricsRequest represents a request to update a resource and link some existing metrics.
+const ResourceUpdateCreateMetricsRequest = `
+{
+    "started_at":"2018-01-12T11:00:00",
+    "metrics": {
+        "disk.read.bytes.rate": {
+            "archive_policy_name": "low"
+        }
+    }
 }
 `
 

--- a/gnocchi/metric/v1/resources/testing/requests_test.go
+++ b/gnocchi/metric/v1/resources/testing/requests_test.go
@@ -248,8 +248,9 @@ func TestUpdateLinkMetrics(t *testing.T) {
 		fmt.Fprintf(w, ResourceUpdateLinkMetricsResponse)
 	})
 
+	endedAt := time.Date(2018, 1, 14, 13, 0, 0, 0, time.UTC)
 	updateOpts := resources.UpdateOpts{
-		EndedAt: "2018-01-14T13:00:00",
+		EndedAt: &endedAt,
 		Metrics: map[string]interface{}{
 			"network.incoming.bytes.rate": "01b2953e-de74-448a-a305-c84440697933",
 		},
@@ -291,8 +292,9 @@ func TestUpdateCreateMetrics(t *testing.T) {
 		fmt.Fprintf(w, ResourceUpdateCreateMetricsResponse)
 	})
 
+	startedAt := time.Date(2018, 1, 12, 11, 0, 0, 0, time.UTC)
 	updateOpts := resources.UpdateOpts{
-		StartedAt: "2018-01-12T11:00:00",
+		StartedAt: &startedAt,
 		Metrics: map[string]interface{}{
 			"disk.read.bytes.rate": map[string]string{
 				"archive_policy_name": "low",

--- a/gnocchi/metric/v1/resources/testing/requests_test.go
+++ b/gnocchi/metric/v1/resources/testing/requests_test.go
@@ -249,11 +249,12 @@ func TestUpdateLinkMetrics(t *testing.T) {
 	})
 
 	endedAt := time.Date(2018, 1, 14, 13, 0, 0, 0, time.UTC)
+	metrics := map[string]interface{}{
+		"network.incoming.bytes.rate": "01b2953e-de74-448a-a305-c84440697933",
+	}
 	updateOpts := resources.UpdateOpts{
 		EndedAt: &endedAt,
-		Metrics: map[string]interface{}{
-			"network.incoming.bytes.rate": "01b2953e-de74-448a-a305-c84440697933",
-		},
+		Metrics: &metrics,
 	}
 	s, err := resources.Update(fake.ServiceClient(), "compute_instance_network", "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55", updateOpts).Extract()
 	th.AssertNoErr(t, err)
@@ -293,13 +294,14 @@ func TestUpdateCreateMetrics(t *testing.T) {
 	})
 
 	startedAt := time.Date(2018, 1, 12, 11, 0, 0, 0, time.UTC)
+	metrics := map[string]interface{}{
+		"disk.read.bytes.rate": map[string]string{
+			"archive_policy_name": "low",
+		},
+	}
 	updateOpts := resources.UpdateOpts{
 		StartedAt: &startedAt,
-		Metrics: map[string]interface{}{
-			"disk.read.bytes.rate": map[string]string{
-				"archive_policy_name": "low",
-			},
-		},
+		Metrics:   &metrics,
 	}
 	s, err := resources.Update(fake.ServiceClient(), "compute_instance_network", "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55", updateOpts).Extract()
 	th.AssertNoErr(t, err)

--- a/gnocchi/metric/v1/resources/testing/requests_test.go
+++ b/gnocchi/metric/v1/resources/testing/requests_test.go
@@ -230,3 +230,91 @@ func TestCreateWithMetrics(t *testing.T) {
 	th.AssertEquals(t, s.Type, "compute_instance_disk")
 	th.AssertEquals(t, s.UserID, "bd5874d6-6662-4b24-a9f01c128871e4ac")
 }
+
+func TestUpdateLinkMetrics(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v1/resource/compute_instance_network/23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PATCH")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, ResourceUpdateLinkMetricsRequest)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, ResourceUpdateLinkMetricsResponse)
+	})
+
+	updateOpts := resources.UpdateOpts{
+		EndedAt: "2018-01-14T13:00:00",
+		Metrics: map[string]interface{}{
+			"network.incoming.bytes.rate": "01b2953e-de74-448a-a305-c84440697933",
+		},
+	}
+	s, err := resources.Update(fake.ServiceClient(), "compute_instance_network", "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55", updateOpts).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, s.CreatedByProjectID, "3d40ca37-7234-4911-8987b9f288f4ae84")
+	th.AssertEquals(t, s.CreatedByUserID, "fdcfb420-c096-45e6-9e177a0bb1950884")
+	th.AssertEquals(t, s.Creator, "fdcfb420-c096-45e6-9e177a0bb1950884:3d40ca37-7234-4911-8987b9f288f4ae84")
+	th.AssertEquals(t, s.ID, "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55")
+	th.AssertDeepEquals(t, s.Metrics, map[string]string{
+		"network.incoming.bytes.rate": "01b2953e-de74-448a-a305-c84440697933",
+	})
+	th.AssertEquals(t, s.OriginalResourceID, "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55")
+	th.AssertEquals(t, s.ProjectID, "4154f088-8333-4e04-94c4-1155c33c0fc9")
+	th.AssertEquals(t, s.RevisionStart, time.Date(2018, 1, 12, 13, 44, 34, 742031000, time.UTC))
+	th.AssertEquals(t, s.RevisionEnd, time.Time{})
+	th.AssertEquals(t, s.StartedAt, time.Date(2018, 1, 12, 13, 44, 34, 742011000, time.UTC))
+	th.AssertEquals(t, s.EndedAt, time.Date(2018, 1, 14, 13, 0, 0, 0, time.UTC))
+	th.AssertEquals(t, s.Type, "compute_instance_network")
+	th.AssertEquals(t, s.UserID, "bd5874d6-6662-4b24-a9f01c128871e4ac")
+}
+
+func TestUpdateCreateMetrics(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v1/resource/compute_instance_network/23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PATCH")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, ResourceUpdateCreateMetricsRequest)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, ResourceUpdateCreateMetricsResponse)
+	})
+
+	updateOpts := resources.UpdateOpts{
+		StartedAt: "2018-01-12T11:00:00",
+		Metrics: map[string]interface{}{
+			"disk.read.bytes.rate": map[string]string{
+				"archive_policy_name": "low",
+			},
+		},
+	}
+	s, err := resources.Update(fake.ServiceClient(), "compute_instance_network", "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55", updateOpts).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, s.CreatedByProjectID, "3d40ca37-7234-4911-8987b9f288f4ae84")
+	th.AssertEquals(t, s.CreatedByUserID, "fdcfb420-c096-45e6-9e177a0bb1950884")
+	th.AssertEquals(t, s.Creator, "fdcfb420-c096-45e6-9e177a0bb1950884:3d40ca37-7234-4911-8987b9f288f4ae84")
+	th.AssertEquals(t, s.ID, "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55")
+	th.AssertDeepEquals(t, s.Metrics, map[string]string{
+		"disk.read.bytes.rate": "ed1bb76f-6ccc-4ad2-994c-dbb19ddccbae",
+	})
+	th.AssertEquals(t, s.OriginalResourceID, "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55")
+	th.AssertEquals(t, s.ProjectID, "4154f088-8333-4e04-94c4-1155c33c0fc9")
+	th.AssertEquals(t, s.RevisionStart, time.Date(2018, 1, 12, 12, 00, 34, 742031000, time.UTC))
+	th.AssertEquals(t, s.RevisionEnd, time.Time{})
+	th.AssertEquals(t, s.StartedAt, time.Date(2018, 1, 12, 11, 00, 00, 0, time.UTC))
+	th.AssertEquals(t, s.EndedAt, time.Time{})
+	th.AssertEquals(t, s.Type, "compute_instance_disk")
+	th.AssertEquals(t, s.UserID, "bd5874d6-6662-4b24-a9f01c128871e4ac")
+}

--- a/gnocchi/metric/v1/resources/urls.go
+++ b/gnocchi/metric/v1/resources/urls.go
@@ -23,3 +23,7 @@ func getURL(c *gophercloud.ServiceClient, resourceType, resourceID string) strin
 func createURL(c *gophercloud.ServiceClient, resourceType string) string {
 	return rootURL(c, resourceType)
 }
+
+func updateURL(c *gophercloud.ServiceClient, resourceType, resourceID string) string {
+	return resourceURL(c, resourceType, resourceID)
+}


### PR DESCRIPTION
Add Gnocchi resource create request with tests and documentation.

The same command with Gnocchi CLI is done with:
`gnocchi resource update`

For [#698](https://github.com/gophercloud/gophercloud/issues/698)

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/gnocchixyz/gnocchi/blob/stable/4.1/gnocchi/rest/api.py#L1007
https://github.com/gnocchixyz/gnocchi/blob/stable/4.1/gnocchi/indexer/sqlalchemy.py#L788