### PR TITLE
Implement Gnocchi measures batch create via resource IDs and metric names

### DIFF
--- a/acceptance/gnocchi/metric/v1/measures.go
+++ b/acceptance/gnocchi/metric/v1/measures.go
@@ -88,8 +88,6 @@ func CreateBatchResourcesMetricsMeasures(t *testing.T, client *gophercloud.Servi
 	batchOpts := make(map[string]map[string][]measures.MeasureOpts)
 
 	for resourceID, metricNames := range batchResourcesMetrics {
-		// DELETE
-		t.Logf("CreateBatchResourcesMetricsMeasures resourceID: %v\n", resourceID)
 		metricMap := make(map[string][]measures.MeasureOpts)
 		for _, metricName := range metricNames {
 			metricMap[metricName] = []measures.MeasureOpts{

--- a/acceptance/gnocchi/metric/v1/measures.go
+++ b/acceptance/gnocchi/metric/v1/measures.go
@@ -31,8 +31,7 @@ func CreateMeasures(t *testing.T, client *gophercloud.ServiceClient, metricID st
 	}
 
 	t.Logf("Attempting to create measures inside a Gnocchi metric %s", metricID)
-
-	if err := measures.Create(client, metricID, createOpts).ExtractErr(); err != nil && err.Error() != "EOF" {
+	if err := measures.Create(client, metricID, createOpts).ExtractErr(); err != nil {
 		return err
 	}
 
@@ -67,8 +66,7 @@ func MeasuresBatchCreateMetrics(t *testing.T, client *gophercloud.ServiceClient,
 	}
 
 	t.Logf("Attempting to create measures inside Gnocchi metrics via batch request")
-
-	if err := measures.BatchCreateMetrics(client, createOpts).ExtractErr(); err != nil && err.Error() != "EOF" {
+	if err := measures.BatchCreateMetrics(client, createOpts).ExtractErr(); err != nil {
 		return err
 	}
 
@@ -125,7 +123,7 @@ func MeasuresBatchCreateResourcesMetrics(t *testing.T, client *gophercloud.Servi
 	}
 
 	t.Logf("Attempting to create measures inside Gnocchi metrics via batch request with resource IDs")
-	if err := measures.BatchCreateResourcesMetrics(client, createOpts).ExtractErr(); err != nil && err.Error() != "EOF" {
+	if err := measures.BatchCreateResourcesMetrics(client, createOpts).ExtractErr(); err != nil {
 		return err
 	}
 

--- a/acceptance/gnocchi/metric/v1/measures.go
+++ b/acceptance/gnocchi/metric/v1/measures.go
@@ -76,10 +76,10 @@ func MeasuresBatchCreateMetrics(t *testing.T, client *gophercloud.ServiceClient,
 	return nil
 }
 
-// CreateBatchResourcesMetricsMeasures will create measures inside different metrics via batch request to resource IDs.
+// BatchResourcesMeasures will create measures inside different metrics via batch request to resource IDs.
 // The batchResourcesMetrics arguments is a mapping between resource IDs and corresponding metric names.
 // An error will be returned if measures could not be created.
-func CreateBatchResourcesMetricsMeasures(t *testing.T, client *gophercloud.ServiceClient, batchResourcesMetrics map[string][]string) error {
+func BatchResourcesMeasures(t *testing.T, client *gophercloud.ServiceClient, batchResourcesMetrics map[string][]string) error {
 	currentTimestamp := time.Now().UTC()
 	pastHourTimestamp := currentTimestamp.Add(-1 * time.Hour)
 	currentValue := float64(tools.RandomInt(100, 200))
@@ -104,13 +104,13 @@ func CreateBatchResourcesMetricsMeasures(t *testing.T, client *gophercloud.Servi
 		}
 	}
 
-	createOpts := measures.CreateBatchResourcesMetricsOpts{
+	createOpts := measures.BatchResourcesOpts{
 		CreateMetrics:                     true,
 		BatchResourcesMetricsMeasuresOpts: batchOpts,
 	}
 
 	t.Logf("Attempting to create measures inside Gnocchi metrics via batch request with resource IDs")
-	if err := measures.CreateBatchResourcesMetrics(client, createOpts).ExtractErr(); err != nil && err.Error() != "EOF" {
+	if err := measures.BatchResources(client, createOpts).ExtractErr(); err != nil && err.Error() != "EOF" {
 		return err
 	}
 

--- a/acceptance/gnocchi/metric/v1/measures.go
+++ b/acceptance/gnocchi/metric/v1/measures.go
@@ -76,41 +76,56 @@ func MeasuresBatchCreateMetrics(t *testing.T, client *gophercloud.ServiceClient,
 	return nil
 }
 
-// BatchResourcesMeasures will create measures inside different metrics via batch request to resource IDs.
+// MeasuresBatchCreateResourcesMetrics will create measures inside different metrics via batch request to resource IDs.
 // The batchResourcesMetrics arguments is a mapping between resource IDs and corresponding metric names.
 // An error will be returned if measures could not be created.
-func BatchResourcesMeasures(t *testing.T, client *gophercloud.ServiceClient, batchResourcesMetrics map[string][]string) error {
+func MeasuresBatchCreateResourcesMetrics(t *testing.T, client *gophercloud.ServiceClient, batchResourcesMetrics map[string][]string) error {
 	currentTimestamp := time.Now().UTC()
 	pastHourTimestamp := currentTimestamp.Add(-1 * time.Hour)
 	currentValue := float64(tools.RandomInt(100, 200))
 	pastHourValue := float64(tools.RandomInt(500, 600))
 
-	batchOpts := make(map[string]map[string][]measures.MeasureOpts)
-
-	for resourceID, metricNames := range batchResourcesMetrics {
-		metricMap := make(map[string][]measures.MeasureOpts)
-		for _, metricName := range metricNames {
-			metricMap[metricName] = []measures.MeasureOpts{
-				{
-					Timestamp: &currentTimestamp,
-					Value:     currentValue,
-				},
-				{
-					Timestamp: &pastHourTimestamp,
-					Value:     pastHourValue,
-				},
-			}
-			batchOpts[resourceID] = metricMap
-		}
+	// measureSet is a set of measures for an every metric.
+	measureSet := []measures.MeasureOpts{
+		{
+			Timestamp: &currentTimestamp,
+			Value:     currentValue,
+		},
+		{
+			Timestamp: &pastHourTimestamp,
+			Value:     pastHourValue,
+		},
 	}
 
-	createOpts := measures.BatchResourcesOpts{
-		CreateMetrics:                     true,
-		BatchResourcesMetricsMeasuresOpts: batchOpts,
+	// batchResourcesMetricsOpts is an internal slice representation of measures.BatchResourcesMetricsOpts stucts.
+	batchResourcesMetricsOpts := make([]measures.BatchResourcesMetricsOpts, 0)
+
+	for resourceID, metricNames := range batchResourcesMetrics {
+		// resourcesMetricsOpts is an internal slice representation of measures.ResourcesMetricsOpts structs.
+		resourcesMetricsOpts := make([]measures.ResourcesMetricsOpts, 0)
+
+		// Populate batch options for each metric of a resource.
+		for _, metricName := range metricNames {
+			resourcesMetricsOpts = append(resourcesMetricsOpts, measures.ResourcesMetricsOpts{
+				MetricName: metricName,
+				Measures:   measureSet,
+			})
+		}
+
+		// Save batch options of a resource.
+		batchResourcesMetricsOpts = append(batchResourcesMetricsOpts, measures.BatchResourcesMetricsOpts{
+			ResourceID:       resourceID,
+			ResourcesMetrics: resourcesMetricsOpts,
+		})
+	}
+
+	createOpts := measures.BatchCreateResourcesMetricsOpts{
+		CreateMetrics:         true,
+		BatchResourcesMetrics: batchResourcesMetricsOpts,
 	}
 
 	t.Logf("Attempting to create measures inside Gnocchi metrics via batch request with resource IDs")
-	if err := measures.BatchResources(client, createOpts).ExtractErr(); err != nil && err.Error() != "EOF" {
+	if err := measures.BatchCreateResourcesMetrics(client, createOpts).ExtractErr(); err != nil && err.Error() != "EOF" {
 		return err
 	}
 

--- a/acceptance/gnocchi/metric/v1/measures_test.go
+++ b/acceptance/gnocchi/metric/v1/measures_test.go
@@ -95,20 +95,20 @@ func TestMeasuresBatchCreateMetrics(t *testing.T) {
 	t.Logf("Measures for the metric: %s, %v", metricToBatchTwo.ID, metricTwoMeasures)
 }
 
-func TestMeasuresBatchResources(t *testing.T) {
+func TestMeasuresBatchCreateResourcesMetrics(t *testing.T) {
 	client, err := clients.NewGnocchiV1Client()
 	if err != nil {
 		t.Fatalf("Unable to create a Gnocchi client: %v", err)
 	}
 
-	// Create a couple of resources with metrics to test BatchResources requets.
+	// Create a couple of resources with metrics to test BatchCreateResourcesMetrics requets.
 	batchResourcesMetrics, err := CreateResourcesToBatchMeasures(t, client)
 	if err != nil {
 		t.Fatalf("Unable to create Gnocchi resources and metrics: %v", err)
 	}
 
 	// Test create batch request based on resource IDs.
-	if err := BatchResourcesMeasures(t, client, batchResourcesMetrics); err != nil {
+	if err := MeasuresBatchCreateResourcesMetrics(t, client, batchResourcesMetrics); err != nil {
 		t.Fatalf("Unable to create measures inside Gnocchi metrics: %v", err)
 	}
 

--- a/acceptance/gnocchi/metric/v1/measures_test.go
+++ b/acceptance/gnocchi/metric/v1/measures_test.go
@@ -94,3 +94,21 @@ func TestMeasuresBatchCreateMetrics(t *testing.T) {
 
 	t.Logf("Measures for the metric: %s, %v", metricToBatchTwo.ID, metricTwoMeasures)
 }
+
+func TestBatchResourcesMetricsMeasuresCreation(t *testing.T) {
+	client, err := clients.NewGnocchiV1Client()
+	if err != nil {
+		t.Fatalf("Unable to create a Gnocchi client: %v", err)
+	}
+
+	// Create a couple of resources with metrics to test CreateBatchResourcesMetrics requets.
+	batchResourcesMetrics, err := CreateResourcesToBatchMeasures(t, client)
+	if err != nil {
+		t.Fatalf("Unable to create Gnocchi resources and metrics: %v", err)
+	}
+
+	// Test create batch request based on resource IDs.
+	if err := CreateBatchResourcesMetricsMeasures(t, client, batchResourcesMetrics); err != nil {
+		t.Fatalf("Unable to create measures inside Gnocchi metrics: %v", err)
+	}
+}

--- a/acceptance/gnocchi/metric/v1/measures_test.go
+++ b/acceptance/gnocchi/metric/v1/measures_test.go
@@ -95,25 +95,25 @@ func TestMeasuresBatchCreateMetrics(t *testing.T) {
 	t.Logf("Measures for the metric: %s, %v", metricToBatchTwo.ID, metricTwoMeasures)
 }
 
-func TestBatchResourcesMetricsMeasuresCreation(t *testing.T) {
+func TestMeasuresBatchResources(t *testing.T) {
 	client, err := clients.NewGnocchiV1Client()
 	if err != nil {
 		t.Fatalf("Unable to create a Gnocchi client: %v", err)
 	}
 
-	// Create a couple of resources with metrics to test CreateBatchResourcesMetrics requets.
+	// Create a couple of resources with metrics to test BatchResources requets.
 	batchResourcesMetrics, err := CreateResourcesToBatchMeasures(t, client)
 	if err != nil {
 		t.Fatalf("Unable to create Gnocchi resources and metrics: %v", err)
 	}
 
 	// Test create batch request based on resource IDs.
-	if err := CreateBatchResourcesMetricsMeasures(t, client, batchResourcesMetrics); err != nil {
+	if err := BatchResourcesMeasures(t, client, batchResourcesMetrics); err != nil {
 		t.Fatalf("Unable to create measures inside Gnocchi metrics: %v", err)
 	}
 
 	// Delete resources.
-	// for resourceID in batchResourcesMetrics {
-	// 	DeleteResource(t, client, "generic", resourceID)
-	// }
+	for resourceID := range batchResourcesMetrics {
+		DeleteResource(t, client, "generic", resourceID)
+	}
 }

--- a/acceptance/gnocchi/metric/v1/measures_test.go
+++ b/acceptance/gnocchi/metric/v1/measures_test.go
@@ -111,4 +111,9 @@ func TestBatchResourcesMetricsMeasuresCreation(t *testing.T) {
 	if err := CreateBatchResourcesMetricsMeasures(t, client, batchResourcesMetrics); err != nil {
 		t.Fatalf("Unable to create measures inside Gnocchi metrics: %v", err)
 	}
+
+	// Delete resources.
+	// for resourceID in batchResourcesMetrics {
+	// 	DeleteResource(t, client, "generic", resourceID)
+	// }
 }

--- a/acceptance/gnocchi/metric/v1/pkg.go
+++ b/acceptance/gnocchi/metric/v1/pkg.go
@@ -1,1 +1,0 @@
-package v1

--- a/gnocchi/metric/v1/measures/doc.go
+++ b/gnocchi/metric/v1/measures/doc.go
@@ -39,7 +39,7 @@ Example of Creating measures inside a single metric
 		},
 	}
 	metricID := "9e5a6441-1044-4181-b66e-34e180753040"
-	if err := measures.Create(gnocchiClient, metricID, createOpts).ExtractErr(); err != nil && err.Error() != "EOF" {
+	if err := measures.Create(gnocchiClient, metricID, createOpts).ExtractErr(); err != nil {
 		panic(err)
 	}
 
@@ -75,7 +75,7 @@ Example of Creating measures inside different metrics via metric ID references i
 			},
 		},
 	}
-	if err := measures.BatchCreateMetrics(gnocchiClient, createOpts).ExtractErr(); err != nil && err.Error() != "EOF" {
+	if err := measures.BatchCreateMetrics(gnocchiClient, createOpts).ExtractErr(); err != nil {
 		panic(err)
 	}
 
@@ -143,7 +143,7 @@ Example of Creating measures inside different metrics via metric names and resou
 			},
 		},
 	}
-	if err := measures.BatchCreateResourcesMetrics(gnocchiClient, createOpts).ExtractErr(); err != nil && err.Error() != "EOF" {
+	if err := measures.BatchCreateResourcesMetrics(gnocchiClient, createOpts).ExtractErr(); err != nil {
 		panic(err)
 	}
 */

--- a/gnocchi/metric/v1/measures/doc.go
+++ b/gnocchi/metric/v1/measures/doc.go
@@ -79,7 +79,7 @@ Example of Creating measures inside different metrics via metric ID references i
 		panic(err)
 	}
 
-Example of Creating measures inside different metrics via metric names and resource IDreferences of that metrics in one request
+Example of Creating measures inside different metrics via metric names and resource IDs references of that metrics in a one request
 
 	currentTimestamp := time.Now().UTC()
 	pastHourTimestamp := currentTimestamp.Add(-1 * time.Hour)

--- a/gnocchi/metric/v1/measures/doc.go
+++ b/gnocchi/metric/v1/measures/doc.go
@@ -83,7 +83,7 @@ Example of Creating measures inside different metrics via metric names and resou
 
 	currentTimestamp := time.Now().UTC()
 	pastHourTimestamp := currentTimestamp.Add(-1 * time.Hour)
-	createOpts := measures.CreateBatchResourcesMetricsOpts{
+	createOpts := measures.BatchResourcesOpts{
 		BatchResourcesMetricsMeasuresOpts: map[string]map[string][]measures.MeasureOpts{
 			"1f3a0724-1807-4bd1-81f9-ee18c8ff6ccc": {
 				"memory.usage": []measures.MeasureOpts{
@@ -121,7 +121,7 @@ Example of Creating measures inside different metrics via metric names and resou
 			},
 		},
 	}
-	if err := measures.CreateBatchResourcesMetrics(gnocchiClient, createOpts).ExtractErr(); err != nil && err.Error() != "EOF" {
+	if err := measures.BatchResources(gnocchiClient, createOpts).ExtractErr(); err != nil && err.Error() != "EOF" {
 		panic(err)
 	}
 */

--- a/gnocchi/metric/v1/measures/doc.go
+++ b/gnocchi/metric/v1/measures/doc.go
@@ -43,7 +43,7 @@ Example of Creating measures inside a single metric
 		panic(err)
 	}
 
-Example of Creating measures inside different metrics via metric ID references in one request
+Example of Creating measures inside different metrics via metric ID references in a single request
 
 	currentTimestamp := time.Now().UTC()
 	pastHourTimestamp := currentTimestamp.Add(-1 * time.Hour)
@@ -79,49 +79,71 @@ Example of Creating measures inside different metrics via metric ID references i
 		panic(err)
 	}
 
-Example of Creating measures inside different metrics via metric names and resource IDs references of that metrics in a one request
+Example of Creating measures inside different metrics via metric names and resource IDs references of that metrics in a single request
 
 	currentTimestamp := time.Now().UTC()
 	pastHourTimestamp := currentTimestamp.Add(-1 * time.Hour)
-	createOpts := measures.BatchResourcesOpts{
-		BatchResourcesMetricsMeasuresOpts: map[string]map[string][]measures.MeasureOpts{
-			"1f3a0724-1807-4bd1-81f9-ee18c8ff6ccc": {
-				"memory.usage": []measures.MeasureOpts{
+	createOpts := measures.BatchCreateResourcesMetricsOpts{
+		CreateMetrics: true,
+		BatchResourcesMetrics: []measures.BatchResourcesMetricsOpts{
+			{
+				ResourceID: "75274f99-faf6-4112-a6d5-2794cb07c789",
+				ResourcesMetrics: []measures.ResourcesMetricsOpts{
 					{
-						Timestamp: &currentTimestamp,
-						Value:     1562.82,
+						MetricName:        "network.incoming.bytes.rate",
+						ArchivePolicyName: "high",
+						Unit:              "B/s",
+						Measures: []measures.MeasureOpts{
+							{
+								Timestamp: &currentTimestamp,
+								Value:     1562.82,
+							},
+							{
+								Timestamp: &pastHourTimestamp,
+								Value:     768.1,
+							},
+						},
 					},
 					{
-						Timestamp: &pastHourTimestamp,
-						Value:     768.1,
+						MetricName:        "network.outgoing.bytes.rate",
+						ArchivePolicyName: "high",
+						Unit:              "B/s",
+						Measures: []measures.MeasureOpts{
+							{
+								Timestamp: &currentTimestamp,
+								Value:     273,
+							},
+							{
+								Timestamp: &pastHourTimestamp,
+								Value:     3141.14,
+							},
+						},
 					},
 				},
 			},
-			"789a7f65-977d-40f4-beed-f717100125f5": {
-				"cpu.util": []measures.MeasureOpts{
+			{
+				ResourceID: "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",
+				ResourcesMetrics: []measures.ResourcesMetricsOpts{
 					{
-						Timestamp: &currentTimestamp,
-						Value:     89.9,
-					},
-					{
-						Timestamp: &pastHourTimestamp,
-						Value:     56,
-					},
-				},
-				"network.incoming.bytes.rate": []measures.MeasureOpts{
-					{
-						Timestamp: &currentTimestamp,
-						Value:     15671.32,
-					},
-					{
-						Timestamp: &pastHourTimestamp,
-						Value:     87123,
+						MetricName:        "disk.write.bytes.rate",
+						ArchivePolicyName: "low",
+						Unit:              "B/s",
+						Measures: []measures.MeasureOpts{
+							{
+								Timestamp: &currentTimestamp,
+								Value:     1237,
+							},
+							{
+								Timestamp: &pastHourTimestamp,
+								Value:     132.12,
+							},
+						},
 					},
 				},
 			},
 		},
 	}
-	if err := measures.BatchResources(gnocchiClient, createOpts).ExtractErr(); err != nil && err.Error() != "EOF" {
+	if err := measures.BatchCreateResourcesMetrics(gnocchiClient, createOpts).ExtractErr(); err != nil && err.Error() != "EOF" {
 		panic(err)
 	}
 */

--- a/gnocchi/metric/v1/measures/doc.go
+++ b/gnocchi/metric/v1/measures/doc.go
@@ -78,5 +78,51 @@ Example of Creating measures inside different metrics via metric ID references i
 	if err := measures.BatchCreateMetrics(gnocchiClient, createOpts).ExtractErr(); err != nil && err.Error() != "EOF" {
 		panic(err)
 	}
+
+Example of Creating measures inside different metrics via metric names and resource IDreferences of that metrics in one request
+
+	currentTimestamp := time.Now().UTC()
+	pastHourTimestamp := currentTimestamp.Add(-1 * time.Hour)
+	createOpts := measures.CreateBatchResourcesMetricsOpts{
+		BatchResourcesMetricsMeasuresOpts: map[string]map[string][]measures.MeasureOpts{
+			"1f3a0724-1807-4bd1-81f9-ee18c8ff6ccc": {
+				"memory.usage": []measures.MeasureOpts{
+					{
+						Timestamp: &currentTimestamp,
+						Value:     1562.82,
+					},
+					{
+						Timestamp: &pastHourTimestamp,
+						Value:     768.1,
+					},
+				},
+			},
+			"789a7f65-977d-40f4-beed-f717100125f5": {
+				"cpu.util": []measures.MeasureOpts{
+					{
+						Timestamp: &currentTimestamp,
+						Value:     89.9,
+					},
+					{
+						Timestamp: &pastHourTimestamp,
+						Value:     56,
+					},
+				},
+				"network.incoming.bytes.rate": []measures.MeasureOpts{
+					{
+						Timestamp: &currentTimestamp,
+						Value:     15671.32,
+					},
+					{
+						Timestamp: &pastHourTimestamp,
+						Value:     87123,
+					},
+				},
+			},
+		},
+	}
+	if err := measures.CreateBatchResourcesMetrics(gnocchiClient, createOpts).ExtractErr(); err != nil && err.Error() != "EOF" {
+		panic(err)
+	}
 */
 package measures

--- a/gnocchi/metric/v1/measures/requests.go
+++ b/gnocchi/metric/v1/measures/requests.go
@@ -1,6 +1,7 @@
 package measures
 
 import (
+	"fmt"
 	"net/url"
 	"time"
 
@@ -146,14 +147,24 @@ type BatchCreateMetricsOpts []MetricOpts
 // MetricOpts represents measures of a single metric of the BatchCreateMetrics request.
 type MetricOpts struct {
 	// ID uniquely identifies the Gnocchi metric.
-	ID string `json:"-" required:"true"`
+	ID string
 
 	// Measures is a set of measures for a single metric that needs to be created.
-	Measures []MeasureOpts `json:"-" required:"true"`
+	Measures []MeasureOpts
 }
 
 // ToMap is a helper function to convert individual MetricOpts structure into a sub-map.
 func (opts MetricOpts) ToMap() (map[string]interface{}, error) {
+	// Check provided MetricOpts fields.
+	if opts.ID == "" {
+		errMsg := "missing input for the MetricOpts 'ID' argument"
+		return nil, fmt.Errorf(errMsg)
+	}
+	if opts.Measures == nil {
+		errMsg := "missing input for the MetricOpts 'Measures' argument"
+		return nil, fmt.Errorf(errMsg)
+	}
+
 	// measures is a slice of measures maps.
 	measures := make([]map[string]interface{}, len(opts.Measures))
 
@@ -228,14 +239,24 @@ type BatchCreateResourcesMetricsOpts struct {
 // BatchResourcesMetricsOpts represents parameters of a single resource of the BatchCreateResourcesMetrics request.
 type BatchResourcesMetricsOpts struct {
 	// ResourceID uniquely identifies the Gnocchi resource.
-	ResourceID string `json:"-" required:"true"`
+	ResourceID string
 
 	// ResourcesMetrics specifies metrics whose measures will be updated.
-	ResourcesMetrics []ResourcesMetricsOpts `json:"-" required:"true"`
+	ResourcesMetrics []ResourcesMetricsOpts
 }
 
 // ToMap is a helper function to convert individual BatchResourcesMetricsOpts structure into a sub-map.
 func (opts BatchResourcesMetricsOpts) ToMap() (map[string]interface{}, error) {
+	// Check provided BatchResourcesMetricsOpts fields.
+	if opts.ResourceID == "" {
+		errMsg := "missing input for the BatchResourcesMetricsOpts 'ResourceID' argument"
+		return nil, fmt.Errorf(errMsg)
+	}
+	if opts.ResourcesMetrics == nil {
+		errMsg := "missing input for the BatchResourcesMetricsOpts 'ResourcesMetrics' argument"
+		return nil, fmt.Errorf(errMsg)
+	}
+
 	// batchResourcesMetricsOpts is an internal map representation of the BatchResourcesMetricsOpts struct.
 	batchResourcesMetricsOpts := make(map[string]interface{})
 
@@ -270,7 +291,7 @@ func (opts BatchResourcesMetricsOpts) ToMap() (map[string]interface{}, error) {
 // ResourcesMetricsOpts represents measures of a single metric of the resource from BatchResourcesMetricsOpts.
 type ResourcesMetricsOpts struct {
 	// MetricName is a human-readable name for the Gnocchi metric.
-	MetricName string `json:"-" required:"true"`
+	MetricName string
 
 	// ArchivePolicyName is a name of the Gnocchi archive policy that describes
 	// the aggregate storage policy of a metric.
@@ -280,11 +301,21 @@ type ResourcesMetricsOpts struct {
 	Unit string
 
 	// Measures is a set of measures for a single metric that needs to be created.
-	Measures []MeasureOpts `json:"-" required:"true"`
+	Measures []MeasureOpts
 }
 
 // ToMap is a helper function to convert individual ResourcesMetricsOpts structure into a sub-map.
 func (opts ResourcesMetricsOpts) ToMap() (map[string]interface{}, error) {
+	// Check provided ResourcesMetricsOpts fields.
+	if opts.MetricName == "" {
+		errMsg := "missing input for the ResourcesMetricsOpts 'MetricName' argument"
+		return nil, fmt.Errorf(errMsg)
+	}
+	if opts.Measures == nil {
+		errMsg := "missing input for the ResourcesMetricsOpts 'Measures' argument"
+		return nil, fmt.Errorf(errMsg)
+	}
+
 	// measures is a slice of measures maps.
 	measures := make([]map[string]interface{}, len(opts.Measures))
 

--- a/gnocchi/metric/v1/measures/requests.go
+++ b/gnocchi/metric/v1/measures/requests.go
@@ -241,8 +241,8 @@ func (opts CreateBatchResourcesMetricsOpts) ToMeasureCreateBatchResourcesMetrics
 		metrics = make(map[string][]measureOpts)
 		for metricName, metricMeasures := range metricsMap {
 			measures = make([]measureOpts, len(metricMeasures))
-			for i, m := range metricMeasures {
-				measureMap, err := m.ToMap()
+			for i, measure := range metricMeasures {
+				measureMap, err := measure.ToMap()
 				if err != nil {
 					return nil, err
 				}

--- a/gnocchi/metric/v1/measures/requests.go
+++ b/gnocchi/metric/v1/measures/requests.go
@@ -204,17 +204,17 @@ func BatchCreateMetrics(client *gophercloud.ServiceClient, opts BatchCreateMetri
 	return
 }
 
-// CreateBatchResourcesMetricsOptsBuilder is needed to add measures to the CreateBatchResourcesMetrics request.
-type CreateBatchResourcesMetricsOptsBuilder interface {
-	// ToMeasureCreateBatchResourcesMetricsMap builds a request body.
-	ToMeasureCreateBatchResourcesMetricsMap() (map[string]interface{}, error)
+// BatchResourcesOptsBuilder is needed to add measures to the BatchResources request.
+type BatchResourcesOptsBuilder interface {
+	// ToMeasureBatchResourcesMap builds a request body.
+	ToMeasureBatchResourcesMap() (map[string]interface{}, error)
 
 	// ToMeasureCreateBatchMetricsQuery builds a query string.
 	ToMeasureCreateBatchMetricsQuery() (string, error)
 }
 
-// CreateBatchResourcesMetricsOpts specifies a parameters for creating measures for different metrics in a single request.
-type CreateBatchResourcesMetricsOpts struct {
+// BatchResourcesOpts specifies a parameters for creating measures for different metrics in a single request.
+type BatchResourcesOpts struct {
 	// CreateMetrics allows request to create metrics that don't exist yet.
 	CreateMetrics bool `q:"create_metrics"`
 
@@ -222,8 +222,8 @@ type CreateBatchResourcesMetricsOpts struct {
 	BatchResourcesMetricsMeasuresOpts map[string]map[string][]MeasureOpts
 }
 
-// ToMeasureCreateBatchResourcesMetricsMap constructs a request body from the CreateBatchMetricsOpts.
-func (opts CreateBatchResourcesMetricsOpts) ToMeasureCreateBatchResourcesMetricsMap() (map[string]interface{}, error) {
+// ToMeasureBatchResourcesMap constructs a request body from the CreateBatchMetricsOpts.
+func (opts BatchResourcesOpts) ToMeasureBatchResourcesMap() (map[string]interface{}, error) {
 	// measures is an internal map representation of the MeasureOpts struct.
 	type measureOpts map[string]interface{}
 
@@ -256,15 +256,15 @@ func (opts CreateBatchResourcesMetricsOpts) ToMeasureCreateBatchResourcesMetrics
 	return map[string]interface{}{"batchResourceMetricsMeasures": batchResourceMetricsMeasuresOpts}, nil
 }
 
-// ToMeasureCreateBatchMetricsQuery formats the CreateBatchResourcesMetricsOpts into a query string.
-func (opts CreateBatchResourcesMetricsOpts) ToMeasureCreateBatchMetricsQuery() (string, error) {
+// ToMeasureCreateBatchMetricsQuery formats the BatchResourcesOpts into a query string.
+func (opts BatchResourcesOpts) ToMeasureCreateBatchMetricsQuery() (string, error) {
 	q, err := gophercloud.BuildQueryString(opts)
 	return q.String(), err
 }
 
-// CreateBatchResourcesMetrics requests the creation of new measures inside metrics via resource IDs and metric names.
-func CreateBatchResourcesMetrics(client *gophercloud.ServiceClient, opts CreateBatchResourcesMetricsOptsBuilder) (r CreateBatchResourcesMetricsResult) {
-	url := createBatchResourcesMetricsURL(client)
+// BatchResources requests the creation of new measures inside metrics via resource IDs and metric names.
+func BatchResources(client *gophercloud.ServiceClient, opts BatchResourcesOptsBuilder) (r BatchResourcesResult) {
+	url := batchResourcesURL(client)
 	if opts != nil {
 		query, err := opts.ToMeasureCreateBatchMetricsQuery()
 		if err != nil {
@@ -274,7 +274,7 @@ func CreateBatchResourcesMetrics(client *gophercloud.ServiceClient, opts CreateB
 		url += query
 	}
 
-	b, err := opts.ToMeasureCreateBatchResourcesMetricsMap()
+	b, err := opts.ToMeasureBatchResourcesMap()
 	if err != nil {
 		r.Err = err
 		return

--- a/gnocchi/metric/v1/measures/requests.go
+++ b/gnocchi/metric/v1/measures/requests.go
@@ -228,10 +228,10 @@ type BatchCreateResourcesMetricsOpts struct {
 // BatchResourcesMetricsOpts represents parameters of a single resource of the BatchCreateResourcesMetrics request.
 type BatchResourcesMetricsOpts struct {
 	// ResourceID uniquely identifies the Gnocchi resource.
-	ResourceID string
+	ResourceID string `json:"-" required:"true"`
 
 	// ResourcesMetrics specifies metrics whose measures will be updated.
-	ResourcesMetrics []ResourcesMetricsOpts
+	ResourcesMetrics []ResourcesMetricsOpts `json:"-" required:"true"`
 }
 
 // ToMap is a helper function to convert individual BatchResourcesMetricsOpts structure into a sub-map.

--- a/gnocchi/metric/v1/measures/requests.go
+++ b/gnocchi/metric/v1/measures/requests.go
@@ -222,7 +222,7 @@ type CreateBatchResourcesMetricsOpts struct {
 	BatchResourcesMetricsMeasuresOpts map[string]map[string][]MeasureOpts
 }
 
-// ToMeasureCreateBatchResourcesMetricsMap constructs a request body from CreateBatchMetricsOpts.
+// ToMeasureCreateBatchResourcesMetricsMap constructs a request body from the CreateBatchMetricsOpts.
 func (opts CreateBatchResourcesMetricsOpts) ToMeasureCreateBatchResourcesMetricsMap() (map[string]interface{}, error) {
 	// measures is an internal map representation of the MeasureOpts struct.
 	type measureOpts map[string]interface{}
@@ -256,13 +256,13 @@ func (opts CreateBatchResourcesMetricsOpts) ToMeasureCreateBatchResourcesMetrics
 	return map[string]interface{}{"batchResourceMetricsMeasures": batchResourceMetricsMeasuresOpts}, nil
 }
 
-// ToMeasureCreateBatchMetricsQuery formats a CreateBatchResourcesMetricsOpts into a query string.
+// ToMeasureCreateBatchMetricsQuery formats the CreateBatchResourcesMetricsOpts into a query string.
 func (opts CreateBatchResourcesMetricsOpts) ToMeasureCreateBatchMetricsQuery() (string, error) {
 	q, err := gophercloud.BuildQueryString(opts)
 	return q.String(), err
 }
 
-// CreateBatchResourcesMetrics requests the creation of a new measures inside metrics via resource IDs and metric names.
+// CreateBatchResourcesMetrics requests the creation of new measures inside metrics via resource IDs and metric names.
 func CreateBatchResourcesMetrics(client *gophercloud.ServiceClient, opts CreateBatchResourcesMetricsOptsBuilder) (r CreateBatchResourcesMetricsResult) {
 	url := createBatchResourcesMetricsURL(client)
 	if opts != nil {

--- a/gnocchi/metric/v1/measures/results.go
+++ b/gnocchi/metric/v1/measures/results.go
@@ -23,6 +23,12 @@ type BatchCreateMetricsResult struct {
 	gophercloud.ErrResult
 }
 
+// CreateBatchResourcesMetricsResult represents the result of a create batch via resource IDs operation.
+// Call its ExtractErr method to determine if the request succeeded or failed.
+type CreateBatchResourcesMetricsResult struct {
+	gophercloud.ErrResult
+}
+
 // Measure is an datapoint thats is composed with a timestamp and a value.
 type Measure struct {
 	// Timestamp represents a timestamp of when measure was pushed into the Gnocchi.

--- a/gnocchi/metric/v1/measures/results.go
+++ b/gnocchi/metric/v1/measures/results.go
@@ -23,9 +23,9 @@ type BatchCreateMetricsResult struct {
 	gophercloud.ErrResult
 }
 
-// CreateBatchResourcesMetricsResult represents the result of a create batch via resource IDs operation.
+// BatchResourcesResult represents the result of a create batch via resource IDs operation.
 // Call its ExtractErr method to determine if the request succeeded or failed.
-type CreateBatchResourcesMetricsResult struct {
+type BatchResourcesResult struct {
 	gophercloud.ErrResult
 }
 

--- a/gnocchi/metric/v1/measures/results.go
+++ b/gnocchi/metric/v1/measures/results.go
@@ -23,9 +23,9 @@ type BatchCreateMetricsResult struct {
 	gophercloud.ErrResult
 }
 
-// BatchResourcesResult represents the result of a create batch via resource IDs operation.
+// BatchCreateResourcesMetricsResult represents the result of a batch create via resource IDs operation.
 // Call its ExtractErr method to determine if the request succeeded or failed.
-type BatchResourcesResult struct {
+type BatchCreateResourcesMetricsResult struct {
 	gophercloud.ErrResult
 }
 

--- a/gnocchi/metric/v1/measures/testing/fixtures.go
+++ b/gnocchi/metric/v1/measures/testing/fixtures.go
@@ -45,3 +45,95 @@ var ListMeasuresExpected = []measures.Measure{
 		Value:       20.0,
 	},
 }
+
+// MeasuresCreateRequest represents a request to create measures for a single metric.
+const MeasuresCreateRequest = `
+[
+    {
+        "timestamp": "2018-01-18T12:31:00",
+        "value": 101.2
+    },
+    {
+        "timestamp": "2018-01-18T14:32:00",
+        "value": 102
+    }
+]
+`
+
+// MeasuresBatchCreateMetricsRequest represents a request to create measures for a single metric.
+const MeasuresBatchCreateMetricsRequest = `
+{
+    "777a01d6-4694-49cb-b86a-5ba9fd4e609e": [
+        {
+            "timestamp": "2018-01-10T01:00:00",
+            "value": 200
+        },
+        {
+            "timestamp": "2018-01-10T02:45:00",
+            "value": 300
+        }
+    ],
+    "6dbc97c5-bfdf-47a2-b184-02e7fa348d21": [
+        {
+            "timestamp": "2018-01-10T01:00:00",
+            "value": 111
+        },
+        {
+            "timestamp": "2018-01-10T02:45:00",
+            "value": 222
+        }
+    ]
+}
+`
+
+// MeasuresBatchCreateResourcesMetricsRequest represents a request to create measures for a single metric.
+const MeasuresBatchCreateResourcesMetricsRequest = `
+{
+    "75274f99-faf6-4112-a6d5-2794cb07c789": {
+        "network.incoming.bytes.rate": {
+			"archive_policy_name": "high",
+			"unit": "B/s",
+            "measures": [
+                {
+                    "timestamp": "2018-01-20T12:30:00",
+                    "value": 1562.82
+                },
+                {
+                    "timestamp": "2018-01-20T13:15:00",
+                    "value": 768.1
+                }
+            ]
+        },
+        "network.outgoing.bytes.rate": {
+            "archive_policy_name": "high",
+            "unit": "B/s",
+            "measures": [
+                {
+                    "timestamp": "2018-01-20T12:30:00",
+                    "value": 273
+                },
+                {
+                    "timestamp": "2018-01-20T13:15:00",
+                    "value": 3141.14
+                }
+            ]
+        }
+    },
+    "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55": {
+        "disk.write.bytes.rate": {
+			"archive_policy_name": "low",
+			"unit": "B/s",
+            "measures": [
+                {
+                    "timestamp": "2018-01-20T12:30:00",
+                    "value": 1237
+                },
+                {
+                    "timestamp": "2018-01-20T13:15:00",
+                    "value": 132.12
+                }
+            ]
+        }
+    }
+}
+`

--- a/gnocchi/metric/v1/measures/testing/requests_test.go
+++ b/gnocchi/metric/v1/measures/testing/requests_test.go
@@ -134,3 +134,63 @@ func TestBatchCreateMetrics(t *testing.T) {
 	}
 	th.AssertNoErr(t, res.Err)
 }
+
+func TestCreateBatchResourcesMetricsMeasures(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v1/batch/resources/metrics/measures", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json, */*")
+		w.WriteHeader(http.StatusAccepted)
+	})
+
+	firstTimestamp := time.Date(2018, 1, 20, 12, 30, 0, 0, time.UTC)
+	secondTimestamp := time.Date(2018, 1, 20, 13, 15, 0, 0, time.UTC)
+	createOpts := measures.CreateBatchResourcesMetricsOpts{
+		CreateMetrics: true,
+		BatchResourcesMetricsMeasuresOpts: map[string]map[string][]measures.MeasureOpts{
+			"75274f99-faf6-4112-a6d5-2794cb07c789": {
+				"network.incoming.bytes.rate": []measures.MeasureOpts{
+					{
+						Timestamp: &firstTimestamp,
+						Value:     1562.82,
+					},
+					{
+						Timestamp: &secondTimestamp,
+						Value:     768.1,
+					},
+				},
+				"network.outgoing.bytes.rate": []measures.MeasureOpts{
+					{
+						Timestamp: &firstTimestamp,
+						Value:     273,
+					},
+					{
+						Timestamp: &secondTimestamp,
+						Value:     3141.14,
+					},
+				},
+			},
+			"23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55": {
+				"disk.write.bytes.rate": []measures.MeasureOpts{
+					{
+						Timestamp: &firstTimestamp,
+						Value:     1237,
+					},
+					{
+						Timestamp: &secondTimestamp,
+						Value:     132.12,
+					},
+				},
+			},
+		},
+	}
+	res := measures.CreateBatchResourcesMetrics(fake.ServiceClient(), createOpts)
+	if res.Err.Error() == "EOF" {
+		res.Err = nil
+	}
+	th.AssertNoErr(t, res.Err)
+}

--- a/gnocchi/metric/v1/measures/testing/requests_test.go
+++ b/gnocchi/metric/v1/measures/testing/requests_test.go
@@ -135,7 +135,7 @@ func TestBatchCreateMetrics(t *testing.T) {
 	th.AssertNoErr(t, res.Err)
 }
 
-func TestBatchResourcesMeasures(t *testing.T) {
+func TestBatchCreateResourcesMetrics(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 
@@ -149,46 +149,67 @@ func TestBatchResourcesMeasures(t *testing.T) {
 
 	firstTimestamp := time.Date(2018, 1, 20, 12, 30, 0, 0, time.UTC)
 	secondTimestamp := time.Date(2018, 1, 20, 13, 15, 0, 0, time.UTC)
-	createOpts := measures.BatchResourcesOpts{
+	createOpts := measures.BatchCreateResourcesMetricsOpts{
 		CreateMetrics: true,
-		BatchResourcesMetricsMeasuresOpts: map[string]map[string][]measures.MeasureOpts{
-			"75274f99-faf6-4112-a6d5-2794cb07c789": {
-				"network.incoming.bytes.rate": []measures.MeasureOpts{
+		BatchResourcesMetrics: []measures.BatchResourcesMetricsOpts{
+			{
+				ResourceID: "75274f99-faf6-4112-a6d5-2794cb07c789",
+				ResourcesMetrics: []measures.ResourcesMetricsOpts{
 					{
-						Timestamp: &firstTimestamp,
-						Value:     1562.82,
+						MetricName:        "network.incoming.bytes.rate",
+						ArchivePolicyName: "high",
+						Unit:              "B/s",
+						Measures: []measures.MeasureOpts{
+							{
+								Timestamp: &firstTimestamp,
+								Value:     1562.82,
+							},
+							{
+								Timestamp: &secondTimestamp,
+								Value:     768.1,
+							},
+						},
 					},
 					{
-						Timestamp: &secondTimestamp,
-						Value:     768.1,
-					},
-				},
-				"network.outgoing.bytes.rate": []measures.MeasureOpts{
-					{
-						Timestamp: &firstTimestamp,
-						Value:     273,
-					},
-					{
-						Timestamp: &secondTimestamp,
-						Value:     3141.14,
+						MetricName:        "network.outgoing.bytes.rate",
+						ArchivePolicyName: "high",
+						Unit:              "B/s",
+						Measures: []measures.MeasureOpts{
+							{
+								Timestamp: &firstTimestamp,
+								Value:     273,
+							},
+							{
+								Timestamp: &secondTimestamp,
+								Value:     3141.14,
+							},
+						},
 					},
 				},
 			},
-			"23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55": {
-				"disk.write.bytes.rate": []measures.MeasureOpts{
+			{
+				ResourceID: "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55",
+				ResourcesMetrics: []measures.ResourcesMetricsOpts{
 					{
-						Timestamp: &firstTimestamp,
-						Value:     1237,
-					},
-					{
-						Timestamp: &secondTimestamp,
-						Value:     132.12,
+						MetricName:        "disk.write.bytes.rate",
+						ArchivePolicyName: "low",
+						Unit:              "B/s",
+						Measures: []measures.MeasureOpts{
+							{
+								Timestamp: &firstTimestamp,
+								Value:     1237,
+							},
+							{
+								Timestamp: &secondTimestamp,
+								Value:     132.12,
+							},
+						},
 					},
 				},
 			},
 		},
 	}
-	res := measures.BatchResources(fake.ServiceClient(), createOpts)
+	res := measures.BatchCreateResourcesMetrics(fake.ServiceClient(), createOpts)
 	if res.Err.Error() == "EOF" {
 		res.Err = nil
 	}

--- a/gnocchi/metric/v1/measures/testing/requests_test.go
+++ b/gnocchi/metric/v1/measures/testing/requests_test.go
@@ -62,7 +62,9 @@ func TestCreateMeasures(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 		th.TestHeader(t, r, "Content-Type", "application/json")
 		th.TestHeader(t, r, "Accept", "application/json, */*")
+		th.TestJSONRequest(t, r, MeasuresCreateRequest)
 		w.WriteHeader(http.StatusAccepted)
+		fmt.Fprintf(w, `{}`)
 	})
 
 	firstMeasureTimestamp := time.Date(2018, 1, 18, 12, 31, 0, 0, time.UTC)
@@ -80,9 +82,6 @@ func TestCreateMeasures(t *testing.T) {
 		},
 	}
 	res := measures.Create(fake.ServiceClient(), "9e5a6441-1044-4181-b66e-34e180753040", createOpts)
-	if res.Err.Error() == "EOF" {
-		res.Err = nil
-	}
 	th.AssertNoErr(t, res.Err)
 }
 
@@ -95,7 +94,9 @@ func TestBatchCreateMetrics(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 		th.TestHeader(t, r, "Content-Type", "application/json")
 		th.TestHeader(t, r, "Accept", "application/json, */*")
+		th.TestJSONRequest(t, r, MeasuresBatchCreateMetricsRequest)
 		w.WriteHeader(http.StatusAccepted)
+		fmt.Fprintf(w, `{}`)
 	})
 
 	firstTimestamp := time.Date(2018, 1, 10, 01, 00, 0, 0, time.UTC)
@@ -129,9 +130,6 @@ func TestBatchCreateMetrics(t *testing.T) {
 		},
 	}
 	res := measures.BatchCreateMetrics(fake.ServiceClient(), createOpts)
-	if res.Err.Error() == "EOF" {
-		res.Err = nil
-	}
 	th.AssertNoErr(t, res.Err)
 }
 
@@ -144,7 +142,9 @@ func TestBatchCreateResourcesMetrics(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 		th.TestHeader(t, r, "Content-Type", "application/json")
 		th.TestHeader(t, r, "Accept", "application/json, */*")
+		th.TestJSONRequest(t, r, MeasuresBatchCreateResourcesMetricsRequest)
 		w.WriteHeader(http.StatusAccepted)
+		fmt.Fprintf(w, `{}`)
 	})
 
 	firstTimestamp := time.Date(2018, 1, 20, 12, 30, 0, 0, time.UTC)
@@ -210,8 +210,5 @@ func TestBatchCreateResourcesMetrics(t *testing.T) {
 		},
 	}
 	res := measures.BatchCreateResourcesMetrics(fake.ServiceClient(), createOpts)
-	if res.Err.Error() == "EOF" {
-		res.Err = nil
-	}
 	th.AssertNoErr(t, res.Err)
 }

--- a/gnocchi/metric/v1/measures/testing/requests_test.go
+++ b/gnocchi/metric/v1/measures/testing/requests_test.go
@@ -135,7 +135,7 @@ func TestBatchCreateMetrics(t *testing.T) {
 	th.AssertNoErr(t, res.Err)
 }
 
-func TestCreateBatchResourcesMetricsMeasures(t *testing.T) {
+func TestBatchResourcesMeasures(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 
@@ -149,7 +149,7 @@ func TestCreateBatchResourcesMetricsMeasures(t *testing.T) {
 
 	firstTimestamp := time.Date(2018, 1, 20, 12, 30, 0, 0, time.UTC)
 	secondTimestamp := time.Date(2018, 1, 20, 13, 15, 0, 0, time.UTC)
-	createOpts := measures.CreateBatchResourcesMetricsOpts{
+	createOpts := measures.BatchResourcesOpts{
 		CreateMetrics: true,
 		BatchResourcesMetricsMeasuresOpts: map[string]map[string][]measures.MeasureOpts{
 			"75274f99-faf6-4112-a6d5-2794cb07c789": {
@@ -188,7 +188,7 @@ func TestCreateBatchResourcesMetricsMeasures(t *testing.T) {
 			},
 		},
 	}
-	res := measures.CreateBatchResourcesMetrics(fake.ServiceClient(), createOpts)
+	res := measures.BatchResources(fake.ServiceClient(), createOpts)
 	if res.Err.Error() == "EOF" {
 		res.Err = nil
 	}

--- a/gnocchi/metric/v1/measures/urls.go
+++ b/gnocchi/metric/v1/measures/urls.go
@@ -3,9 +3,9 @@ package measures
 import "github.com/gophercloud/gophercloud"
 
 const (
-	resourcePath           = "metric"
-	batchCreateMetricsPath = "batch/metrics"
-	batchResourcePath      = "batch/resources/metrics"
+	resourcePath                    = "metric"
+	batchCreateMetricsPath          = "batch/metrics"
+	batchCreateResourcesMetricsPath = "batch/resources/metrics"
 )
 
 func resourceURL(c *gophercloud.ServiceClient, metricID string) string {
@@ -24,6 +24,6 @@ func batchCreateMetricsURL(c *gophercloud.ServiceClient) string {
 	return c.ServiceURL(batchCreateMetricsPath, "measures")
 }
 
-func batchResourcesURL(c *gophercloud.ServiceClient) string {
-	return c.ServiceURL(batchResourcePath, "measures")
+func batchCreateResourcesMetricsURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL(batchCreateResourcesMetricsPath, "measures")
 }

--- a/gnocchi/metric/v1/measures/urls.go
+++ b/gnocchi/metric/v1/measures/urls.go
@@ -3,9 +3,9 @@ package measures
 import "github.com/gophercloud/gophercloud"
 
 const (
-	resourcePath             = "metric"
-	batchCreateMetricsPath   = "batch/metrics"
-	batchResourceMetricsPath = "batch/resources/metrics"
+	resourcePath           = "metric"
+	batchCreateMetricsPath = "batch/metrics"
+	batchResourcePath      = "batch/resources/metrics"
 )
 
 func resourceURL(c *gophercloud.ServiceClient, metricID string) string {
@@ -24,6 +24,6 @@ func batchCreateMetricsURL(c *gophercloud.ServiceClient) string {
 	return c.ServiceURL(batchCreateMetricsPath, "measures")
 }
 
-func createBatchResourcesMetricsURL(c *gophercloud.ServiceClient) string {
-	return c.ServiceURL(batchResourceMetricsPath, "measures")
+func batchResourcesURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL(batchResourcePath, "measures")
 }

--- a/gnocchi/metric/v1/measures/urls.go
+++ b/gnocchi/metric/v1/measures/urls.go
@@ -3,8 +3,9 @@ package measures
 import "github.com/gophercloud/gophercloud"
 
 const (
-	resourcePath           = "metric"
-	batchCreateMetricsPath = "batch/metrics"
+	resourcePath             = "metric"
+	batchCreateMetricsPath   = "batch/metrics"
+	batchResourceMetricsPath = "batch/resources/metrics"
 )
 
 func resourceURL(c *gophercloud.ServiceClient, metricID string) string {
@@ -21,4 +22,8 @@ func createURL(c *gophercloud.ServiceClient, metricID string) string {
 
 func batchCreateMetricsURL(c *gophercloud.ServiceClient) string {
 	return c.ServiceURL(batchCreateMetricsPath, "measures")
+}
+
+func createBatchResourcesMetricsURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL(batchResourceMetricsPath, "measures")
 }


### PR DESCRIPTION
Add ability to create measures of a different metrics via resource IDs and metrics names references.
Add unit and acceptance tests and a documentation example.

That request implements pushing measures to different metrics via batch request to resource IDs and metric names.

Docs reference: [rest.html#batch (second example)](https://gnocchi.xyz/stable_4.2/rest.html#batch)

For [#698](https://github.com/gophercloud/gophercloud/issues/698)

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

API:

- https://github.com/gnocchixyz/gnocchi/blob/stable/4.2/gnocchi/rest/api.py#L1567

Storage code depends on a driver that is used for saving measures:

- Ceph: https://github.com/gnocchixyz/gnocchi/blob/stable/4.2/gnocchi/incoming/ceph.py#L81
- Redis: https://github.com/gnocchixyz/gnocchi/blob/stable/4.2/gnocchi/incoming/redis.py#L52
- File: https://github.com/gnocchixyz/gnocchi/blob/stable/4.2/gnocchi/incoming/file.py#L166
- S3: https://github.com/gnocchixyz/gnocchi/blob/stable/4.2/gnocchi/incoming/s3.py#L161
- Swift: https://github.com/gnocchixyz/gnocchi/blob/stable/4.2/gnocchi/incoming/swift.py#L100