### PR TITLE
Adding token authentication to clouds.yaml

### DIFF
--- a/openstack/clientconfig/requests.go
+++ b/openstack/clientconfig/requests.go
@@ -168,19 +168,23 @@ func AuthOptions(opts *ClientOpts) (*gophercloud.AuthOptions, error) {
 		ao.DomainName = v
 	}
 
+	// If an auth_type of "token" was specified, then make sure
+	// Gophercloud properly authenticates with a token. This involves
+	// unsetting a few other auth options. The reason this is done
+	// here is to wait until all auth settings (both in clouds.yaml
+	// and via environment variables) are set and then unset them.
+	if cloud.AuthType == "token" {
+		ao.TokenID = auth.Token
+		ao.Username = ""
+		ao.Password = ""
+		ao.UserID = ""
+		ao.DomainID = ""
+		ao.DomainName = ""
+	}
+
 	// Check for absolute minimum requirements.
 	if ao.IdentityEndpoint == "" {
 		err := gophercloud.ErrMissingInput{Argument: "authURL"}
-		return nil, err
-	}
-
-	if ao.Username == "" {
-		err := gophercloud.ErrMissingInput{Argument: "username"}
-		return nil, err
-	}
-
-	if ao.Password == "" {
-		err := gophercloud.ErrMissingInput{Argument: "password"}
 		return nil, err
 	}
 

--- a/openstack/clientconfig/results.go
+++ b/openstack/clientconfig/results.go
@@ -10,6 +10,7 @@ type Clouds struct {
 // Cloud represents an entry in a clouds.yaml file.
 type Cloud struct {
 	Auth       *CloudAuth    `yaml:"auth"`
+	AuthType   string        `yaml:"auth_type"`
 	RegionName string        `yaml:"region_name"`
 	Regions    []interface{} `yaml:"regions"`
 
@@ -21,6 +22,7 @@ type Cloud struct {
 // CloudAuth represents the auth section of a cloud entry.
 type CloudAuth struct {
 	AuthURL           string `yaml:"auth_url"`
+	Token             string `yaml:"token"`
 	Username          string `yaml:"username"`
 	Password          string `yaml:"password"`
 	ProjectName       string `yaml:"project_name"`

--- a/openstack/clientconfig/testing/clouds.yaml
+++ b/openstack/clientconfig/testing/clouds.yaml
@@ -28,4 +28,12 @@ clouds:
     regions:
       - SAN
       - LAX
-
+  arizona:
+    profile: "Some profile"
+    auth_type: "token"
+    auth:
+      auth_url: "https://az.example.com:5000/v3"
+      token: "12345"
+      project_id: "1234"
+      project_name: "Some Project"
+    region_name: "PHX"

--- a/openstack/clientconfig/testing/fixtures.go
+++ b/openstack/clientconfig/testing/fixtures.go
@@ -41,11 +41,23 @@ var CloudYAMLCalifornia = clientconfig.Cloud{
 	},
 }
 
+var CloudYAMLArizona = clientconfig.Cloud{
+	RegionName: "PHX",
+	AuthType:   "token",
+	Auth: &clientconfig.CloudAuth{
+		AuthURL:     "https://az.example.com:5000/v3",
+		Token:       "12345",
+		ProjectID:   "1234",
+		ProjectName: "Some Project",
+	},
+}
+
 var CloudYAML = clientconfig.Clouds{
 	Clouds: map[string]clientconfig.Cloud{
 		"hawaii":     CloudYAMLHawaii,
 		"florida":    CloudYAMLFlorida,
 		"california": CloudYAMLCalifornia,
+		"arizona":    CloudYAMLArizona,
 	},
 }
 
@@ -55,4 +67,11 @@ var HawaiiAuthOpts = &gophercloud.AuthOptions{
 	Password:         "password",
 	TenantName:       "Some Project",
 	DomainName:       "default",
+}
+
+var ArizonaAuthOpts = &gophercloud.AuthOptions{
+	IdentityEndpoint: "https://az.example.com:5000/v3",
+	TokenID:          "12345",
+	TenantID:         "1234",
+	TenantName:       "Some Project",
 }

--- a/openstack/clientconfig/testing/requests_test.go
+++ b/openstack/clientconfig/testing/requests_test.go
@@ -57,3 +57,18 @@ func TestAuthOptionsOSCLOUD(t *testing.T) {
 
 	th.AssertDeepEquals(t, HawaiiAuthOpts, actual)
 }
+
+func TestAuthOptionsToken(t *testing.T) {
+	os.Setenv("OS_CLOUD", "arizona")
+
+	clientOpts := &clientconfig.ClientOpts{
+		Cloud: "arizona",
+	}
+
+	actual, err := clientconfig.AuthOptions(clientOpts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	th.AssertDeepEquals(t, ArizonaAuthOpts, actual)
+}


### PR DESCRIPTION
For #25 

I removed the requirement to have a username and password set since token-based authentication complicates that. Invalid combinations will now be handled by Gophercloud and any errors will propagate up.

There are other possible `auth_types` such as `v3password` and `v2password`. Support for those can be added as needed. For now, `clouds.yaml` files which specify them will implicitly work if all other settings (username, password, and auth_url) are set correctly.

I've tested this locally with Terraform and can confirm the `clouds.yaml` format given in #25 works.

/cc @dklyle