### PR TITLE
Implement Gnocchi measures list

### DIFF
--- a/gnocchi/metric/v1/measures/doc.go
+++ b/gnocchi/metric/v1/measures/doc.go
@@ -1,0 +1,27 @@
+/*
+Package measures provides the ability to retrieve measures through the Gnocchi API.
+
+Example of Listing measures of a known metric
+
+	startTime := time.Date(2018, 1, 4, 10, 0, 0, 0, time.UTC)
+	metricID := "9e5a6441-1044-4181-b66e-34e180753040"
+	listOpts := measures.ListOpts{
+		Resample: "2h",
+		Granularity: "1h",
+		Start: &startTime,
+	}
+	allPages, err := measures.List(gnocchiClient, metricID, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allMeasures, err := measures.ExtractMeasures(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, measure := range allMeasures {
+		fmt.Printf("%+v\n", measure)
+	}
+*/
+package measures

--- a/gnocchi/metric/v1/measures/requests.go
+++ b/gnocchi/metric/v1/measures/requests.go
@@ -1,0 +1,82 @@
+package measures
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+	"github.com/gophercloud/utils/gnocchi"
+)
+
+// ListOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type ListOptsBuilder interface {
+	ToMeasureListQuery() (string, error)
+}
+
+// ListOpts allows to provide additional options to the Gnocchi measures List request.
+type ListOpts struct {
+	// Refresh can be used to force any unprocessed measures to be handled in the Gnocchi
+	// to ensure that List request returns all aggregates.
+	Refresh bool `q:"refresh"`
+
+	// Start is a start of time time range for the measures.
+	Start *time.Time
+
+	// Stop is a stop of time time range for the measures.
+	Stop *time.Time
+
+	// Aggregation is a needed aggregation method for returned measures.
+	// Gnocchi returns "mean" by default.
+	Aggregation string `q:"aggregation"`
+
+	// Granularity is a needed time between two series of measures to retreive.
+	// Gnocchi will response with all granularities for available measures by default.
+	Granularity string `q:"granularity"`
+
+	// Resample allows to select different granularity instead of those that were defined in the
+	// archive policy.
+	Resample string `q:"resample"`
+}
+
+// ToMeasureListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToMeasureListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+
+	// delete
+	fmt.Printf("ToMeasureListQuery start: %s\n", q.String())
+
+	if opts.Start != nil {
+		start := strings.Join([]string{"start=", opts.Start.Format(gnocchi.RFC3339NanoNoTimezone)}, "")
+		q.RawQuery = strings.Join([]string{q.RawQuery, start}, "&")
+	}
+
+	if opts.Stop != nil {
+		stop := strings.Join([]string{"stop=", opts.Stop.Format(gnocchi.RFC3339NanoNoTimezone)}, "")
+		q.RawQuery = strings.Join([]string{q.RawQuery, stop}, "&")
+	}
+
+	// delete
+	fmt.Printf("ToMeasureListQuery finish: %s\n", q.String())
+
+	return q.String(), err
+}
+
+// List returns a Pager which allows you to iterate over a collection of
+// measures.
+// It accepts a ListOpts struct, which allows you to provide options to a Gnocchi measures List request.
+func List(c *gophercloud.ServiceClient, measureID string, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(c, measureID)
+	if opts != nil {
+		query, err := opts.ToMeasureListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		return MeasurePage{pagination.SinglePageBase(r)}
+	})
+}

--- a/gnocchi/metric/v1/measures/requests.go
+++ b/gnocchi/metric/v1/measures/requests.go
@@ -1,7 +1,6 @@
 package measures
 
 import (
-	"fmt"
 	"strings"
 	"time"
 
@@ -45,9 +44,6 @@ type ListOpts struct {
 func (opts ListOpts) ToMeasureListQuery() (string, error) {
 	q, err := gophercloud.BuildQueryString(opts)
 
-	// delete
-	fmt.Printf("ToMeasureListQuery start: %s\n", q.String())
-
 	if opts.Start != nil {
 		start := strings.Join([]string{"start=", opts.Start.Format(gnocchi.RFC3339NanoNoTimezone)}, "")
 		q.RawQuery = strings.Join([]string{q.RawQuery, start}, "&")
@@ -57,9 +53,6 @@ func (opts ListOpts) ToMeasureListQuery() (string, error) {
 		stop := strings.Join([]string{"stop=", opts.Stop.Format(gnocchi.RFC3339NanoNoTimezone)}, "")
 		q.RawQuery = strings.Join([]string{q.RawQuery, stop}, "&")
 	}
-
-	// delete
-	fmt.Printf("ToMeasureListQuery finish: %s\n", q.String())
 
 	return q.String(), err
 }

--- a/gnocchi/metric/v1/measures/requests.go
+++ b/gnocchi/metric/v1/measures/requests.go
@@ -1,7 +1,7 @@
 package measures
 
 import (
-	"strings"
+	"net/url"
 	"time"
 
 	"github.com/gophercloud/gophercloud"
@@ -43,17 +43,17 @@ type ListOpts struct {
 // ToMeasureListQuery formats a ListOpts into a query string.
 func (opts ListOpts) ToMeasureListQuery() (string, error) {
 	q, err := gophercloud.BuildQueryString(opts)
+	params := q.Query()
 
 	if opts.Start != nil {
-		start := strings.Join([]string{"start=", opts.Start.Format(gnocchi.RFC3339NanoNoTimezone)}, "")
-		q.RawQuery = strings.Join([]string{q.RawQuery, start}, "&")
+		params.Add("start", opts.Start.Format(gnocchi.RFC3339NanoNoTimezone))
 	}
 
 	if opts.Stop != nil {
-		stop := strings.Join([]string{"stop=", opts.Stop.Format(gnocchi.RFC3339NanoNoTimezone)}, "")
-		q.RawQuery = strings.Join([]string{q.RawQuery, stop}, "&")
+		params.Add("stop", opts.Stop.Format(gnocchi.RFC3339NanoNoTimezone))
 	}
 
+	q = &url.URL{RawQuery: params.Encode()}
 	return q.String(), err
 }
 

--- a/gnocchi/metric/v1/measures/requests.go
+++ b/gnocchi/metric/v1/measures/requests.go
@@ -60,8 +60,8 @@ func (opts ListOpts) ToMeasureListQuery() (string, error) {
 // List returns a Pager which allows you to iterate over a collection of
 // measures.
 // It accepts a ListOpts struct, which allows you to provide options to a Gnocchi measures List request.
-func List(c *gophercloud.ServiceClient, measureID string, opts ListOptsBuilder) pagination.Pager {
-	url := listURL(c, measureID)
+func List(c *gophercloud.ServiceClient, metricID string, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(c, metricID)
 	if opts != nil {
 		query, err := opts.ToMeasureListQuery()
 		if err != nil {

--- a/gnocchi/metric/v1/measures/results.go
+++ b/gnocchi/metric/v1/measures/results.go
@@ -1,0 +1,88 @@
+package measures
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// Measure is an datapoint thats is composed with a timestamp and a value.
+type Measure struct {
+	// TimeStamp represents a timestamp of when measure was pushed into the Gnocchi.
+	TimeStamp string `json:"-"`
+
+	// Granularity is a level of precision that is kept when aggregating data.
+	Granularity float64 `json:"-"`
+
+	// Value represents a value of data that was pushed into the Gnocchi.
+	Value float64 `json:"-"`
+}
+
+/*
+UnmarshalJSON helps to unmarshal response from reading Gnocchi measures.
+
+Gnocchi APIv1 returns measures in a such format:
+
+[
+    [
+        "2017-01-08T10:00:00+00:00",
+        300.0,
+        146.0
+    ],
+    [
+        "2017-01-08T10:05:00+00:00",
+        300.0,
+        58.0
+    ]
+]
+
+Helper unmarshals every nested array into the Measure type.
+*/
+func (r *Measure) UnmarshalJSON(b []byte) error {
+	type tmp Measure
+	var measuresSlice []interface{}
+
+	var s struct {
+		tmp
+	}
+	err := json.Unmarshal(b, &measuresSlice)
+	if err != nil {
+		return err
+	}
+
+	*r = Measure(s.tmp)
+	r.TimeStamp = measuresSlice[0].(string)
+	r.Granularity = measuresSlice[1].(float64)
+	r.Value = measuresSlice[2].(float64)
+
+	fmt.Printf("measuresSlice: %#v\n", measuresSlice)
+	fmt.Printf("r: %#v\n", r)
+
+	return nil
+}
+
+// MeasurePage is the page returned by a pager when traversing over a collection
+// of measures.
+type MeasurePage struct {
+	pagination.SinglePageBase
+}
+
+// IsEmpty checks whether a MeasurePage struct is empty.
+func (r MeasurePage) IsEmpty() (bool, error) {
+	is, err := ExtractMeasures(r)
+	return len(is) == 0, err
+}
+
+// ExtractMeasures interprets the results of a single page from a List() call,
+// producing a slice of Measures structs.
+func ExtractMeasures(r pagination.Page) ([]Measure, error) {
+	var s []Measure
+
+	err := (r.(MeasurePage)).ExtractInto(&s)
+	if err != nil {
+		return nil, err
+	}
+
+	return s, err
+}

--- a/gnocchi/metric/v1/measures/results.go
+++ b/gnocchi/metric/v1/measures/results.go
@@ -2,7 +2,6 @@ package measures
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"time"
 
@@ -53,7 +52,7 @@ func (r *Measure) UnmarshalJSON(b []byte) error {
 	// We need to check that a measure contains all needed data.
 	if len(measuresSlice) != 3 {
 		errMsg := fmt.Sprintf("got an invalid measure: %v", measuresSlice)
-		return errors.New(errMsg)
+		return fmt.Errorf(errMsg)
 	}
 
 	type tmp Measure
@@ -67,7 +66,7 @@ func (r *Measure) UnmarshalJSON(b []byte) error {
 	var ok bool
 	if timeStamp, ok = measuresSlice[0].(string); !ok {
 		errMsg := fmt.Sprintf("got an invalid timestamp of a measure %v: %v", measuresSlice, measuresSlice[0])
-		return errors.New(errMsg)
+		return fmt.Errorf(errMsg)
 	}
 	r.TimeStamp, err = time.Parse(gnocchi.RFC3339NanoTimezone, timeStamp)
 	if err != nil {
@@ -77,13 +76,13 @@ func (r *Measure) UnmarshalJSON(b []byte) error {
 	// Populate a measure's granularity.
 	if r.Granularity, ok = measuresSlice[1].(float64); !ok {
 		errMsg := fmt.Sprintf("got an invalid granularity of a measure %v: %v", measuresSlice, measuresSlice[1])
-		return errors.New(errMsg)
+		return fmt.Errorf(errMsg)
 	}
 
 	// Populate a measure's value.
 	if r.Value = measuresSlice[2].(float64); !ok {
 		errMsg := fmt.Sprintf("got an invalid value of a measure %v: %v", measuresSlice, measuresSlice[2])
-		return errors.New(errMsg)
+		return fmt.Errorf(errMsg)
 	}
 
 	return nil

--- a/gnocchi/metric/v1/measures/results.go
+++ b/gnocchi/metric/v1/measures/results.go
@@ -2,7 +2,6 @@ package measures
 
 import (
 	"encoding/json"
-	"fmt"
 
 	"github.com/gophercloud/gophercloud/pagination"
 )
@@ -55,9 +54,6 @@ func (r *Measure) UnmarshalJSON(b []byte) error {
 	r.TimeStamp = measuresSlice[0].(string)
 	r.Granularity = measuresSlice[1].(float64)
 	r.Value = measuresSlice[2].(float64)
-
-	fmt.Printf("measuresSlice: %#v\n", measuresSlice)
-	fmt.Printf("r: %#v\n", r)
 
 	return nil
 }

--- a/gnocchi/metric/v1/measures/results.go
+++ b/gnocchi/metric/v1/measures/results.go
@@ -12,8 +12,8 @@ import (
 
 // Measure is an datapoint thats is composed with a timestamp and a value.
 type Measure struct {
-	// TimeStamp represents a timestamp of when measure was pushed into the Gnocchi.
-	TimeStamp time.Time `json:"-"`
+	// Timestamp represents a timestamp of when measure was pushed into the Gnocchi.
+	Timestamp time.Time `json:"-"`
 
 	// Granularity is a level of precision that is kept when aggregating data.
 	Granularity float64 `json:"-"`
@@ -68,7 +68,7 @@ func (r *Measure) UnmarshalJSON(b []byte) error {
 		errMsg := fmt.Sprintf("got an invalid timestamp of a measure %v: %v", measuresSlice, measuresSlice[0])
 		return fmt.Errorf(errMsg)
 	}
-	r.TimeStamp, err = time.Parse(gnocchi.RFC3339NanoTimezone, timeStamp)
+	r.Timestamp, err = time.Parse(gnocchi.RFC3339NanoTimezone, timeStamp)
 	if err != nil {
 		return err
 	}

--- a/gnocchi/metric/v1/measures/testing/doc.go
+++ b/gnocchi/metric/v1/measures/testing/doc.go
@@ -1,0 +1,2 @@
+// measures unit tests
+package testing

--- a/gnocchi/metric/v1/measures/testing/fixtures.go
+++ b/gnocchi/metric/v1/measures/testing/fixtures.go
@@ -1,6 +1,10 @@
 package testing
 
-import "github.com/gophercloud/utils/gnocchi/metric/v1/measures"
+import (
+	"time"
+
+	"github.com/gophercloud/utils/gnocchi/metric/v1/measures"
+)
 
 // MeasuresListResult represents a raw server response from a server to a List call.
 const MeasuresListResult = `
@@ -26,17 +30,17 @@ const MeasuresListResult = `
 // ListArchivePoliciesExpected represents an expected repsonse from a List request.
 var ListArchivePoliciesExpected = []measures.Measure{
 	{
-		TimeStamp:   "2018-01-10T12:00:00+00:00",
+		TimeStamp:   time.Date(2018, 1, 10, 12, 0, 0, 0, time.UTC),
 		Granularity: 3600.0,
 		Value:       15.0,
 	},
 	{
-		TimeStamp:   "2018-01-10T13:00:00+00:00",
+		TimeStamp:   time.Date(2018, 1, 10, 13, 0, 0, 0, time.UTC),
 		Granularity: 3600.0,
 		Value:       10.0,
 	},
 	{
-		TimeStamp:   "2018-01-10T14:00:00+00:00",
+		TimeStamp:   time.Date(2018, 1, 10, 14, 0, 0, 0, time.UTC),
 		Granularity: 3600.0,
 		Value:       20.0,
 	},

--- a/gnocchi/metric/v1/measures/testing/fixtures.go
+++ b/gnocchi/metric/v1/measures/testing/fixtures.go
@@ -1,0 +1,43 @@
+package testing
+
+import "github.com/gophercloud/utils/gnocchi/metric/v1/measures"
+
+// MeasuresListResult represents a raw server response from a server to a List call.
+const MeasuresListResult = `
+[
+    [
+        "2018-01-10T12:00:00+00:00",
+        3600.0,
+        15.0
+    ],
+    [
+        "2018-01-10T13:00:00+00:00",
+        3600.0,
+        10.0
+    ],
+    [
+        "2018-01-10T14:00:00+00:00",
+        3600.0,
+        20.0
+    ]
+]
+`
+
+// ListArchivePoliciesExpected represents an expected repsonse from a List request.
+var ListArchivePoliciesExpected = []measures.Measure{
+	{
+		TimeStamp:   "2018-01-10T12:00:00+00:00",
+		Granularity: 3600.0,
+		Value:       15.0,
+	},
+	{
+		TimeStamp:   "2018-01-10T13:00:00+00:00",
+		Granularity: 3600.0,
+		Value:       10.0,
+	},
+	{
+		TimeStamp:   "2018-01-10T14:00:00+00:00",
+		Granularity: 3600.0,
+		Value:       20.0,
+	},
+}

--- a/gnocchi/metric/v1/measures/testing/fixtures.go
+++ b/gnocchi/metric/v1/measures/testing/fixtures.go
@@ -27,20 +27,20 @@ const MeasuresListResult = `
 ]
 `
 
-// ListArchivePoliciesExpected represents an expected repsonse from a List request.
-var ListArchivePoliciesExpected = []measures.Measure{
+// ListMeasuresExpected represents an expected repsonse from a List request.
+var ListMeasuresExpected = []measures.Measure{
 	{
-		TimeStamp:   time.Date(2018, 1, 10, 12, 0, 0, 0, time.UTC),
+		Timestamp:   time.Date(2018, 1, 10, 12, 0, 0, 0, time.UTC),
 		Granularity: 3600.0,
 		Value:       15.0,
 	},
 	{
-		TimeStamp:   time.Date(2018, 1, 10, 13, 0, 0, 0, time.UTC),
+		Timestamp:   time.Date(2018, 1, 10, 13, 0, 0, 0, time.UTC),
 		Granularity: 3600.0,
 		Value:       10.0,
 	},
 	{
-		TimeStamp:   time.Date(2018, 1, 10, 14, 0, 0, 0, time.UTC),
+		Timestamp:   time.Date(2018, 1, 10, 14, 0, 0, 0, time.UTC),
 		Granularity: 3600.0,
 		Value:       20.0,
 	},

--- a/gnocchi/metric/v1/measures/testing/requests_test.go
+++ b/gnocchi/metric/v1/measures/testing/requests_test.go
@@ -34,7 +34,7 @@ func TestListMeasures(t *testing.T) {
 		Stop:        &stopTime,
 		Granularity: "1h",
 	}
-	expected := ListArchivePoliciesExpected
+	expected := ListMeasuresExpected
 	pages := 0
 	err := measures.List(fake.ServiceClient(), metricID, opts).EachPage(func(page pagination.Page) (bool, error) {
 		pages++

--- a/gnocchi/metric/v1/measures/testing/requests_test.go
+++ b/gnocchi/metric/v1/measures/testing/requests_test.go
@@ -1,0 +1,54 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gophercloud/gophercloud/pagination"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/utils/gnocchi/metric/v1/measures"
+	fake "github.com/gophercloud/utils/gnocchi/testhelper/client"
+)
+
+func TestListMeasures(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v1/metric/9e5a6441-1044-4181-b66e-34e180753040/measures", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, MeasuresListResult)
+	})
+
+	metricID := "9e5a6441-1044-4181-b66e-34e180753040"
+	startTime := time.Date(2018, 1, 10, 12, 0, 0, 0, time.UTC)
+	stopTime := time.Date(2018, 1, 10, 14, 0, 5, 0, time.UTC)
+	opts := measures.ListOpts{
+		Start:       &startTime,
+		Stop:        &stopTime,
+		Granularity: "1h",
+	}
+	expected := ListArchivePoliciesExpected
+	pages := 0
+	err := measures.List(fake.ServiceClient(), metricID, opts).EachPage(func(page pagination.Page) (bool, error) {
+		pages++
+
+		actual, err := measures.ExtractMeasures(page)
+		th.AssertNoErr(t, err)
+
+		if len(actual) != 3 {
+			t.Fatalf("Expected 2 measures, got %d", len(actual))
+		}
+		th.CheckDeepEquals(t, expected, actual)
+
+		return true, nil
+	})
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, 1, pages)
+}

--- a/gnocchi/metric/v1/measures/urls.go
+++ b/gnocchi/metric/v1/measures/urls.go
@@ -1,0 +1,13 @@
+package measures
+
+import "github.com/gophercloud/gophercloud"
+
+const resourcePath = "metric"
+
+func resourceURL(c *gophercloud.ServiceClient, metricID string) string {
+	return c.ServiceURL(resourcePath, metricID, "measures")
+}
+
+func listURL(c *gophercloud.ServiceClient, metricID string) string {
+	return resourceURL(c, metricID)
+}

--- a/gnocchi/results.go
+++ b/gnocchi/results.go
@@ -9,7 +9,11 @@ import (
 // RFC3339NanoTimezone describes a common timestamp format used by Gnocchi API responses.
 const RFC3339NanoTimezone = "2006-01-02T15:04:05.999999+00:00"
 
-// JSONRFC3339NanoTimezone is a type for Gnocchi timestamps.
+// RFC3339NanoNoTimezone describes a common timestamp format that can be used for Gnocchi requests
+// with time ranges.
+const RFC3339NanoNoTimezone = "2006-01-02T15:04:05.999999"
+
+// JSONRFC3339NanoTimezone is a type for Gnocchi responses timestamps with a timezone offset.
 type JSONRFC3339NanoTimezone time.Time
 
 // UnmarshalJSON helps to unmarshal timestamps from Gnocchi responses to the


### PR DESCRIPTION
Add Gnocchi measures list request with tests and documentation.

The same command with Gnocchi CLI is done with:
`gnocchi measures show`

For [#698](https://github.com/gophercloud/gophercloud/issues/698)

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

API:
- https://github.com/gnocchixyz/gnocchi/blob/stable/4.1/gnocchi/rest/api.py#L465

Storage code depends on a driver that is used for saving measures:
- Ceph: https://github.com/gnocchixyz/gnocchi/blob/stable/4.1/gnocchi/storage/ceph.py#L140
- Redis: https://github.com/gnocchixyz/gnocchi/blob/stable/4.1/gnocchi/storage/redis.py#L103
- File: https://github.com/gnocchixyz/gnocchi/blob/stable/4.1/gnocchi/storage/file.py#L142
- S3: https://github.com/gnocchixyz/gnocchi/blob/stable/4.1/gnocchi/storage/s3.py#L161
- Swift: https://github.com/gnocchixyz/gnocchi/blob/stable/4.1/gnocchi/storage/swift.py#L145