### PR TITLE
Implement Gnocchi metric delete

### DIFF
--- a/acceptance/gnocchi/metric/v1/metrics.go
+++ b/acceptance/gnocchi/metric/v1/metrics.go
@@ -29,3 +29,16 @@ func CreateMetric(t *testing.T, client *gophercloud.ServiceClient) (*metrics.Met
 	t.Logf("Successfully created the Gnocchi metric.")
 	return metric, nil
 }
+
+// DeleteMetric will delete a Gnocchi metric with a specified ID.
+// A fatal error will occur if the delete was not successful.
+func DeleteMetric(t *testing.T, client *gophercloud.ServiceClient, metricID string) {
+	t.Logf("Attempting to delete the Gnocchi metric: %s", metricID)
+
+	err := metrics.Delete(client, metricID).ExtractErr()
+	if err != nil {
+		t.Fatalf("Unable to delete the Gnocchi metric %s: %v", metricID, err)
+	}
+
+	t.Logf("Deleted the Gnocchi metric: %s", metricID)
+}

--- a/acceptance/gnocchi/metric/v1/metrics_test.go
+++ b/acceptance/gnocchi/metric/v1/metrics_test.go
@@ -20,6 +20,7 @@ func TestMetricsCRUD(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to create a Gnocchi metric: %v", err)
 	}
+	defer DeleteMetric(t, client, metric.ID)
 
 	tools.PrintResource(t, metric)
 }

--- a/gnocchi/metric/v1/metrics/doc.go
+++ b/gnocchi/metric/v1/metrics/doc.go
@@ -53,5 +53,13 @@ archive policy rule and can assign the policy automatically
 	if err != nil {
 		panic(err)
 	}
+
+Example of Deleting a Gnocchi metric
+
+	metricID := "01b2953e-de74-448a-a305-c84440697933"
+	err := metrics.Delete(gnocchiClient, metricID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
 */
 package metrics

--- a/gnocchi/metric/v1/metrics/requests.go
+++ b/gnocchi/metric/v1/metrics/requests.go
@@ -115,3 +115,14 @@ func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r Create
 	})
 	return
 }
+
+// Delete accepts a unique ID and deletes the Gnocchi metric associated with it.
+func Delete(c *gophercloud.ServiceClient, metricID string) (r DeleteResult) {
+	requestOpts := &gophercloud.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Accept": "application/json, */*",
+		},
+	}
+	_, r.Err = c.Delete(deleteURL(c, metricID), requestOpts)
+	return
+}

--- a/gnocchi/metric/v1/metrics/results.go
+++ b/gnocchi/metric/v1/metrics/results.go
@@ -30,6 +30,12 @@ type CreateResult struct {
 	commonResult
 }
 
+// DeleteResult represents the result of a delete operation. Call its
+// ExtractErr method to determine if the request succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
 // Metric is an entity storing aggregates identified by an UUID.
 // It can be attached to a resource using a name.
 // How a metric stores its aggregates is defined by the archive policy

--- a/gnocchi/metric/v1/metrics/testing/requests_test.go
+++ b/gnocchi/metric/v1/metrics/testing/requests_test.go
@@ -148,3 +148,17 @@ func TestCreate(t *testing.T) {
 	th.AssertEquals(t, s.ResourceID, "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55")
 	th.AssertEquals(t, s.Unit, "B/s")
 }
+
+func TestDelete(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v1/metric/01b2953e-de74-448a-a305-c84440697933", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	res := metrics.Delete(fake.ServiceClient(), "01b2953e-de74-448a-a305-c84440697933")
+	th.AssertNoErr(t, res.Err)
+}

--- a/gnocchi/metric/v1/metrics/urls.go
+++ b/gnocchi/metric/v1/metrics/urls.go
@@ -23,3 +23,7 @@ func getURL(c *gophercloud.ServiceClient, metricID string) string {
 func createURL(c *gophercloud.ServiceClient) string {
 	return rootURL(c)
 }
+
+func deleteURL(c *gophercloud.ServiceClient, metricID string) string {
+	return resourceURL(c, metricID)
+}


### PR DESCRIPTION
Add Gnocchi metric delete request with tests and documentation.

The same command with Gnocchi CLI is done with:
`gnocchi metric delete`

For [#698](https://github.com/gophercloud/gophercloud/issues/698)

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/gnocchixyz/gnocchi/blob/stable/4.1/gnocchi/rest/api.py#L533
https://github.com/gnocchixyz/gnocchi/blob/stable/4.1/gnocchi/indexer/sqlalchemy.py#L1118