### PR TITLE
Implement Gnocchi metric creation

### DIFF
--- a/acceptance/gnocchi/metric/v1/metrics.go
+++ b/acceptance/gnocchi/metric/v1/metrics.go
@@ -1,0 +1,28 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/utils/gnocchi/metric/v1/metrics"
+)
+
+// CreateMetric will create Gnocchi metric. An error will be returned if the
+// metric could not be created.
+func CreateMetric(t *testing.T, client *gophercloud.ServiceClient) (*metrics.Metric, error) {
+	// Metric will be created assuming that your Gnocchi's indexer installation was configured with
+	// the "gnocchi-manage --noskip-archive-policies-creation" command. So Gnocchi has the default policies:
+	// "low", "medium", "high", "bool".
+	createOpts := metrics.CreateOpts{
+		ArchivePolicyName: "low",
+	}
+	t.Logf("Attempting to create a Gnocchi metric")
+
+	metric, err := metrics.Create(client, createOpts).Extract()
+	if err != nil {
+		return nil, err
+	}
+
+	t.Logf("Successfully created the Gnocchi metric.")
+	return metric, nil
+}

--- a/acceptance/gnocchi/metric/v1/metrics.go
+++ b/acceptance/gnocchi/metric/v1/metrics.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/acceptance/tools"
 	"github.com/gophercloud/utils/gnocchi/metric/v1/metrics"
 )
 
@@ -13,8 +14,10 @@ func CreateMetric(t *testing.T, client *gophercloud.ServiceClient) (*metrics.Met
 	// Metric will be created assuming that your Gnocchi's indexer installation was configured with
 	// the "gnocchi-manage --noskip-archive-policies-creation" command. So Gnocchi has the default policies:
 	// "low", "medium", "high", "bool".
+	name := tools.RandomString("TESTACCT-", 8)
 	createOpts := metrics.CreateOpts{
 		ArchivePolicyName: "low",
+		Name:              name,
 	}
 	t.Logf("Attempting to create a Gnocchi metric")
 

--- a/acceptance/gnocchi/metric/v1/metrics_test.go
+++ b/acceptance/gnocchi/metric/v1/metrics_test.go
@@ -10,6 +10,20 @@ import (
 	"github.com/gophercloud/utils/gnocchi/metric/v1/metrics"
 )
 
+func TestMetricsCRUD(t *testing.T) {
+	client, err := clients.NewGnocchiV1Client()
+	if err != nil {
+		t.Fatalf("Unable to create a Gnocchi client: %v", err)
+	}
+
+	metric, err := CreateMetric(t, client)
+	if err != nil {
+		t.Fatalf("Unable to create a Gnocchi metric: %v", err)
+	}
+
+	tools.PrintResource(t, metric)
+}
+
 func TestMetricsList(t *testing.T) {
 	client, err := clients.NewGnocchiV1Client()
 	if err != nil {

--- a/gnocchi/metric/v1/metrics/doc.go
+++ b/gnocchi/metric/v1/metrics/doc.go
@@ -28,5 +28,29 @@ Example of Getting a metric
 	if err != nil {
 		panic(err)
 	}
+
+Example of Creating a metric and link it to an existing archive policy
+
+	createOpts := metrics.CreateOpts{
+		ArchivePolicyName: "low",
+		CreatedByProjectID: "3d40ca37-7234-4911-8987b9f288f4ae84",
+		CreatedByUserID: "fdcfb420-c096-45e6-9e177a0bb1950884",
+		Creator: "fdcfb420-c096-45e6-9e177a0bb1950884:3d40ca37-7234-4911-8987b9f288f4ae84",
+	}
+	metric, err := metrics.Create(gnocchiClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example of Creating a metric without an archive policy, assuming that Gnocchi has the needed
+archive policy rule and can assign the policy automatically
+
+	createOpts := metrics.CreateOpts{
+		Unit: "MB",
+	}
+	metric, err := metrics.Create(gnocchiClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
 */
 package metrics

--- a/gnocchi/metric/v1/metrics/doc.go
+++ b/gnocchi/metric/v1/metrics/doc.go
@@ -33,9 +33,8 @@ Example of Creating a metric and link it to an existing archive policy
 
 	createOpts := metrics.CreateOpts{
 		ArchivePolicyName: "low",
-		CreatedByProjectID: "3d40ca37-7234-4911-8987b9f288f4ae84",
-		CreatedByUserID: "fdcfb420-c096-45e6-9e177a0bb1950884",
-		Creator: "fdcfb420-c096-45e6-9e177a0bb1950884:3d40ca37-7234-4911-8987b9f288f4ae84",
+		Name: "network.incoming.packets.rate",
+		Unit: "packet/s",
 	}
 	metric, err := metrics.Create(gnocchiClient, createOpts).Extract()
 	if err != nil {

--- a/gnocchi/metric/v1/metrics/doc.go
+++ b/gnocchi/metric/v1/metrics/doc.go
@@ -45,6 +45,8 @@ Example of Creating a metric without an archive policy, assuming that Gnocchi ha
 archive policy rule and can assign the policy automatically
 
 	createOpts := metrics.CreateOpts{
+		ResourceID: "1f3a0724-1807-4bd1-81f9-ee18c8ff6ccc",
+		Name: "memory.usage",
 		Unit: "MB",
 	}
 	metric, err := metrics.Create(gnocchiClient, createOpts).Extract()

--- a/gnocchi/metric/v1/metrics/requests.go
+++ b/gnocchi/metric/v1/metrics/requests.go
@@ -82,19 +82,6 @@ type CreateOpts struct {
 	// archive policy rule to assign an archive policy by a metric's name.
 	ArchivePolicyName string `json:"archive_policy_name,omitempty"`
 
-	// CreatedByProjectID contains the id of the Identity project that
-	// was used for a metric creation.
-	CreatedByProjectID string `json:"created_by_project_id,omitempty"`
-
-	// CreatedByUserID contains the id of the Identity user
-	// that created the Gnocchi metric.
-	CreatedByUserID string `json:"created_by_user_id,omitempty"`
-
-	// Creator shows who created the metric.
-	// Usually it contains concatenated string with values from
-	// "created_by_user_id" and "created_by_project_id" fields.
-	Creator string `json:"creator,omitempty"`
-
 	// Name is a human-readable name for the Gnocchi metric.
 	// You must provide it if you are also providing a ResourceID in the request.
 	Name string `json:"name,omitempty"`

--- a/gnocchi/metric/v1/metrics/results.go
+++ b/gnocchi/metric/v1/metrics/results.go
@@ -24,6 +24,12 @@ type GetResult struct {
 	commonResult
 }
 
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a Gnocchi metric.
+type CreateResult struct {
+	commonResult
+}
+
 // Metric is an entity storing aggregates identified by an UUID.
 // It can be attached to a resource using a name.
 // How a metric stores its aggregates is defined by the archive policy

--- a/gnocchi/metric/v1/metrics/testing/fixtures.go
+++ b/gnocchi/metric/v1/metrics/testing/fixtures.go
@@ -184,3 +184,30 @@ const MetricGetResult = `
     "unit": "packet/s"
 }
 `
+
+// MetricCreateRequest represents a request to create a metric.
+const MetricCreateRequest = `
+{
+    "archive_policy_name": "high",
+    "created_by_project_id": "3d40ca37-7234-4911-8987b9f288f4ae84",
+    "created_by_user_id": "fdcfb420-c096-45e6-9e177a0bb1950884",
+    "creator": "fdcfb420-c096-45e6-9e177a0bb1950884:3d40ca37-7234-4911-8987b9f288f4ae84",
+    "name": "network.incoming.bytes.rate",
+    "resource_id": "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",
+    "unit": "B/s"
+}
+`
+
+// MetricCreateResponse represents a raw server responce to the MetricCreateRequest.
+const MetricCreateResponse = `
+{
+    "archive_policy_name": "high",
+    "created_by_project_id": "3d40ca37-7234-4911-8987b9f288f4ae84",
+    "created_by_user_id": "fdcfb420-c096-45e6-9e177a0bb1950884",
+    "creator": "fdcfb420-c096-45e6-9e177a0bb1950884:3d40ca37-7234-4911-8987b9f288f4ae84",
+    "id": "01b2953e-de74-448a-a305-c84440697933",
+    "name": "network.incoming.bytes.rate",
+    "resource_id": "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",
+    "unit": "B/s"
+}
+`

--- a/gnocchi/metric/v1/metrics/testing/fixtures.go
+++ b/gnocchi/metric/v1/metrics/testing/fixtures.go
@@ -189,9 +189,6 @@ const MetricGetResult = `
 const MetricCreateRequest = `
 {
     "archive_policy_name": "high",
-    "created_by_project_id": "3d40ca37-7234-4911-8987b9f288f4ae84",
-    "created_by_user_id": "fdcfb420-c096-45e6-9e177a0bb1950884",
-    "creator": "fdcfb420-c096-45e6-9e177a0bb1950884:3d40ca37-7234-4911-8987b9f288f4ae84",
     "name": "network.incoming.bytes.rate",
     "resource_id": "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",
     "unit": "B/s"

--- a/gnocchi/metric/v1/metrics/testing/requests_test.go
+++ b/gnocchi/metric/v1/metrics/testing/requests_test.go
@@ -131,13 +131,10 @@ func TestCreate(t *testing.T) {
 	})
 
 	opts := metrics.CreateOpts{
-		ArchivePolicyName:  "high",
-		CreatedByProjectID: "3d40ca37-7234-4911-8987b9f288f4ae84",
-		CreatedByUserID:    "fdcfb420-c096-45e6-9e177a0bb1950884",
-		Creator:            "fdcfb420-c096-45e6-9e177a0bb1950884:3d40ca37-7234-4911-8987b9f288f4ae84",
-		Name:               "network.incoming.bytes.rate",
-		ResourceID:         "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",
-		Unit:               "B/s",
+		ArchivePolicyName: "high",
+		Name:              "network.incoming.bytes.rate",
+		ResourceID:        "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",
+		Unit:              "B/s",
 	}
 	s, err := metrics.Create(fake.ServiceClient(), opts).Extract()
 	th.AssertNoErr(t, err)

--- a/gnocchi/metric/v1/metrics/testing/requests_test.go
+++ b/gnocchi/metric/v1/metrics/testing/requests_test.go
@@ -112,3 +112,42 @@ func TestGet(t *testing.T) {
 	})
 	th.AssertEquals(t, s.Unit, "packet/s")
 }
+
+func TestCreate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v1/metric", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, MetricCreateRequest)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+
+		fmt.Fprintf(w, MetricCreateResponse)
+	})
+
+	opts := metrics.CreateOpts{
+		ArchivePolicyName:  "high",
+		CreatedByProjectID: "3d40ca37-7234-4911-8987b9f288f4ae84",
+		CreatedByUserID:    "fdcfb420-c096-45e6-9e177a0bb1950884",
+		Creator:            "fdcfb420-c096-45e6-9e177a0bb1950884:3d40ca37-7234-4911-8987b9f288f4ae84",
+		Name:               "network.incoming.bytes.rate",
+		ResourceID:         "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",
+		Unit:               "B/s",
+	}
+	s, err := metrics.Create(fake.ServiceClient(), opts).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, s.ArchivePolicyName, "high")
+	th.AssertEquals(t, s.CreatedByProjectID, "3d40ca37-7234-4911-8987b9f288f4ae84")
+	th.AssertEquals(t, s.CreatedByUserID, "fdcfb420-c096-45e6-9e177a0bb1950884")
+	th.AssertEquals(t, s.Creator, "fdcfb420-c096-45e6-9e177a0bb1950884:3d40ca37-7234-4911-8987b9f288f4ae84")
+	th.AssertEquals(t, s.ID, "01b2953e-de74-448a-a305-c84440697933")
+	th.AssertEquals(t, s.Name, "network.incoming.bytes.rate")
+	th.AssertEquals(t, s.ResourceID, "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55")
+	th.AssertEquals(t, s.Unit, "B/s")
+}

--- a/gnocchi/metric/v1/metrics/urls.go
+++ b/gnocchi/metric/v1/metrics/urls.go
@@ -19,3 +19,7 @@ func listURL(c *gophercloud.ServiceClient) string {
 func getURL(c *gophercloud.ServiceClient, metricID string) string {
 	return resourceURL(c, metricID)
 }
+
+func createURL(c *gophercloud.ServiceClient) string {
+	return rootURL(c)
+}


### PR DESCRIPTION
Add Gnocchi metric create request with tests and documentation.

The same command with Gnocchi CLI is done with:
`gnocchi metric create`

For [#698](https://github.com/gophercloud/gophercloud/issues/698)

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/gnocchixyz/gnocchi/blob/stable/4.1/gnocchi/rest/api.py#L618
https://github.com/gnocchixyz/gnocchi/blob/stable/4.1/gnocchi/indexer/sqlalchemy.py#L670