### PR TITLE
Implement Gnocchi measures batch create via metrics IDs

### DIFF
--- a/acceptance/gnocchi/metric/v1/measures.go
+++ b/acceptance/gnocchi/metric/v1/measures.go
@@ -47,11 +47,11 @@ func MeasuresBatchCreateMetrics(t *testing.T, client *gophercloud.ServiceClient,
 	pastHourTimestamp := currentTimestamp.Add(-1 * time.Hour)
 	currentValue := float64(tools.RandomInt(100, 200))
 	pastHourValue := float64(tools.RandomInt(500, 600))
-	batchMetricsOpts := make([]measures.MetricOpts, len(metricIDs))
+	createOpts := make([]measures.MetricOpts, len(metricIDs))
 
 	// Populate batch options with provided metric IDs and generated values.
 	for i, m := range metricIDs {
-		batchMetricsOpts[i] = measures.MetricOpts{
+		createOpts[i] = measures.MetricOpts{
 			ID: m,
 			Measures: []measures.MeasureOpts{
 				{
@@ -64,9 +64,6 @@ func MeasuresBatchCreateMetrics(t *testing.T, client *gophercloud.ServiceClient,
 				},
 			},
 		}
-	}
-	createOpts := measures.BatchCreateMetricsOpts{
-		BatchMetricsOpts: batchMetricsOpts,
 	}
 
 	t.Logf("Attempting to create measures inside Gnocchi metrics via batch request")

--- a/acceptance/gnocchi/metric/v1/measures.go
+++ b/acceptance/gnocchi/metric/v1/measures.go
@@ -43,19 +43,19 @@ func CreateMeasures(t *testing.T, client *gophercloud.ServiceClient, metricID st
 // CreateBatchMetricsMeasures will create measures inside different metrics via batch request. An error will be returned if the
 // measures could not be created.
 func CreateBatchMetricsMeasures(t *testing.T, client *gophercloud.ServiceClient, metricIDs ...string) error {
-	currentTimeStamp := time.Now().UTC()
-	pastHourTimeStamp := currentTimeStamp.Add(-1 * time.Hour)
+	currentTimestamp := time.Now().UTC()
+	pastHourTimestamp := currentTimestamp.Add(-1 * time.Hour)
 	currentValue := float64(tools.RandomInt(100, 200))
 	pastHourValue := float64(tools.RandomInt(500, 600))
 	batchOpts := make(map[string][]measures.MeasureOpts)
 	for _, m := range metricIDs {
 		batchOpts[m] = []measures.MeasureOpts{
 			{
-				TimeStamp: currentTimeStamp,
+				Timestamp: &currentTimestamp,
 				Value:     currentValue,
 			},
 			{
-				TimeStamp: pastHourTimeStamp,
+				Timestamp: &pastHourTimestamp,
 				Value:     pastHourValue,
 			},
 		}

--- a/acceptance/gnocchi/metric/v1/measures.go
+++ b/acceptance/gnocchi/metric/v1/measures.go
@@ -40,9 +40,9 @@ func CreateMeasures(t *testing.T, client *gophercloud.ServiceClient, metricID st
 	return nil
 }
 
-// CreateBatchMetricsMeasures will create measures inside different metrics via batch request. An error will be returned if the
+// BatchMetricsMeasures will create measures inside different metrics via batch request. An error will be returned if the
 // measures could not be created.
-func CreateBatchMetricsMeasures(t *testing.T, client *gophercloud.ServiceClient, metricIDs ...string) error {
+func BatchMetricsMeasures(t *testing.T, client *gophercloud.ServiceClient, metricIDs ...string) error {
 	currentTimestamp := time.Now().UTC()
 	pastHourTimestamp := currentTimestamp.Add(-1 * time.Hour)
 	currentValue := float64(tools.RandomInt(100, 200))
@@ -60,13 +60,13 @@ func CreateBatchMetricsMeasures(t *testing.T, client *gophercloud.ServiceClient,
 			},
 		}
 	}
-	createOpts := measures.CreateBatchMetricsOpts{
+	createOpts := measures.BatchMetricsOpts{
 		BatchOpts: batchOpts,
 	}
 
 	t.Logf("Attempting to create measures inside Gnocchi metrics via batch request")
 
-	if err := measures.CreateBatchMetrics(client, createOpts).ExtractErr(); err != nil && err.Error() != "EOF" {
+	if err := measures.BatchMetrics(client, createOpts).ExtractErr(); err != nil && err.Error() != "EOF" {
 		return err
 	}
 

--- a/acceptance/gnocchi/metric/v1/measures.go
+++ b/acceptance/gnocchi/metric/v1/measures.go
@@ -40,33 +40,38 @@ func CreateMeasures(t *testing.T, client *gophercloud.ServiceClient, metricID st
 	return nil
 }
 
-// BatchMetricsMeasures will create measures inside different metrics via batch request. An error will be returned if the
-// measures could not be created.
-func BatchMetricsMeasures(t *testing.T, client *gophercloud.ServiceClient, metricIDs ...string) error {
+// MeasuresBatchCreateMetrics will create measures inside different metrics via batch request.
+// An error will be returned if measures could not be created.
+func MeasuresBatchCreateMetrics(t *testing.T, client *gophercloud.ServiceClient, metricIDs ...string) error {
 	currentTimestamp := time.Now().UTC()
 	pastHourTimestamp := currentTimestamp.Add(-1 * time.Hour)
 	currentValue := float64(tools.RandomInt(100, 200))
 	pastHourValue := float64(tools.RandomInt(500, 600))
-	batchOpts := make(map[string][]measures.MeasureOpts)
-	for _, m := range metricIDs {
-		batchOpts[m] = []measures.MeasureOpts{
-			{
-				Timestamp: &currentTimestamp,
-				Value:     currentValue,
-			},
-			{
-				Timestamp: &pastHourTimestamp,
-				Value:     pastHourValue,
+	batchMetricsOpts := make([]measures.MetricOpts, len(metricIDs))
+
+	// Populate batch options with provided metric IDs and generated values.
+	for i, m := range metricIDs {
+		batchMetricsOpts[i] = measures.MetricOpts{
+			ID: m,
+			Measures: []measures.MeasureOpts{
+				{
+					Timestamp: &currentTimestamp,
+					Value:     currentValue,
+				},
+				{
+					Timestamp: &pastHourTimestamp,
+					Value:     pastHourValue,
+				},
 			},
 		}
 	}
-	createOpts := measures.BatchMetricsOpts{
-		BatchOpts: batchOpts,
+	createOpts := measures.BatchCreateMetricsOpts{
+		BatchMetricsOpts: batchMetricsOpts,
 	}
 
 	t.Logf("Attempting to create measures inside Gnocchi metrics via batch request")
 
-	if err := measures.BatchMetrics(client, createOpts).ExtractErr(); err != nil && err.Error() != "EOF" {
+	if err := measures.BatchCreateMetrics(client, createOpts).ExtractErr(); err != nil && err.Error() != "EOF" {
 		return err
 	}
 

--- a/acceptance/gnocchi/metric/v1/measures_test.go
+++ b/acceptance/gnocchi/metric/v1/measures_test.go
@@ -44,13 +44,13 @@ func TestMeasuresCRUD(t *testing.T) {
 	t.Log(metricMeasures)
 }
 
-func TestMeasuresBatchMetrics(t *testing.T) {
+func TestMeasuresBatchCreateMetrics(t *testing.T) {
 	client, err := clients.NewGnocchiV1Client()
 	if err != nil {
 		t.Fatalf("Unable to create a Gnocchi client: %v", err)
 	}
 
-	// Create a couple of metrics to test BatchMetrics requets.
+	// Create a couple of metrics to test BatchCreateMetrics requets.
 	metricToBatchOne, err := CreateMetric(t, client)
 	if err != nil {
 		t.Fatalf("Unable to create a Gnocchi metric: %v", err)
@@ -64,7 +64,7 @@ func TestMeasuresBatchMetrics(t *testing.T) {
 	defer DeleteMetric(t, client, metricToBatchTwo.ID)
 
 	// Test create batch request based on metrics IDs.
-	if err := BatchMetricsMeasures(t, client, metricToBatchOne.ID, metricToBatchTwo.ID); err != nil {
+	if err := MeasuresBatchCreateMetrics(t, client, metricToBatchOne.ID, metricToBatchTwo.ID); err != nil {
 		t.Fatalf("Unable to create measures inside Gnocchi metrics: %v", err)
 	}
 
@@ -81,7 +81,7 @@ func TestMeasuresBatchMetrics(t *testing.T) {
 		t.Fatalf("Unable to extract measures: %v", metricOneMeasures)
 	}
 
-	t.Log(metricOneMeasures)
+	t.Logf("Measures for the metric: %s, %v", metricToBatchOne.ID, metricOneMeasures)
 
 	allPagesMetricTwo, err := measures.List(client, metricToBatchTwo.ID, listOpts).AllPages()
 	if err != nil {
@@ -92,5 +92,5 @@ func TestMeasuresBatchMetrics(t *testing.T) {
 		t.Fatalf("Unable to extract measures: %v", metricTwoMeasures)
 	}
 
-	t.Log(metricTwoMeasures)
+	t.Logf("Measures for the metric: %s, %v", metricToBatchTwo.ID, metricTwoMeasures)
 }

--- a/acceptance/gnocchi/metric/v1/measures_test.go
+++ b/acceptance/gnocchi/metric/v1/measures_test.go
@@ -44,13 +44,13 @@ func TestMeasuresCRUD(t *testing.T) {
 	t.Log(metricMeasures)
 }
 
-func TestBatchMetricsMeasuresCreation(t *testing.T) {
+func TestMeasuresBatchMetrics(t *testing.T) {
 	client, err := clients.NewGnocchiV1Client()
 	if err != nil {
 		t.Fatalf("Unable to create a Gnocchi client: %v", err)
 	}
 
-	// Create a couple of metrics to test CreateBatchMetrics requets.
+	// Create a couple of metrics to test BatchMetrics requets.
 	metricToBatchOne, err := CreateMetric(t, client)
 	if err != nil {
 		t.Fatalf("Unable to create a Gnocchi metric: %v", err)
@@ -64,11 +64,11 @@ func TestBatchMetricsMeasuresCreation(t *testing.T) {
 	defer DeleteMetric(t, client, metricToBatchTwo.ID)
 
 	// Test create batch request based on metrics IDs.
-	if err := CreateBatchMetricsMeasures(t, client, metricToBatchOne.ID, metricToBatchTwo.ID); err != nil {
+	if err := BatchMetricsMeasures(t, client, metricToBatchOne.ID, metricToBatchTwo.ID); err != nil {
 		t.Fatalf("Unable to create measures inside Gnocchi metrics: %v", err)
 	}
 
-	// Check measures of each metric after the CreateBatchMetrics request.
+	// Check measures of each metric after the BatchMetrics request.
 	listOpts := measures.ListOpts{
 		Refresh: true,
 	}

--- a/gnocchi/metric/v1/measures/doc.go
+++ b/gnocchi/metric/v1/measures/doc.go
@@ -47,31 +47,37 @@ Example of Creating measures inside different metrics via metric ID references i
 
 	currentTimestamp := time.Now().UTC()
 	pastHourTimestamp := currentTimestamp.Add(-1 * time.Hour)
-	createOpts := measures.BatchMetricsOpts{
-		BatchOpts: map[string][]measures.MeasureOpts{
-			"777a01d6-4694-49cb-b86a-5ba9fd4e609e": []measures.MeasureOpts{
-				{
-					Timestamp: &currentTimestamp,
-					Value:     200.5,
-				},
-				{
-					Timestamp: &pastHourTimestamp,
-					Value:     300,
+	createOpts := measures.BatchCreateMetricsOpts{
+		BatchMetricsOpts: []measures.MetricOpts{
+			{
+				ID: "777a01d6-4694-49cb-b86a-5ba9fd4e609e",
+				Measures: []measures.MeasureOpts{
+					{
+						Timestamp: &currentTimestamp,
+						Value:     200,
+					},
+					{
+						Timestamp: &pastHourTimestamp,
+						Value:     300,
+					},
 				},
 			},
-			"6dbc97c5-bfdf-47a2-b184-02e7fa348d21": []measures.MeasureOpts{
-				{
-					Timestamp: &currentTimestamp,
-					Value:     111.1,
-				},
-				{
-					Timestamp: &pastHourTimestamp,
-					Value:     222.22,
+			{
+				ID: "6dbc97c5-bfdf-47a2-b184-02e7fa348d21",
+				Measures: []measures.MeasureOpts{
+					{
+						Timestamp: &currentTimestamp,
+						Value:     111,
+					},
+					{
+						Timestamp: &pastHourTimestamp,
+						Value:     222,
+					},
 				},
 			},
 		},
 	}
-	if err := measures.BatchMetrics(gnocchiClient, createOpts).ExtractErr(); err != nil && err.Error() != "EOF" {
+	if err := measures.BatchCreateMetrics(gnocchiClient, createOpts).ExtractErr(); err != nil && err.Error() != "EOF" {
 		panic(err)
 	}
 */

--- a/gnocchi/metric/v1/measures/doc.go
+++ b/gnocchi/metric/v1/measures/doc.go
@@ -45,25 +45,27 @@ Example of Creating measures inside a single metric
 
 Example of Creating measures inside different metrics via metric ID references in one request
 
+	currentTimeStamp := time.Now().UTC()
+	pastHourTimestamp := currentTimestamp.Add(-1 * time.Hour)
 	createOpts := measures.CreateBatchMetricsOpts{
 		BatchOpts: map[string][]measures.MeasureOpts{
 			"777a01d6-4694-49cb-b86a-5ba9fd4e609e": []measures.MeasureOpts{
 				{
-					TimeStamp: time.Date(2018, 1, 10, 01, 00, 0, 0, time.UTC),
+					TimeStamp: &currentTimeStamp,
 					Value:     200.5,
 				},
 				{
-					TimeStamp: time.Date(2018, 1, 10, 01, 30, 0, 0, time.UTC),
+					TimeStamp: &pastHourTimestamp,
 					Value:     300,
 				},
 			},
 			"6dbc97c5-bfdf-47a2-b184-02e7fa348d21": []measures.MeasureOpts{
 				{
-					TimeStamp: time.Date(2018, 1, 10, 01, 00, 0, 0, time.UTC),
+					TimeStamp: &currentTimeStamp,
 					Value:     111.1,
 				},
 				{
-					TimeStamp: time.Date(2018, 1, 10, 02, 45, 0, 0, time.UTC),
+					TimeStamp: &pastHourTimestamp,
 					Value:     222.22,
 				},
 			},

--- a/gnocchi/metric/v1/measures/doc.go
+++ b/gnocchi/metric/v1/measures/doc.go
@@ -47,7 +47,7 @@ Example of Creating measures inside different metrics via metric ID references i
 
 	currentTimestamp := time.Now().UTC()
 	pastHourTimestamp := currentTimestamp.Add(-1 * time.Hour)
-	createOpts := measures.CreateBatchMetricsOpts{
+	createOpts := measures.BatchMetricsOpts{
 		BatchOpts: map[string][]measures.MeasureOpts{
 			"777a01d6-4694-49cb-b86a-5ba9fd4e609e": []measures.MeasureOpts{
 				{
@@ -71,7 +71,7 @@ Example of Creating measures inside different metrics via metric ID references i
 			},
 		},
 	}
-	if err := measures.CreateBatchMetrics(gnocchiClient, createOpts).ExtractErr(); err != nil && err.Error() != "EOF" {
+	if err := measures.BatchMetrics(gnocchiClient, createOpts).ExtractErr(); err != nil && err.Error() != "EOF" {
 		panic(err)
 	}
 */

--- a/gnocchi/metric/v1/measures/doc.go
+++ b/gnocchi/metric/v1/measures/doc.go
@@ -48,31 +48,29 @@ Example of Creating measures inside different metrics via metric ID references i
 	currentTimestamp := time.Now().UTC()
 	pastHourTimestamp := currentTimestamp.Add(-1 * time.Hour)
 	createOpts := measures.BatchCreateMetricsOpts{
-		BatchMetricsOpts: []measures.MetricOpts{
-			{
-				ID: "777a01d6-4694-49cb-b86a-5ba9fd4e609e",
-				Measures: []measures.MeasureOpts{
-					{
-						Timestamp: &currentTimestamp,
-						Value:     200,
-					},
-					{
-						Timestamp: &pastHourTimestamp,
-						Value:     300,
-					},
+		{
+			ID: "777a01d6-4694-49cb-b86a-5ba9fd4e609e",
+			Measures: []measures.MeasureOpts{
+				{
+					Timestamp: &currentTimestamp,
+					Value:     200,
+				},
+				{
+					Timestamp: &pastHourTimestamp,
+					Value:     300,
 				},
 			},
-			{
-				ID: "6dbc97c5-bfdf-47a2-b184-02e7fa348d21",
-				Measures: []measures.MeasureOpts{
-					{
-						Timestamp: &currentTimestamp,
-						Value:     111,
-					},
-					{
-						Timestamp: &pastHourTimestamp,
-						Value:     222,
-					},
+		},
+		{
+			ID: "6dbc97c5-bfdf-47a2-b184-02e7fa348d21",
+			Measures: []measures.MeasureOpts{
+				{
+					Timestamp: &currentTimestamp,
+					Value:     111,
+				},
+				{
+					Timestamp: &pastHourTimestamp,
+					Value:     222,
 				},
 			},
 		},

--- a/gnocchi/metric/v1/measures/doc.go
+++ b/gnocchi/metric/v1/measures/doc.go
@@ -42,5 +42,35 @@ Example of Creating measures inside a single metric
 	if err := measures.Create(gnocchiClient, metricID, createOpts).ExtractErr(); err != nil && err.Error() != "EOF" {
 		panic(err)
 	}
+
+Example of Creating measures inside different metrics via metric ID references in one request
+
+	createOpts := measures.CreateBatchMetricsOpts{
+		BatchOpts: map[string][]measures.MeasureOpts{
+			"777a01d6-4694-49cb-b86a-5ba9fd4e609e": []measures.MeasureOpts{
+				{
+					TimeStamp: time.Date(2018, 1, 10, 01, 00, 0, 0, time.UTC),
+					Value:     200.5,
+				},
+				{
+					TimeStamp: time.Date(2018, 1, 10, 01, 30, 0, 0, time.UTC),
+					Value:     300,
+				},
+			},
+			"6dbc97c5-bfdf-47a2-b184-02e7fa348d21": []measures.MeasureOpts{
+				{
+					TimeStamp: time.Date(2018, 1, 10, 01, 00, 0, 0, time.UTC),
+					Value:     111.1,
+				},
+				{
+					TimeStamp: time.Date(2018, 1, 10, 02, 45, 0, 0, time.UTC),
+					Value:     222.22,
+				},
+			},
+		},
+	}
+	if err := measures.CreateBatchMetrics(gnocchiClient, createOpts).ExtractErr(); err != nil && err.Error() != "EOF" {
+		panic(err)
+	}
 */
 package measures

--- a/gnocchi/metric/v1/measures/doc.go
+++ b/gnocchi/metric/v1/measures/doc.go
@@ -45,27 +45,27 @@ Example of Creating measures inside a single metric
 
 Example of Creating measures inside different metrics via metric ID references in one request
 
-	currentTimeStamp := time.Now().UTC()
+	currentTimestamp := time.Now().UTC()
 	pastHourTimestamp := currentTimestamp.Add(-1 * time.Hour)
 	createOpts := measures.CreateBatchMetricsOpts{
 		BatchOpts: map[string][]measures.MeasureOpts{
 			"777a01d6-4694-49cb-b86a-5ba9fd4e609e": []measures.MeasureOpts{
 				{
-					TimeStamp: &currentTimeStamp,
+					Timestamp: &currentTimestamp,
 					Value:     200.5,
 				},
 				{
-					TimeStamp: &pastHourTimestamp,
+					Timestamp: &pastHourTimestamp,
 					Value:     300,
 				},
 			},
 			"6dbc97c5-bfdf-47a2-b184-02e7fa348d21": []measures.MeasureOpts{
 				{
-					TimeStamp: &currentTimeStamp,
+					Timestamp: &currentTimestamp,
 					Value:     111.1,
 				},
 				{
-					TimeStamp: &pastHourTimestamp,
+					Timestamp: &pastHourTimestamp,
 					Value:     222.22,
 				},
 			},

--- a/gnocchi/metric/v1/measures/requests.go
+++ b/gnocchi/metric/v1/measures/requests.go
@@ -158,16 +158,16 @@ func (opts CreateBatchMetricsOpts) ToMeasureCreateBatchMetricsMap() (map[string]
 	batchOpts := make(map[string][]measureOpts)
 
 	// Populate batchOpts.
-	for k, v := range opts.BatchOpts {
-		measures = make([]measureOpts, len(v))
-		for i, m := range v {
-			measureMap, err := m.ToMap()
+	for metricID, metricMeasures := range opts.BatchOpts {
+		measures = make([]measureOpts, len(metricMeasures))
+		for i, measure := range metricMeasures {
+			measureMap, err := measure.ToMap()
 			if err != nil {
 				return nil, err
 			}
 			measures[i] = measureMap
 		}
-		batchOpts[k] = measures
+		batchOpts[metricID] = measures
 	}
 
 	return map[string]interface{}{"batchMeasures": batchOpts}, nil

--- a/gnocchi/metric/v1/measures/requests.go
+++ b/gnocchi/metric/v1/measures/requests.go
@@ -137,7 +137,7 @@ func Create(client *gophercloud.ServiceClient, metricID string, opts CreateOptsB
 
 // BatchCreateMetricsOptsBuilder is needed to add measures to the BatchCreateMetrics request.
 type BatchCreateMetricsOptsBuilder interface {
-	ToBatchCreateMetricsMap() (map[string]interface{}, error)
+	ToMeasuresBatchCreateMetricsMap() (map[string]interface{}, error)
 }
 
 // BatchCreateMetricsOpts specifies a parameters for creating measures for different metrics in a single request.
@@ -171,8 +171,8 @@ func (opts MetricOpts) ToMap() (map[string]interface{}, error) {
 	return metricOpts, nil
 }
 
-// ToBatchCreateMetricsMap constructs a request body from BatchCreateMetricsOpts.
-func (opts BatchCreateMetricsOpts) ToBatchCreateMetricsMap() (map[string]interface{}, error) {
+// ToMeasuresBatchCreateMetricsMap constructs a request body from BatchCreateMetricsOpts.
+func (opts BatchCreateMetricsOpts) ToMeasuresBatchCreateMetricsMap() (map[string]interface{}, error) {
 	// batchCreateMetricsOpts is an internal representation of the BatchCreateMetricsOpts struct.
 	batchCreateMetricsOpts := make(map[string]interface{})
 
@@ -191,7 +191,7 @@ func (opts BatchCreateMetricsOpts) ToBatchCreateMetricsMap() (map[string]interfa
 
 // BatchCreateMetrics requests the creation of a new measures for different metrics.
 func BatchCreateMetrics(client *gophercloud.ServiceClient, opts BatchCreateMetricsOpts) (r BatchCreateMetricsResult) {
-	b, err := opts.ToBatchCreateMetricsMap()
+	b, err := opts.ToMeasuresBatchCreateMetricsMap()
 	if err != nil {
 		r.Err = err
 		return

--- a/gnocchi/metric/v1/measures/requests.go
+++ b/gnocchi/metric/v1/measures/requests.go
@@ -141,9 +141,7 @@ type BatchCreateMetricsOptsBuilder interface {
 }
 
 // BatchCreateMetricsOpts specifies a parameters for creating measures for different metrics in a single request.
-type BatchCreateMetricsOpts struct {
-	BatchMetricsOpts []MetricOpts
-}
+type BatchCreateMetricsOpts []MetricOpts
 
 // MetricOpts represents measures of a single metric of the BatchCreateMetrics request.
 type MetricOpts struct {
@@ -176,7 +174,7 @@ func (opts BatchCreateMetricsOpts) ToMeasuresBatchCreateMetricsMap() (map[string
 	// batchCreateMetricsOpts is an internal representation of the BatchCreateMetricsOpts struct.
 	batchCreateMetricsOpts := make(map[string]interface{})
 
-	for _, metricOpts := range opts.BatchMetricsOpts {
+	for _, metricOpts := range opts {
 		metricOptsMap, err := metricOpts.ToMap()
 		if err != nil {
 			return nil, err

--- a/gnocchi/metric/v1/measures/requests.go
+++ b/gnocchi/metric/v1/measures/requests.go
@@ -135,19 +135,19 @@ func Create(client *gophercloud.ServiceClient, metricID string, opts CreateOptsB
 	return
 }
 
-// CreateBatchMetricsOptsBuilder is needed to add measures to the CreateBatchMetrics request.
-type CreateBatchMetricsOptsBuilder interface {
-	ToMeasureCreateBatchMetricsMap() (map[string]interface{}, error)
+// BatchMetricsOptsBuilder is needed to add measures to the BatchMetrics request.
+type BatchMetricsOptsBuilder interface {
+	ToMeasureBatchMetricsMap() (map[string]interface{}, error)
 }
 
-// CreateBatchMetricsOpts specifies a parameters for creating measures for different metrics in a single request.
-type CreateBatchMetricsOpts struct {
+// BatchMetricsOpts specifies a parameters for creating measures for different metrics in a single request.
+type BatchMetricsOpts struct {
 	// BatchOpts is a map of metric ids and corresponding measures that needs to be created.
 	BatchOpts map[string][]MeasureOpts
 }
 
-// ToMeasureCreateBatchMetricsMap constructs a request body from CreateBatchMetricsOpts.
-func (opts CreateBatchMetricsOpts) ToMeasureCreateBatchMetricsMap() (map[string]interface{}, error) {
+// ToMeasureBatchMetricsMap constructs a request body from BatchMetricsOpts.
+func (opts BatchMetricsOpts) ToMeasureBatchMetricsMap() (map[string]interface{}, error) {
 	// measures is an internal map representation of the MeasureOpts struct.
 	type measureOpts map[string]interface{}
 
@@ -173,15 +173,15 @@ func (opts CreateBatchMetricsOpts) ToMeasureCreateBatchMetricsMap() (map[string]
 	return map[string]interface{}{"batchMeasures": batchOpts}, nil
 }
 
-// CreateBatchMetrics requests the creation of a new measures for different metrics.
-func CreateBatchMetrics(client *gophercloud.ServiceClient, opts CreateBatchMetricsOptsBuilder) (r CreateBatchMetricsResult) {
-	b, err := opts.ToMeasureCreateBatchMetricsMap()
+// BatchMetrics requests the creation of a new measures for different metrics.
+func BatchMetrics(client *gophercloud.ServiceClient, opts BatchMetricsOptsBuilder) (r BatchMetricsResult) {
+	b, err := opts.ToMeasureBatchMetricsMap()
 	if err != nil {
 		r.Err = err
 		return
 	}
 
-	_, r.Err = client.Post(createBatchMetricsURL(client), b["batchMeasures"], &r.Body, &gophercloud.RequestOpts{
+	_, r.Err = client.Post(batchMetricsURL(client), b["batchMeasures"], &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{202},
 		MoreHeaders: map[string]string{
 			"Accept": "application/json, */*",

--- a/gnocchi/metric/v1/measures/results.go
+++ b/gnocchi/metric/v1/measures/results.go
@@ -17,6 +17,12 @@ type CreateResult struct {
 	gophercloud.ErrResult
 }
 
+// CreateBatchMetricsResult represents the result of a create batch operation. Call its
+// ExtractErr method to determine if the request succeeded or failed.
+type CreateBatchMetricsResult struct {
+	gophercloud.ErrResult
+}
+
 // Measure is an datapoint thats is composed with a timestamp and a value.
 type Measure struct {
 	// Timestamp represents a timestamp of when measure was pushed into the Gnocchi.

--- a/gnocchi/metric/v1/measures/results.go
+++ b/gnocchi/metric/v1/measures/results.go
@@ -17,9 +17,9 @@ type CreateResult struct {
 	gophercloud.ErrResult
 }
 
-// CreateBatchMetricsResult represents the result of a create batch operation. Call its
+// BatchMetricsResult represents the result of a create batch operation. Call its
 // ExtractErr method to determine if the request succeeded or failed.
-type CreateBatchMetricsResult struct {
+type BatchMetricsResult struct {
 	gophercloud.ErrResult
 }
 

--- a/gnocchi/metric/v1/measures/results.go
+++ b/gnocchi/metric/v1/measures/results.go
@@ -17,9 +17,9 @@ type CreateResult struct {
 	gophercloud.ErrResult
 }
 
-// BatchMetricsResult represents the result of a create batch operation. Call its
+// BatchCreateMetricsResult represents the result of a batch create metrics operation. Call its
 // ExtractErr method to determine if the request succeeded or failed.
-type BatchMetricsResult struct {
+type BatchCreateMetricsResult struct {
 	gophercloud.ErrResult
 }
 

--- a/gnocchi/metric/v1/measures/testing/requests_test.go
+++ b/gnocchi/metric/v1/measures/testing/requests_test.go
@@ -100,7 +100,7 @@ func TestCreateBatchMetricMeasures(t *testing.T) {
 
 	firstTimestamp := time.Date(2018, 1, 10, 01, 00, 0, 0, time.UTC)
 	secondTimestamp := time.Date(2018, 1, 10, 02, 45, 0, 0, time.UTC)
-	createOpts := measures.CreateBatchMetricsOpts{
+	createOpts := measures.BatchMetricsOpts{
 		BatchOpts: map[string][]measures.MeasureOpts{
 			"777a01d6-4694-49cb-b86a-5ba9fd4e609e": []measures.MeasureOpts{
 				{
@@ -124,7 +124,7 @@ func TestCreateBatchMetricMeasures(t *testing.T) {
 			},
 		},
 	}
-	res := measures.CreateBatchMetrics(fake.ServiceClient(), createOpts)
+	res := measures.BatchMetrics(fake.ServiceClient(), createOpts)
 	if res.Err.Error() == "EOF" {
 		res.Err = nil
 	}

--- a/gnocchi/metric/v1/measures/testing/requests_test.go
+++ b/gnocchi/metric/v1/measures/testing/requests_test.go
@@ -86,7 +86,7 @@ func TestCreateMeasures(t *testing.T) {
 	th.AssertNoErr(t, res.Err)
 }
 
-func TestCreateBatchMetricMeasures(t *testing.T) {
+func TestBatchCreateMetrics(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 
@@ -100,31 +100,37 @@ func TestCreateBatchMetricMeasures(t *testing.T) {
 
 	firstTimestamp := time.Date(2018, 1, 10, 01, 00, 0, 0, time.UTC)
 	secondTimestamp := time.Date(2018, 1, 10, 02, 45, 0, 0, time.UTC)
-	createOpts := measures.BatchMetricsOpts{
-		BatchOpts: map[string][]measures.MeasureOpts{
-			"777a01d6-4694-49cb-b86a-5ba9fd4e609e": []measures.MeasureOpts{
-				{
-					Timestamp: &firstTimestamp,
-					Value:     200.5,
-				},
-				{
-					Timestamp: &secondTimestamp,
-					Value:     300,
+	createOpts := measures.BatchCreateMetricsOpts{
+		BatchMetricsOpts: []measures.MetricOpts{
+			{
+				ID: "777a01d6-4694-49cb-b86a-5ba9fd4e609e",
+				Measures: []measures.MeasureOpts{
+					{
+						Timestamp: &firstTimestamp,
+						Value:     200,
+					},
+					{
+						Timestamp: &secondTimestamp,
+						Value:     300,
+					},
 				},
 			},
-			"6dbc97c5-bfdf-47a2-b184-02e7fa348d21": []measures.MeasureOpts{
-				{
-					Timestamp: &firstTimestamp,
-					Value:     111.1,
-				},
-				{
-					Timestamp: &secondTimestamp,
-					Value:     222.22,
+			{
+				ID: "6dbc97c5-bfdf-47a2-b184-02e7fa348d21",
+				Measures: []measures.MeasureOpts{
+					{
+						Timestamp: &firstTimestamp,
+						Value:     111,
+					},
+					{
+						Timestamp: &secondTimestamp,
+						Value:     222,
+					},
 				},
 			},
 		},
 	}
-	res := measures.BatchMetrics(fake.ServiceClient(), createOpts)
+	res := measures.BatchCreateMetrics(fake.ServiceClient(), createOpts)
 	if res.Err.Error() == "EOF" {
 		res.Err = nil
 	}

--- a/gnocchi/metric/v1/measures/testing/requests_test.go
+++ b/gnocchi/metric/v1/measures/testing/requests_test.go
@@ -98,25 +98,27 @@ func TestCreateBatchMetricMeasures(t *testing.T) {
 		w.WriteHeader(http.StatusAccepted)
 	})
 
+	firstTimeStamp := time.Date(2018, 1, 10, 01, 00, 0, 0, time.UTC)
+	secondTimeStamp := time.Date(2018, 1, 10, 02, 45, 0, 0, time.UTC)
 	createOpts := measures.CreateBatchMetricsOpts{
 		BatchOpts: map[string][]measures.MeasureOpts{
 			"777a01d6-4694-49cb-b86a-5ba9fd4e609e": []measures.MeasureOpts{
 				{
-					TimeStamp: time.Date(2018, 1, 10, 01, 00, 0, 0, time.UTC),
+					Timestamp: &firstTimeStamp,
 					Value:     200.5,
 				},
 				{
-					TimeStamp: time.Date(2018, 1, 10, 01, 30, 0, 0, time.UTC),
+					Timestamp: &secondTimeStamp,
 					Value:     300,
 				},
 			},
 			"6dbc97c5-bfdf-47a2-b184-02e7fa348d21": []measures.MeasureOpts{
 				{
-					TimeStamp: time.Date(2018, 1, 10, 01, 00, 0, 0, time.UTC),
+					Timestamp: &firstTimeStamp,
 					Value:     111.1,
 				},
 				{
-					TimeStamp: time.Date(2018, 1, 10, 02, 45, 0, 0, time.UTC),
+					Timestamp: &secondTimeStamp,
 					Value:     222.22,
 				},
 			},

--- a/gnocchi/metric/v1/measures/testing/requests_test.go
+++ b/gnocchi/metric/v1/measures/testing/requests_test.go
@@ -98,27 +98,27 @@ func TestCreateBatchMetricMeasures(t *testing.T) {
 		w.WriteHeader(http.StatusAccepted)
 	})
 
-	firstTimeStamp := time.Date(2018, 1, 10, 01, 00, 0, 0, time.UTC)
-	secondTimeStamp := time.Date(2018, 1, 10, 02, 45, 0, 0, time.UTC)
+	firstTimestamp := time.Date(2018, 1, 10, 01, 00, 0, 0, time.UTC)
+	secondTimestamp := time.Date(2018, 1, 10, 02, 45, 0, 0, time.UTC)
 	createOpts := measures.CreateBatchMetricsOpts{
 		BatchOpts: map[string][]measures.MeasureOpts{
 			"777a01d6-4694-49cb-b86a-5ba9fd4e609e": []measures.MeasureOpts{
 				{
-					Timestamp: &firstTimeStamp,
+					Timestamp: &firstTimestamp,
 					Value:     200.5,
 				},
 				{
-					Timestamp: &secondTimeStamp,
+					Timestamp: &secondTimestamp,
 					Value:     300,
 				},
 			},
 			"6dbc97c5-bfdf-47a2-b184-02e7fa348d21": []measures.MeasureOpts{
 				{
-					Timestamp: &firstTimeStamp,
+					Timestamp: &firstTimestamp,
 					Value:     111.1,
 				},
 				{
-					Timestamp: &secondTimeStamp,
+					Timestamp: &secondTimestamp,
 					Value:     222.22,
 				},
 			},

--- a/gnocchi/metric/v1/measures/testing/requests_test.go
+++ b/gnocchi/metric/v1/measures/testing/requests_test.go
@@ -85,3 +85,46 @@ func TestCreateMeasures(t *testing.T) {
 	}
 	th.AssertNoErr(t, res.Err)
 }
+
+func TestCreateBatchMetricMeasures(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v1/batch/metrics/measures", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json, */*")
+		w.WriteHeader(http.StatusAccepted)
+	})
+
+	createOpts := measures.CreateBatchMetricsOpts{
+		BatchOpts: map[string][]measures.MeasureOpts{
+			"777a01d6-4694-49cb-b86a-5ba9fd4e609e": []measures.MeasureOpts{
+				{
+					TimeStamp: time.Date(2018, 1, 10, 01, 00, 0, 0, time.UTC),
+					Value:     200.5,
+				},
+				{
+					TimeStamp: time.Date(2018, 1, 10, 01, 30, 0, 0, time.UTC),
+					Value:     300,
+				},
+			},
+			"6dbc97c5-bfdf-47a2-b184-02e7fa348d21": []measures.MeasureOpts{
+				{
+					TimeStamp: time.Date(2018, 1, 10, 01, 00, 0, 0, time.UTC),
+					Value:     111.1,
+				},
+				{
+					TimeStamp: time.Date(2018, 1, 10, 02, 45, 0, 0, time.UTC),
+					Value:     222.22,
+				},
+			},
+		},
+	}
+	res := measures.CreateBatchMetrics(fake.ServiceClient(), createOpts)
+	if res.Err.Error() == "EOF" {
+		res.Err = nil
+	}
+	th.AssertNoErr(t, res.Err)
+}

--- a/gnocchi/metric/v1/measures/testing/requests_test.go
+++ b/gnocchi/metric/v1/measures/testing/requests_test.go
@@ -101,31 +101,29 @@ func TestBatchCreateMetrics(t *testing.T) {
 	firstTimestamp := time.Date(2018, 1, 10, 01, 00, 0, 0, time.UTC)
 	secondTimestamp := time.Date(2018, 1, 10, 02, 45, 0, 0, time.UTC)
 	createOpts := measures.BatchCreateMetricsOpts{
-		BatchMetricsOpts: []measures.MetricOpts{
-			{
-				ID: "777a01d6-4694-49cb-b86a-5ba9fd4e609e",
-				Measures: []measures.MeasureOpts{
-					{
-						Timestamp: &firstTimestamp,
-						Value:     200,
-					},
-					{
-						Timestamp: &secondTimestamp,
-						Value:     300,
-					},
+		{
+			ID: "777a01d6-4694-49cb-b86a-5ba9fd4e609e",
+			Measures: []measures.MeasureOpts{
+				{
+					Timestamp: &firstTimestamp,
+					Value:     200,
+				},
+				{
+					Timestamp: &secondTimestamp,
+					Value:     300,
 				},
 			},
-			{
-				ID: "6dbc97c5-bfdf-47a2-b184-02e7fa348d21",
-				Measures: []measures.MeasureOpts{
-					{
-						Timestamp: &firstTimestamp,
-						Value:     111,
-					},
-					{
-						Timestamp: &secondTimestamp,
-						Value:     222,
-					},
+		},
+		{
+			ID: "6dbc97c5-bfdf-47a2-b184-02e7fa348d21",
+			Measures: []measures.MeasureOpts{
+				{
+					Timestamp: &firstTimestamp,
+					Value:     111,
+				},
+				{
+					Timestamp: &secondTimestamp,
+					Value:     222,
 				},
 			},
 		},

--- a/gnocchi/metric/v1/measures/urls.go
+++ b/gnocchi/metric/v1/measures/urls.go
@@ -19,6 +19,6 @@ func createURL(c *gophercloud.ServiceClient, metricID string) string {
 	return resourceURL(c, metricID)
 }
 
-func createBatchMetricsURL(c *gophercloud.ServiceClient) string {
+func batchMetricsURL(c *gophercloud.ServiceClient) string {
 	return c.ServiceURL(batchMetricsPath, "measures")
 }

--- a/gnocchi/metric/v1/measures/urls.go
+++ b/gnocchi/metric/v1/measures/urls.go
@@ -2,7 +2,10 @@ package measures
 
 import "github.com/gophercloud/gophercloud"
 
-const resourcePath = "metric"
+const (
+	resourcePath     = "metric"
+	batchMetricsPath = "batch/metrics"
+)
 
 func resourceURL(c *gophercloud.ServiceClient, metricID string) string {
 	return c.ServiceURL(resourcePath, metricID, "measures")
@@ -14,4 +17,8 @@ func listURL(c *gophercloud.ServiceClient, metricID string) string {
 
 func createURL(c *gophercloud.ServiceClient, metricID string) string {
 	return resourceURL(c, metricID)
+}
+
+func createBatchMetricsURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL(batchMetricsPath, "measures")
 }

--- a/gnocchi/metric/v1/measures/urls.go
+++ b/gnocchi/metric/v1/measures/urls.go
@@ -3,8 +3,8 @@ package measures
 import "github.com/gophercloud/gophercloud"
 
 const (
-	resourcePath     = "metric"
-	batchMetricsPath = "batch/metrics"
+	resourcePath           = "metric"
+	batchCreateMetricsPath = "batch/metrics"
 )
 
 func resourceURL(c *gophercloud.ServiceClient, metricID string) string {
@@ -19,6 +19,6 @@ func createURL(c *gophercloud.ServiceClient, metricID string) string {
 	return resourceURL(c, metricID)
 }
 
-func batchMetricsURL(c *gophercloud.ServiceClient) string {
-	return c.ServiceURL(batchMetricsPath, "measures")
+func batchCreateMetricsURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL(batchCreateMetricsPath, "measures")
 }


### PR DESCRIPTION
Add ability to create measures of a different metrics via metrics IDs references.
Add unit and acceptance tests and a documentation example.

That request implements pushing measures to different metrics via batch request to metric IDs.
Those changes won't provide the ability that allow user to batch measures via resource IDs and metric names.

Docs reference: [rest.html#batch](https://gnocchi.xyz/rest.html#batch)

For [#698](https://github.com/gophercloud/gophercloud/issues/698)

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

API:

- https://github.com/gnocchixyz/gnocchi/blob/stable/4.1/gnocchi/rest/api.py#L1614

Storage code depends on a driver that is used for saving measures:

- Ceph: https://github.com/gnocchixyz/gnocchi/blob/stable/4.1/gnocchi/incoming/ceph.py#L81
- Redis: https://github.com/gnocchixyz/gnocchi/blob/stable/4.1/gnocchi/incoming/redis.py#L52
- File: https://github.com/gnocchixyz/gnocchi/blob/stable/4.1/gnocchi/incoming/file.py#L168
- S3: https://github.com/gnocchixyz/gnocchi/blob/stable/4.1/gnocchi/incoming/s3.py#L161
- Swift: https://github.com/gnocchixyz/gnocchi/blob/stable/4.1/gnocchi/incoming/swift.py#L100