### PR TITLE
Implement Gnocchi measures create

### DIFF
--- a/acceptance/gnocchi/metric/v1/measures.go
+++ b/acceptance/gnocchi/metric/v1/measures.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/acceptance/tools"
 	"github.com/gophercloud/utils/gnocchi/metric/v1/measures"
 )
 
@@ -13,14 +14,16 @@ import (
 func CreateMeasures(t *testing.T, client *gophercloud.ServiceClient, metricID string) error {
 	currentTimeStamp := time.Now().UTC()
 	pastHourTimeStamp := currentTimeStamp.Add(-1 * time.Hour)
+	currentValue := float64(tools.RandomInt(100, 200))
+	pastHourValue := float64(tools.RandomInt(500, 600))
 	measuresToCreate := []measures.MeasureOpts{
 		{
 			TimeStamp: currentTimeStamp,
-			Value:     100.5,
+			Value:     currentValue,
 		},
 		{
 			TimeStamp: pastHourTimeStamp,
-			Value:     500,
+			Value:     pastHourValue,
 		},
 	}
 	createOpts := measures.CreateOpts{

--- a/acceptance/gnocchi/metric/v1/measures.go
+++ b/acceptance/gnocchi/metric/v1/measures.go
@@ -12,17 +12,17 @@ import (
 // CreateMeasures will create measures inside a single Gnocchi metric. An error will be returned if the
 // measures could not be created.
 func CreateMeasures(t *testing.T, client *gophercloud.ServiceClient, metricID string) error {
-	currentTimeStamp := time.Now().UTC()
-	pastHourTimeStamp := currentTimeStamp.Add(-1 * time.Hour)
+	currentTimestamp := time.Now().UTC()
+	pastHourTimestamp := currentTimestamp.Add(-1 * time.Hour)
 	currentValue := float64(tools.RandomInt(100, 200))
 	pastHourValue := float64(tools.RandomInt(500, 600))
 	measuresToCreate := []measures.MeasureOpts{
 		{
-			TimeStamp: currentTimeStamp,
+			Timestamp: currentTimestamp,
 			Value:     currentValue,
 		},
 		{
-			TimeStamp: pastHourTimeStamp,
+			Timestamp: pastHourTimestamp,
 			Value:     pastHourValue,
 		},
 	}

--- a/acceptance/gnocchi/metric/v1/measures.go
+++ b/acceptance/gnocchi/metric/v1/measures.go
@@ -8,12 +8,12 @@ import (
 	"github.com/gophercloud/utils/gnocchi/metric/v1/measures"
 )
 
-// PushMeasures will push measures into a single Gnocchi metric. An error will be returned if the
+// CreateMeasures will create measures inside a single Gnocchi metric. An error will be returned if the
 // measures could not be created.
-func PushMeasures(t *testing.T, client *gophercloud.ServiceClient, metricID string) error {
+func CreateMeasures(t *testing.T, client *gophercloud.ServiceClient, metricID string) error {
 	currentTimeStamp := time.Now().UTC()
 	pastHourTimeStamp := currentTimeStamp.Add(-1 * time.Hour)
-	measuresToPush := []measures.MeasureToPush{
+	measuresToCreate := []measures.MeasureOpts{
 		{
 			TimeStamp: currentTimeStamp,
 			Value:     100.5,
@@ -23,16 +23,16 @@ func PushMeasures(t *testing.T, client *gophercloud.ServiceClient, metricID stri
 			Value:     500,
 		},
 	}
-	pushOpts := measures.PushOpts{
-		Measures: measuresToPush,
+	createOpts := measures.CreateOpts{
+		Measures: measuresToCreate,
 	}
 
-	t.Logf("Attempting to push measures into a Gnocchi metric %s", metricID)
+	t.Logf("Attempting to create measures inside a Gnocchi metric %s", metricID)
 
-	if err := measures.Push(client, metricID, pushOpts).ExtractErr(); err != nil && err.Error() != "EOF" {
+	if err := measures.Create(client, metricID, createOpts).ExtractErr(); err != nil && err.Error() != "EOF" {
 		return err
 	}
 
-	t.Logf("Successfully pushed measures into the Gnocchi metric %s", metricID)
+	t.Logf("Successfully created measures inside the Gnocchi metric %s", metricID)
 	return nil
 }

--- a/acceptance/gnocchi/metric/v1/measures.go
+++ b/acceptance/gnocchi/metric/v1/measures.go
@@ -18,11 +18,11 @@ func CreateMeasures(t *testing.T, client *gophercloud.ServiceClient, metricID st
 	pastHourValue := float64(tools.RandomInt(500, 600))
 	measuresToCreate := []measures.MeasureOpts{
 		{
-			Timestamp: currentTimestamp,
+			Timestamp: &currentTimestamp,
 			Value:     currentValue,
 		},
 		{
-			Timestamp: pastHourTimestamp,
+			Timestamp: &pastHourTimestamp,
 			Value:     pastHourValue,
 		},
 	}

--- a/acceptance/gnocchi/metric/v1/measures.go
+++ b/acceptance/gnocchi/metric/v1/measures.go
@@ -1,0 +1,38 @@
+package v1
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/utils/gnocchi/metric/v1/measures"
+)
+
+// PushMeasures will push measures into a single Gnocchi metric. An error will be returned if the
+// measures could not be created.
+func PushMeasures(t *testing.T, client *gophercloud.ServiceClient, metricID string) error {
+	currentTimeStamp := time.Now().UTC()
+	pastHourTimeStamp := currentTimeStamp.Add(-1 * time.Hour)
+	measuresToPush := []measures.MeasureToPush{
+		{
+			TimeStamp: currentTimeStamp,
+			Value:     100.5,
+		},
+		{
+			TimeStamp: pastHourTimeStamp,
+			Value:     500,
+		},
+	}
+	pushOpts := measures.PushOpts{
+		Measures: measuresToPush,
+	}
+
+	t.Logf("Attempting to push measures into a Gnocchi metric %s", metricID)
+
+	if err := measures.Push(client, metricID, pushOpts).ExtractErr(); err != nil && err.Error() != "EOF" {
+		return err
+	}
+
+	t.Logf("Successfully pushed measures into the Gnocchi metric %s", metricID)
+	return nil
+}

--- a/acceptance/gnocchi/metric/v1/measures_test.go
+++ b/acceptance/gnocchi/metric/v1/measures_test.go
@@ -19,10 +19,10 @@ func TestMeasuresCRUD(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to create a Gnocchi metric: %v", err)
 	}
-	// defer DeleteMetric(t, client, metric.ID)
+	defer DeleteMetric(t, client, metric.ID)
 
-	if err := PushMeasures(t, client, metric.ID); err != nil {
-		t.Fatalf("Unable to push measures into the Gnocchi metric: %v", err)
+	if err := CreateMeasures(t, client, metric.ID); err != nil {
+		t.Fatalf("Unable to create measures inside the Gnocchi metric: %v", err)
 	}
 
 	listOpts := measures.ListOpts{

--- a/acceptance/gnocchi/metric/v1/measures_test.go
+++ b/acceptance/gnocchi/metric/v1/measures_test.go
@@ -15,16 +15,19 @@ func TestMeasuresCRUD(t *testing.T) {
 		t.Fatalf("Unable to create a Gnocchi client: %v", err)
 	}
 
+	// Create a single metric to test Create measures request.
 	metric, err := CreateMetric(t, client)
 	if err != nil {
 		t.Fatalf("Unable to create a Gnocchi metric: %v", err)
 	}
 	defer DeleteMetric(t, client, metric.ID)
 
+	// Test Create measures request.
 	if err := CreateMeasures(t, client, metric.ID); err != nil {
 		t.Fatalf("Unable to create measures inside the Gnocchi metric: %v", err)
 	}
 
+	// Check created measures.
 	listOpts := measures.ListOpts{
 		Refresh: true,
 	}

--- a/acceptance/gnocchi/metric/v1/measures_test.go
+++ b/acceptance/gnocchi/metric/v1/measures_test.go
@@ -1,0 +1,42 @@
+// +build acceptance metric measures
+
+package v1
+
+import (
+	"testing"
+
+	"github.com/gophercloud/utils/acceptance/clients"
+	"github.com/gophercloud/utils/gnocchi/metric/v1/measures"
+)
+
+func TestMeasuresCRUD(t *testing.T) {
+	client, err := clients.NewGnocchiV1Client()
+	if err != nil {
+		t.Fatalf("Unable to create a Gnocchi client: %v", err)
+	}
+
+	metric, err := CreateMetric(t, client)
+	if err != nil {
+		t.Fatalf("Unable to create a Gnocchi metric: %v", err)
+	}
+	// defer DeleteMetric(t, client, metric.ID)
+
+	if err := PushMeasures(t, client, metric.ID); err != nil {
+		t.Fatalf("Unable to push measures into the Gnocchi metric: %v", err)
+	}
+
+	listOpts := measures.ListOpts{
+		Refresh: true,
+	}
+	allPages, err := measures.List(client, metric.ID, listOpts).AllPages()
+	if err != nil {
+		t.Fatalf("Unable to list measures of the metric %s: %v", metric.ID, err)
+	}
+
+	metricMeasures, err := measures.ExtractMeasures(allPages)
+	if err != nil {
+		t.Fatalf("Unable to extract measures: %v", metricMeasures)
+	}
+
+	t.Log(metricMeasures)
+}

--- a/gnocchi/metric/v1/measures/doc.go
+++ b/gnocchi/metric/v1/measures/doc.go
@@ -24,10 +24,10 @@ Example of Listing measures of a known metric
 		fmt.Printf("%+v\n", measure)
 	}
 
-Example of Pushing measures to a single metric
+Example of Creating measures inside a single metric
 
-	pushOpts := measures.PushOpts{
-		Measures: []measures.MeasureToPush{
+	createOpts := measures.CreateOpts{
+		Measures: []measures.MeasureOpts{
 			{
 				TimeStamp: time.Date(2018, 1, 18, 12, 31, 0, 0, time.UTC),
 				Value:     101.2,
@@ -39,7 +39,7 @@ Example of Pushing measures to a single metric
 		},
 	}
 	metricID := "9e5a6441-1044-4181-b66e-34e180753040"
-	if err := measures.Push(gnocchiClient, metricID, pushOpts).ExtractErr(); err != nil && err.Error() != "EOF" {
+	if err := measures.Create(gnocchiClient, metricID, createOpts).ExtractErr(); err != nil && err.Error() != "EOF" {
 		panic(err)
 	}
 */

--- a/gnocchi/metric/v1/measures/doc.go
+++ b/gnocchi/metric/v1/measures/doc.go
@@ -23,5 +23,24 @@ Example of Listing measures of a known metric
 	for _, measure := range allMeasures {
 		fmt.Printf("%+v\n", measure)
 	}
+
+Example of Pushing measures to a single metric
+
+	pushOpts := measures.PushOpts{
+		Measures: []measures.MeasureToPush{
+			{
+				TimeStamp: time.Date(2018, 1, 18, 12, 31, 0, 0, time.UTC),
+				Value:     101.2,
+			},
+			{
+				TimeStamp: time.Date(2018, 1, 18, 14, 32, 0, 0, time.UTC),
+				Value:     102,
+			},
+		},
+	}
+	metricID := "9e5a6441-1044-4181-b66e-34e180753040"
+	if err := measures.Push(gnocchiClient, metricID, pushOpts).ExtractErr(); err != nil && err.Error() != "EOF" {
+		panic(err)
+	}
 */
 package measures

--- a/gnocchi/metric/v1/measures/doc.go
+++ b/gnocchi/metric/v1/measures/doc.go
@@ -29,11 +29,11 @@ Example of Creating measures inside a single metric
 	createOpts := measures.CreateOpts{
 		Measures: []measures.MeasureOpts{
 			{
-				TimeStamp: time.Date(2018, 1, 18, 12, 31, 0, 0, time.UTC),
+				Timestamp: time.Date(2018, 1, 18, 12, 31, 0, 0, time.UTC),
 				Value:     101.2,
 			},
 			{
-				TimeStamp: time.Date(2018, 1, 18, 14, 32, 0, 0, time.UTC),
+				Timestamp: time.Date(2018, 1, 18, 14, 32, 0, 0, time.UTC),
 				Value:     102,
 			},
 		},

--- a/gnocchi/metric/v1/measures/requests.go
+++ b/gnocchi/metric/v1/measures/requests.go
@@ -130,7 +130,7 @@ func Create(client *gophercloud.ServiceClient, metricID string, opts CreateOptsB
 		r.Err = err
 		return
 	}
-	_, r.Err = client.Post(pushURL(client, metricID), b["measures"], &r.Body, &gophercloud.RequestOpts{
+	_, r.Err = client.Post(createURL(client, metricID), b["measures"], &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{202},
 		MoreHeaders: map[string]string{
 			"Accept": "application/json, */*",

--- a/gnocchi/metric/v1/measures/requests.go
+++ b/gnocchi/metric/v1/measures/requests.go
@@ -82,10 +82,10 @@ type CreateOptsBuilder interface {
 // MeasureOpts represents options of a single measure that can be created in the Gnocchi.
 type MeasureOpts struct {
 	// Timestamp represents a measure creation timestamp.
-	Timestamp time.Time
+	Timestamp time.Time `json:"-" required:"true"`
 
 	// Value represents a measure data value.
-	Value float64
+	Value float64 `json:"-" required:"true"`
 }
 
 // ToMap is a helper function to convert individual MeasureOpts structure into a sub-map.

--- a/gnocchi/metric/v1/measures/requests.go
+++ b/gnocchi/metric/v1/measures/requests.go
@@ -81,8 +81,8 @@ type CreateOptsBuilder interface {
 
 // MeasureOpts represents options of a single measure that can be created in the Gnocchi.
 type MeasureOpts struct {
-	// TimeStamp represents a measure creation timestamp.
-	TimeStamp time.Time
+	// Timestamp represents a measure creation timestamp.
+	Timestamp time.Time
 
 	// Value represents a measure data value.
 	Value float64
@@ -92,13 +92,13 @@ type MeasureOpts struct {
 func (opts MeasureOpts) ToMap() (map[string]interface{}, error) {
 	// Struct measureToCreate represents internal MeasureOpts variant with string timestamps.
 	type measureToCreate struct {
-		TimeStamp string  `json:"timestamp"`
+		Timestamp string  `json:"timestamp"`
 		Value     float64 `json:"value"`
 	}
 
 	// Convert exported MeasureOpts to its internal representation.
 	m := &measureToCreate{
-		TimeStamp: opts.TimeStamp.Format(gnocchi.RFC3339NanoNoTimezone),
+		Timestamp: opts.Timestamp.Format(gnocchi.RFC3339NanoNoTimezone),
 		Value:     opts.Value,
 	}
 	return gophercloud.BuildRequestBody(m, "")

--- a/gnocchi/metric/v1/measures/requests.go
+++ b/gnocchi/metric/v1/measures/requests.go
@@ -73,3 +73,70 @@ func List(c *gophercloud.ServiceClient, metricID string, opts ListOptsBuilder) p
 		return MeasurePage{pagination.SinglePageBase(r)}
 	})
 }
+
+// MeasureToPush represents a single measure that can be pushed into the Gnocchi API.
+type MeasureToPush struct {
+	// TimeStamp represents a timestamp of when measure is pushed into the Gnocchi.
+	TimeStamp time.Time
+
+	// Value represents a value of data that is pushed into the Gnocchi.
+	Value float64
+}
+
+// PushOptsBuilder is needed to add measures to the Push request.
+type PushOptsBuilder interface {
+	ToMeasurePushMap() (map[string]interface{}, error)
+}
+
+// PushOpts specifies a parameters for pushing measures into a single metric.
+type PushOpts struct {
+	// Measures is a set of measures that needs to be pushed to a single metric.
+	Measures []MeasureToPush
+}
+
+// ToMeasurePushMap constructs a request body from PushOpts.
+func (opts PushOpts) ToMeasurePushMap() (map[string]interface{}, error) {
+	// Struct measureToPush represents internal MeasureToPush variant with string timestamps.
+	type measureToPush struct {
+		TimeStamp string  `json:"timestamp"`
+		Value     float64 `json:"value"`
+	}
+	type pushOpts struct {
+		Measures []measureToPush
+	}
+
+	// Convert exported PushOpts to internal pushOpts variant that contains measures with string timestamps.
+	internalMeasures := make([]measureToPush, len(opts.Measures))
+	for i, m := range opts.Measures {
+		internalMeasures[i] = measureToPush{
+			TimeStamp: m.TimeStamp.Format(gnocchi.RFC3339NanoNoTimezone),
+			Value:     m.Value,
+		}
+	}
+	internalPushOpts := pushOpts{
+		Measures: internalMeasures,
+	}
+
+	b, err := gophercloud.BuildRequestBody(internalPushOpts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	return b, nil
+}
+
+// Push requests the creation of a new measures in the single Gnocchi metric.
+func Push(client *gophercloud.ServiceClient, metricID string, opts PushOptsBuilder) (r PushResult) {
+	b, err := opts.ToMeasurePushMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(pushURL(client, metricID), b["Measures"], &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+		MoreHeaders: map[string]string{
+			"Accept": "application/json, */*",
+		},
+	})
+	return
+}

--- a/gnocchi/metric/v1/measures/requests.go
+++ b/gnocchi/metric/v1/measures/requests.go
@@ -82,26 +82,22 @@ type CreateOptsBuilder interface {
 // MeasureOpts represents options of a single measure that can be created in the Gnocchi.
 type MeasureOpts struct {
 	// Timestamp represents a measure creation timestamp.
-	Timestamp time.Time `json:"-" required:"true"`
+	Timestamp *time.Time `json:"-" required:"true"`
 
 	// Value represents a measure data value.
-	Value float64 `json:"-" required:"true"`
+	Value float64 `json:"value" required:"true"`
 }
 
 // ToMap is a helper function to convert individual MeasureOpts structure into a sub-map.
 func (opts MeasureOpts) ToMap() (map[string]interface{}, error) {
-	// Struct measureToCreate represents internal MeasureOpts variant with string timestamps.
-	type measureToCreate struct {
-		Timestamp string  `json:"timestamp"`
-		Value     float64 `json:"value"`
+	b, err := gophercloud.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
 	}
-
-	// Convert exported MeasureOpts to its internal representation.
-	m := &measureToCreate{
-		Timestamp: opts.Timestamp.Format(gnocchi.RFC3339NanoNoTimezone),
-		Value:     opts.Value,
+	if opts.Timestamp != nil {
+		b["timestamp"] = opts.Timestamp.Format(gnocchi.RFC3339NanoNoTimezone)
 	}
-	return gophercloud.BuildRequestBody(m, "")
+	return b, nil
 }
 
 // CreateOpts specifies a parameters for creating measures for a single metric.

--- a/gnocchi/metric/v1/measures/results.go
+++ b/gnocchi/metric/v1/measures/results.go
@@ -7,8 +7,15 @@ import (
 
 	"github.com/gophercloud/utils/gnocchi"
 
+	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/pagination"
 )
+
+// PushResult represents the result of a push operation. Call its
+// ExtractErr method to determine if the request succeeded or failed.
+type PushResult struct {
+	gophercloud.ErrResult
+}
 
 // Measure is an datapoint thats is composed with a timestamp and a value.
 type Measure struct {

--- a/gnocchi/metric/v1/measures/results.go
+++ b/gnocchi/metric/v1/measures/results.go
@@ -11,9 +11,9 @@ import (
 	"github.com/gophercloud/gophercloud/pagination"
 )
 
-// PushResult represents the result of a push operation. Call its
+// CreateResult represents the result of a create operation. Call its
 // ExtractErr method to determine if the request succeeded or failed.
-type PushResult struct {
+type CreateResult struct {
 	gophercloud.ErrResult
 }
 

--- a/gnocchi/metric/v1/measures/testing/requests_test.go
+++ b/gnocchi/metric/v1/measures/testing/requests_test.go
@@ -65,14 +65,16 @@ func TestCreateMeasures(t *testing.T) {
 		w.WriteHeader(http.StatusAccepted)
 	})
 
+	firstMeasureTimestamp := time.Date(2018, 1, 18, 12, 31, 0, 0, time.UTC)
+	secondMeasureTimestamp := time.Date(2018, 1, 18, 14, 32, 0, 0, time.UTC)
 	createOpts := measures.CreateOpts{
 		Measures: []measures.MeasureOpts{
 			{
-				Timestamp: time.Date(2018, 1, 18, 12, 31, 0, 0, time.UTC),
+				Timestamp: &firstMeasureTimestamp,
 				Value:     101.2,
 			},
 			{
-				Timestamp: time.Date(2018, 1, 18, 14, 32, 0, 0, time.UTC),
+				Timestamp: &secondMeasureTimestamp,
 				Value:     102,
 			},
 		},

--- a/gnocchi/metric/v1/measures/testing/requests_test.go
+++ b/gnocchi/metric/v1/measures/testing/requests_test.go
@@ -68,11 +68,11 @@ func TestCreateMeasures(t *testing.T) {
 	createOpts := measures.CreateOpts{
 		Measures: []measures.MeasureOpts{
 			{
-				TimeStamp: time.Date(2018, 1, 18, 12, 31, 0, 0, time.UTC),
+				Timestamp: time.Date(2018, 1, 18, 12, 31, 0, 0, time.UTC),
 				Value:     101.2,
 			},
 			{
-				TimeStamp: time.Date(2018, 1, 18, 14, 32, 0, 0, time.UTC),
+				Timestamp: time.Date(2018, 1, 18, 14, 32, 0, 0, time.UTC),
 				Value:     102,
 			},
 		},

--- a/gnocchi/metric/v1/measures/testing/requests_test.go
+++ b/gnocchi/metric/v1/measures/testing/requests_test.go
@@ -53,7 +53,7 @@ func TestListMeasures(t *testing.T) {
 	th.CheckEquals(t, 1, pages)
 }
 
-func TestPushMeasures(t *testing.T) {
+func TestCreateMeasures(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 
@@ -65,8 +65,8 @@ func TestPushMeasures(t *testing.T) {
 		w.WriteHeader(http.StatusAccepted)
 	})
 
-	pushOpts := measures.PushOpts{
-		Measures: []measures.MeasureToPush{
+	createOpts := measures.CreateOpts{
+		Measures: []measures.MeasureOpts{
 			{
 				TimeStamp: time.Date(2018, 1, 18, 12, 31, 0, 0, time.UTC),
 				Value:     101.2,
@@ -77,7 +77,7 @@ func TestPushMeasures(t *testing.T) {
 			},
 		},
 	}
-	res := measures.Push(fake.ServiceClient(), "9e5a6441-1044-4181-b66e-34e180753040", pushOpts)
+	res := measures.Create(fake.ServiceClient(), "9e5a6441-1044-4181-b66e-34e180753040", createOpts)
 	if res.Err.Error() == "EOF" {
 		res.Err = nil
 	}

--- a/gnocchi/metric/v1/measures/urls.go
+++ b/gnocchi/metric/v1/measures/urls.go
@@ -11,3 +11,7 @@ func resourceURL(c *gophercloud.ServiceClient, metricID string) string {
 func listURL(c *gophercloud.ServiceClient, metricID string) string {
 	return resourceURL(c, metricID)
 }
+
+func pushURL(c *gophercloud.ServiceClient, metricID string) string {
+	return resourceURL(c, metricID)
+}

--- a/gnocchi/metric/v1/measures/urls.go
+++ b/gnocchi/metric/v1/measures/urls.go
@@ -12,6 +12,6 @@ func listURL(c *gophercloud.ServiceClient, metricID string) string {
 	return resourceURL(c, metricID)
 }
 
-func pushURL(c *gophercloud.ServiceClient, metricID string) string {
+func createURL(c *gophercloud.ServiceClient, metricID string) string {
 	return resourceURL(c, metricID)
 }


### PR DESCRIPTION
Add Gnocchi measures create request with tests and documentation.

That request implements pushing measures to a single metric, without batching.
Docs reference: [rest#push](https://gnocchi.xyz/rest.html#push)

The same command with Gnocchi CLI is done with:
`gnocchi measures add`

For [#698](https://github.com/gophercloud/gophercloud/issues/698)

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

API:
- https://github.com/gnocchixyz/gnocchi/blob/stable/4.1/gnocchi/rest/api.py#L454

Storage code depends on a driver that is used for saving measures:
- Ceph: https://github.com/gnocchixyz/gnocchi/blob/stable/4.1/gnocchi/incoming/ceph.py#L193
- Redis: https://github.com/gnocchixyz/gnocchi/blob/stable/4.1/gnocchi/incoming/redis.py#L107
- File: https://github.com/gnocchixyz/gnocchi/blob/stable/4.1/gnocchi/incoming/file.py#L168
- S3: https://github.com/gnocchixyz/gnocchi/blob/stable/4.1/gnocchi/incoming/s3.py#L161
- Swift: https://github.com/gnocchixyz/gnocchi/blob/stable/4.1/gnocchi/incoming/swift.py#L100