### PR TITLE
Implement Gnocchi resource delete

### DIFF
--- a/acceptance/gnocchi/metric/v1/resources.go
+++ b/acceptance/gnocchi/metric/v1/resources.go
@@ -40,3 +40,16 @@ func CreateGenericResource(t *testing.T, client *gophercloud.ServiceClient) (*re
 	t.Logf("Successfully created the generic Gnocchi resource.")
 	return resource, nil
 }
+
+// DeleteResource will delete a Gnocchi resource with specified type and ID.
+// A fatal error will occur if the delete was not successful.
+func DeleteResource(t *testing.T, client *gophercloud.ServiceClient, resourceType, resourceID string) {
+	t.Logf("Attempting to delete the Gnocchi resource: %s", resourceID)
+
+	err := resources.Delete(client, resourceType, resourceID).ExtractErr()
+	if err != nil {
+		t.Fatalf("Unable to delete the Gnocchi resource %s: %v", resourceID, err)
+	}
+
+	t.Logf("Deleted the Gnocchi resource: %s", resourceID)
+}

--- a/acceptance/gnocchi/metric/v1/resources_test.go
+++ b/acceptance/gnocchi/metric/v1/resources_test.go
@@ -1,5 +1,4 @@
 // +build acceptance metric resources
-
 package v1
 
 import (

--- a/acceptance/gnocchi/metric/v1/resources_test.go
+++ b/acceptance/gnocchi/metric/v1/resources_test.go
@@ -21,7 +21,7 @@ func TestResourcesCRUD(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to create a generic Gnocchi resource: %v", err)
 	}
-	defer DeleteResource(t, client, resource.Type, resource.ID)
+	defer DeleteResource(t, client, genericResource.Type, genericResource.ID)
 
 	tools.PrintResource(t, genericResource)
 

--- a/acceptance/gnocchi/metric/v1/resources_test.go
+++ b/acceptance/gnocchi/metric/v1/resources_test.go
@@ -1,4 +1,5 @@
 // +build acceptance metric resources
+
 package v1
 
 import (
@@ -20,6 +21,7 @@ func TestResourcesCRUD(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to create a generic Gnocchi resource: %v", err)
 	}
+	defer DeleteResource(t, client, resource.Type, resource.ID)
 
 	tools.PrintResource(t, genericResource)
 

--- a/gnocchi/metric/v1/resources/doc.go
+++ b/gnocchi/metric/v1/resources/doc.go
@@ -31,10 +31,11 @@ Example of Getting a resource
 		panic(err)
 	}
 
-Example of Creating a resource without a metric
+Example of Creating a resource without a metric with a string timestamp for the starting time
 
 	createOpts := resources.CreateOpts{
 		ID: "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",
+		StartedAtString: "2018-01-09T22:15:00+00:00",
 	}
 	resourceType = "generic"
 	resource, err := resources.Create(gnocchiClient, resourceType, createOpts).Extract()

--- a/gnocchi/metric/v1/resources/doc.go
+++ b/gnocchi/metric/v1/resources/doc.go
@@ -31,11 +31,10 @@ Example of Getting a resource
 		panic(err)
 	}
 
-Example of Creating a resource without a metric with a string timestamp for the starting time
+Example of Creating a resource without a metric
 
 	createOpts := resources.CreateOpts{
 		ID: "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",
-		StartedAtString: "2018-01-09T22:15:00+00:00",
 	}
 	resourceType = "generic"
 	resource, err := resources.Create(gnocchiClient, resourceType, createOpts).Extract()

--- a/gnocchi/metric/v1/resources/doc.go
+++ b/gnocchi/metric/v1/resources/doc.go
@@ -123,5 +123,13 @@ Example of Updating a resource and creating an associated metric at the same tim
 	if err != nil {
 		panic(err)
 	}
+
+Example of Deleting a Gnocchi resource
+
+	resourceID := "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55"
+	err := resources.Delete(gnocchiClient, resourceType, resourceID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
 */
 package resources

--- a/gnocchi/metric/v1/resources/requests.go
+++ b/gnocchi/metric/v1/resources/requests.go
@@ -98,6 +98,16 @@ type CreateOpts struct {
 
 // ToResourceCreateMap constructs a request body from CreateOpts.
 func (opts CreateOpts) ToResourceCreateMap() (map[string]interface{}, error) {
+	if opts.StartedAtTimeStamp != nil {
+		opts.StartedAtString = opts.StartedAtTimeStamp.Format(gnocchi.RFC3339NanoTimezone)
+		opts.StartedAtTimeStamp = nil
+	}
+
+	if opts.EndedAtTimeStamp != nil {
+		opts.EndedAtString = opts.EndedAtTimeStamp.Format(gnocchi.RFC3339NanoTimezone)
+		opts.EndedAtTimeStamp = nil
+	}
+
 	b, err := gophercloud.BuildRequestBody(opts, "")
 	if err != nil {
 		return nil, err

--- a/gnocchi/metric/v1/resources/requests.go
+++ b/gnocchi/metric/v1/resources/requests.go
@@ -98,16 +98,6 @@ type CreateOpts struct {
 
 // ToResourceCreateMap constructs a request body from CreateOpts.
 func (opts CreateOpts) ToResourceCreateMap() (map[string]interface{}, error) {
-	if opts.StartedAtTimeStamp != nil {
-		opts.StartedAtString = opts.StartedAtTimeStamp.Format(gnocchi.RFC3339NanoTimezone)
-		opts.StartedAtTimeStamp = nil
-	}
-
-	if opts.EndedAtTimeStamp != nil {
-		opts.EndedAtString = opts.EndedAtTimeStamp.Format(gnocchi.RFC3339NanoTimezone)
-		opts.EndedAtTimeStamp = nil
-	}
-
 	b, err := gophercloud.BuildRequestBody(opts, "")
 	if err != nil {
 		return nil, err

--- a/gnocchi/metric/v1/resources/requests.go
+++ b/gnocchi/metric/v1/resources/requests.go
@@ -200,3 +200,14 @@ func Update(c *gophercloud.ServiceClient, resourceType, resourceID string, opts 
 	})
 	return
 }
+
+// Delete accepts a unique ID and deletes the Gnocchi resource associated with it.
+func Delete(c *gophercloud.ServiceClient, resourceType, resourceID string) (r DeleteResult) {
+	requestOpts := &gophercloud.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Accept": "application/json, */*",
+		},
+	}
+	_, r.Err = c.Delete(deleteURL(c, resourceType, resourceID), requestOpts)
+	return
+}

--- a/gnocchi/metric/v1/resources/results.go
+++ b/gnocchi/metric/v1/resources/results.go
@@ -82,7 +82,7 @@ type Resource struct {
 	EndedAt time.Time `json:"-"`
 
 	// EndedAt is a timestamp of when the resource has ended.
-	EndedAt string `json:"ended_at"`
+	EndedAt time.Time `json:"-"`
 
 	// Type is a type of the resource.
 	Type string `json:"type"`
@@ -136,6 +136,30 @@ func (r *Resource) UnmarshalJSON(b []byte) error {
 			r.ExtraAttributes = internal.RemainingKeys(Resource{}, resultMap)
 		}
 	}
+
+	return err
+}
+
+// UnmarshalJSON helps to unmarshal Resource fields into needed values.
+func (r *Resource) UnmarshalJSON(b []byte) error {
+	type tmp Resource
+	var s struct {
+		tmp
+		RevisionStart gnocchi.JSONRFC3339NanoTimezone `json:"revision_start"`
+		RevisionEnd   gnocchi.JSONRFC3339NanoTimezone `json:"revision_end"`
+		StartedAt     gnocchi.JSONRFC3339NanoTimezone `json:"started_at"`
+		EndedAt       gnocchi.JSONRFC3339NanoTimezone `json:"ended_at"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*r = Resource(s.tmp)
+
+	r.RevisionStart = time.Time(s.RevisionStart)
+	r.RevisionEnd = time.Time(s.RevisionEnd)
+	r.StartedAt = time.Time(s.StartedAt)
+	r.EndedAt = time.Time(s.EndedAt)
 
 	return err
 }

--- a/gnocchi/metric/v1/resources/results.go
+++ b/gnocchi/metric/v1/resources/results.go
@@ -81,6 +81,9 @@ type Resource struct {
 	// EndedAt is a timestamp of when the resource has ended.
 	EndedAt time.Time `json:"-"`
 
+	// EndedAt is a timestamp of when the resource has ended.
+	EndedAt string `json:"ended_at"`
+
 	// Type is a type of the resource.
 	Type string `json:"type"`
 

--- a/gnocchi/metric/v1/resources/results.go
+++ b/gnocchi/metric/v1/resources/results.go
@@ -137,51 +137,6 @@ func (r *Resource) UnmarshalJSON(b []byte) error {
 	return err
 }
 
-// UnmarshalJSON helps to unmarshal Resource fields into needed values.
-func (r *Resource) UnmarshalJSON(b []byte) error {
-	type tmp Resource
-	var s struct {
-		tmp
-		Extra         map[string]interface{}          `json:"extra"`
-		RevisionStart gnocchi.JSONRFC3339NanoTimezone `json:"revision_start"`
-		RevisionEnd   gnocchi.JSONRFC3339NanoTimezone `json:"revision_end"`
-		StartedAt     gnocchi.JSONRFC3339NanoTimezone `json:"started_at"`
-		EndedAt       gnocchi.JSONRFC3339NanoTimezone `json:"ended_at"`
-	}
-	err := json.Unmarshal(b, &s)
-	if err != nil {
-		return err
-	}
-	*r = Resource(s.tmp)
-
-	// Collect Gnocchi timestamps.
-	r.RevisionStart = time.Time(s.RevisionStart)
-	r.RevisionEnd = time.Time(s.RevisionEnd)
-	r.StartedAt = time.Time(s.StartedAt)
-	r.EndedAt = time.Time(s.EndedAt)
-
-	// Collect other resource fields
-	// and bundle them into Extra.
-	if s.Extra != nil {
-		r.Extra = s.Extra
-	} else {
-		var result interface{}
-		err := json.Unmarshal(b, &result)
-		if err != nil {
-			return err
-		}
-		if resultMap, ok := result.(map[string]interface{}); ok {
-			delete(resultMap, "revision_start")
-			delete(resultMap, "revision_end")
-			delete(resultMap, "started_at")
-			delete(resultMap, "ended_at")
-			r.Extra = internal.RemainingKeys(Resource{}, resultMap)
-		}
-	}
-
-	return err
-}
-
 // ResourcePage abstracts the raw results of making a List() request against
 // the Gnocchi API.
 //

--- a/gnocchi/metric/v1/resources/results.go
+++ b/gnocchi/metric/v1/resources/results.go
@@ -81,9 +81,6 @@ type Resource struct {
 	// EndedAt is a timestamp of when the resource has ended.
 	EndedAt time.Time `json:"-"`
 
-	// EndedAt is a timestamp of when the resource has ended.
-	EndedAt time.Time `json:"-"`
-
 	// Type is a type of the resource.
 	Type string `json:"type"`
 
@@ -145,6 +142,7 @@ func (r *Resource) UnmarshalJSON(b []byte) error {
 	type tmp Resource
 	var s struct {
 		tmp
+		Extra         map[string]interface{}          `json:"extra"`
 		RevisionStart gnocchi.JSONRFC3339NanoTimezone `json:"revision_start"`
 		RevisionEnd   gnocchi.JSONRFC3339NanoTimezone `json:"revision_end"`
 		StartedAt     gnocchi.JSONRFC3339NanoTimezone `json:"started_at"`
@@ -156,10 +154,30 @@ func (r *Resource) UnmarshalJSON(b []byte) error {
 	}
 	*r = Resource(s.tmp)
 
+	// Collect Gnocchi timestamps.
 	r.RevisionStart = time.Time(s.RevisionStart)
 	r.RevisionEnd = time.Time(s.RevisionEnd)
 	r.StartedAt = time.Time(s.StartedAt)
 	r.EndedAt = time.Time(s.EndedAt)
+
+	// Collect other resource fields
+	// and bundle them into Extra.
+	if s.Extra != nil {
+		r.Extra = s.Extra
+	} else {
+		var result interface{}
+		err := json.Unmarshal(b, &result)
+		if err != nil {
+			return err
+		}
+		if resultMap, ok := result.(map[string]interface{}); ok {
+			delete(resultMap, "revision_start")
+			delete(resultMap, "revision_end")
+			delete(resultMap, "started_at")
+			delete(resultMap, "ended_at")
+			r.Extra = internal.RemainingKeys(Resource{}, resultMap)
+		}
+	}
 
 	return err
 }

--- a/gnocchi/metric/v1/resources/results.go
+++ b/gnocchi/metric/v1/resources/results.go
@@ -122,7 +122,7 @@ func (r *Resource) UnmarshalJSON(b []byte) error {
 	r.EndedAt = time.Time(s.EndedAt)
 
 	// Collect other resource fields
-	// and bundle them into Extra.
+	// and bundle them into ExtraAttributes.
 	if s.ExtraAttributes != nil {
 		r.ExtraAttributes = s.ExtraAttributes
 	} else {

--- a/gnocchi/metric/v1/resources/results.go
+++ b/gnocchi/metric/v1/resources/results.go
@@ -39,6 +39,12 @@ type UpdateResult struct {
 	commonResult
 }
 
+// DeleteResult represents the result of a delete operation. Call its
+// ExtractErr method to determine if the request succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
 // Resource is an entity representing anything in your infrastructure
 // that you will associate metric(s) with.
 // It is identified by a unique ID and can contain attributes.

--- a/gnocchi/metric/v1/resources/results.go
+++ b/gnocchi/metric/v1/resources/results.go
@@ -81,9 +81,6 @@ type Resource struct {
 	// EndedAt is a timestamp of when the resource has ended.
 	EndedAt time.Time `json:"-"`
 
-	// EndedAt is a timestamp of when the resource has ended.
-	EndedAt string `json:"ended_at"`
-
 	// Type is a type of the resource.
 	Type string `json:"type"`
 

--- a/gnocchi/metric/v1/resources/testing/fixtures.go
+++ b/gnocchi/metric/v1/resources/testing/fixtures.go
@@ -273,7 +273,6 @@ const ResourceUpdateCreateMetricsResponse = `
     "created_by_project_id": "3d40ca37-7234-4911-8987b9f288f4ae84",
     "created_by_user_id": "fdcfb420-c096-45e6-9e177a0bb1950884",
     "creator": "fdcfb420-c096-45e6-9e177a0bb1950884:3d40ca37-7234-4911-8987b9f288f4ae84",
-    "ended_at": "2018-01-09T20:00:00+00:00",
     "id": "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",
     "project_id": "4154f088-8333-4e04-94c4-1155c33c0fc9",
     "original_resource_id": "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",

--- a/gnocchi/metric/v1/resources/testing/fixtures.go
+++ b/gnocchi/metric/v1/resources/testing/fixtures.go
@@ -273,6 +273,7 @@ const ResourceUpdateCreateMetricsResponse = `
     "created_by_project_id": "3d40ca37-7234-4911-8987b9f288f4ae84",
     "created_by_user_id": "fdcfb420-c096-45e6-9e177a0bb1950884",
     "creator": "fdcfb420-c096-45e6-9e177a0bb1950884:3d40ca37-7234-4911-8987b9f288f4ae84",
+    "ended_at": null,
     "id": "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",
     "project_id": "4154f088-8333-4e04-94c4-1155c33c0fc9",
     "original_resource_id": "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",

--- a/gnocchi/metric/v1/resources/testing/fixtures.go
+++ b/gnocchi/metric/v1/resources/testing/fixtures.go
@@ -273,7 +273,7 @@ const ResourceUpdateCreateMetricsResponse = `
     "created_by_project_id": "3d40ca37-7234-4911-8987b9f288f4ae84",
     "created_by_user_id": "fdcfb420-c096-45e6-9e177a0bb1950884",
     "creator": "fdcfb420-c096-45e6-9e177a0bb1950884:3d40ca37-7234-4911-8987b9f288f4ae84",
-    "ended_at": null,
+    "ended_at": "2018-01-09T20:00:00+00:00",
     "id": "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",
     "project_id": "4154f088-8333-4e04-94c4-1155c33c0fc9",
     "original_resource_id": "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",

--- a/gnocchi/metric/v1/resources/testing/requests_test.go
+++ b/gnocchi/metric/v1/resources/testing/requests_test.go
@@ -322,3 +322,17 @@ func TestUpdateCreateMetrics(t *testing.T) {
 	th.AssertEquals(t, s.Type, "compute_instance_disk")
 	th.AssertEquals(t, s.UserID, "bd5874d6-6662-4b24-a9f01c128871e4ac")
 }
+
+func TestDelete(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v1/resource/generic/23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	res := resources.Delete(fake.ServiceClient(), "generic", "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55")
+	th.AssertNoErr(t, res.Err)
+}

--- a/gnocchi/metric/v1/resources/urls.go
+++ b/gnocchi/metric/v1/resources/urls.go
@@ -27,3 +27,7 @@ func createURL(c *gophercloud.ServiceClient, resourceType string) string {
 func updateURL(c *gophercloud.ServiceClient, resourceType, resourceID string) string {
 	return resourceURL(c, resourceType, resourceID)
 }
+
+func deleteURL(c *gophercloud.ServiceClient, resourceType, resourceID string) string {
+	return resourceURL(c, resourceType, resourceID)
+}


### PR DESCRIPTION
Add Gnocchi resource delete request with tests and documentation.

The same command with Gnocchi CLI is done with:
`gnocchi resource delete`

For [#698](https://github.com/gophercloud/gophercloud/issues/698)

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/gnocchixyz/gnocchi/blob/stable/4.1/gnocchi/rest/api.py#L1050
https://github.com/gnocchixyz/gnocchi/blob/stable/4.1/gnocchi/indexer/sqlalchemy.py#L896