### PR TITLE
clientconfig refactor

### DIFF
--- a/openstack/clientconfig/requests.go
+++ b/openstack/clientconfig/requests.go
@@ -168,19 +168,23 @@ func AuthOptions(opts *ClientOpts) (*gophercloud.AuthOptions, error) {
 		ao.DomainName = v
 	}
 
+	// If an auth_type of "token" was specified, then make sure
+	// Gophercloud properly authenticates with a token. This involves
+	// unsetting a few other auth options. The reason this is done
+	// here is to wait until all auth settings (both in clouds.yaml
+	// and via environment variables) are set and then unset them.
+	if cloud.AuthType == "token" {
+		ao.TokenID = auth.Token
+		ao.Username = ""
+		ao.Password = ""
+		ao.UserID = ""
+		ao.DomainID = ""
+		ao.DomainName = ""
+	}
+
 	// Check for absolute minimum requirements.
 	if ao.IdentityEndpoint == "" {
 		err := gophercloud.ErrMissingInput{Argument: "authURL"}
-		return nil, err
-	}
-
-	if ao.Username == "" {
-		err := gophercloud.ErrMissingInput{Argument: "username"}
-		return nil, err
-	}
-
-	if ao.Password == "" {
-		err := gophercloud.ErrMissingInput{Argument: "password"}
 		return nil, err
 	}
 

--- a/openstack/clientconfig/requests.go
+++ b/openstack/clientconfig/requests.go
@@ -11,6 +11,20 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+// AuthType respresents a valid method of authentication.
+type AuthType string
+
+const (
+	AuthPassword AuthType = "password"
+	AuthToken    AuthType = "token"
+
+	AuthV2Password AuthType = "v2password"
+	AuthV2Token    AuthType = "v2token"
+
+	AuthV3Password AuthType = "v3password"
+	AuthV3Token    AuthType = "v3token"
+)
+
 // ClientOpts represents options to customize the way a client is
 // configured.
 type ClientOpts struct {
@@ -22,11 +36,11 @@ type ClientOpts struct {
 
 	// AuthType specifies the type of authentication to use.
 	// By default, this is "password".
-	AuthType string
+	AuthType AuthType
 
-	// Auth defines the authentication information needed to
+	// AuthInfo defines the authentication information needed to
 	// authenticate to a cloud when clouds.yaml isn't used.
-	Auth *Auth
+	AuthInfo *AuthInfo
 }
 
 // LoadYAML will load a clouds.yaml file and return the full config.
@@ -138,17 +152,17 @@ func AuthOptions(opts *ClientOpts) (*gophercloud.AuthOptions, error) {
 		}
 	}
 
-	// If cloud.Auth is nil, then no cloud was specified.
-	if cloud.Auth == nil {
+	// If cloud.AuthInfo is nil, then no cloud was specified.
+	if cloud.AuthInfo == nil {
 		// If opts.Auth is not nil, then try using the auth settings from it.
-		if opts.Auth != nil {
-			cloud.Auth = opts.Auth
+		if opts.AuthInfo != nil {
+			cloud.AuthInfo = opts.AuthInfo
 		}
 
-		// If cloud.Auth is still nil, then set it to an empty Auth struct
+		// If cloud.AuthInfo is still nil, then set it to an empty Auth struct
 		// and rely on environment variables to do the authentication.
-		if cloud.Auth == nil {
-			cloud.Auth = new(Auth)
+		if cloud.AuthInfo == nil {
+			cloud.AuthInfo = new(AuthInfo)
 		}
 	}
 
@@ -179,12 +193,12 @@ func determineIdentityAPI(cloud *Cloud, opts *ClientOpts) string {
 	}
 
 	if identityAPI == "" {
-		if cloud.Auth != nil {
-			if strings.Contains(cloud.Auth.AuthURL, "v2.0") {
+		if cloud.AuthInfo != nil {
+			if strings.Contains(cloud.AuthInfo.AuthURL, "v2.0") {
 				identityAPI = "2.0"
 			}
 
-			if strings.Contains(cloud.Auth.AuthURL, "v3") {
+			if strings.Contains(cloud.AuthInfo.AuthURL, "v3") {
 				identityAPI = "3"
 			}
 		}
@@ -192,13 +206,13 @@ func determineIdentityAPI(cloud *Cloud, opts *ClientOpts) string {
 
 	if identityAPI == "" {
 		switch cloud.AuthType {
-		case "v2password":
+		case AuthV2Password:
 			identityAPI = "2.0"
-		case "v2token":
+		case AuthV2Token:
 			identityAPI = "2.0"
-		case "v3password":
+		case AuthV3Password:
 			identityAPI = "3"
-		case "v3token":
+		case AuthV3Token:
 			identityAPI = "3"
 		}
 	}
@@ -221,48 +235,48 @@ func v2auth(cloud *Cloud, opts *ClientOpts) (*gophercloud.AuthOptions, error) {
 	}
 
 	if v := os.Getenv(envPrefix + "AUTH_URL"); v != "" {
-		cloud.Auth.AuthURL = v
+		cloud.AuthInfo.AuthURL = v
 	}
 
 	if v := os.Getenv(envPrefix + "TOKEN"); v != "" {
-		cloud.Auth.Token = v
+		cloud.AuthInfo.Token = v
 	}
 
 	if v := os.Getenv(envPrefix + "AUTH_TOKEN"); v != "" {
-		cloud.Auth.Token = v
+		cloud.AuthInfo.Token = v
 	}
 
 	if v := os.Getenv(envPrefix + "USERNAME"); v != "" {
-		cloud.Auth.Username = v
+		cloud.AuthInfo.Username = v
 	}
 
 	if v := os.Getenv(envPrefix + "PASSWORD"); v != "" {
-		cloud.Auth.Password = v
+		cloud.AuthInfo.Password = v
 	}
 
 	if v := os.Getenv(envPrefix + "TENANT_ID"); v != "" {
-		cloud.Auth.ProjectID = v
+		cloud.AuthInfo.ProjectID = v
 	}
 
 	if v := os.Getenv(envPrefix + "PROJECT_ID"); v != "" {
-		cloud.Auth.ProjectID = v
+		cloud.AuthInfo.ProjectID = v
 	}
 
 	if v := os.Getenv(envPrefix + "TENANT_NAME"); v != "" {
-		cloud.Auth.ProjectName = v
+		cloud.AuthInfo.ProjectName = v
 	}
 
 	if v := os.Getenv(envPrefix + "PROJECT_NAME"); v != "" {
-		cloud.Auth.ProjectName = v
+		cloud.AuthInfo.ProjectName = v
 	}
 
 	ao := &gophercloud.AuthOptions{
-		IdentityEndpoint: cloud.Auth.AuthURL,
-		TokenID:          cloud.Auth.Token,
-		Username:         cloud.Auth.Username,
-		Password:         cloud.Auth.Password,
-		TenantID:         cloud.Auth.ProjectID,
-		TenantName:       cloud.Auth.ProjectName,
+		IdentityEndpoint: cloud.AuthInfo.AuthURL,
+		TokenID:          cloud.AuthInfo.Token,
+		Username:         cloud.AuthInfo.Username,
+		Password:         cloud.AuthInfo.Password,
+		TenantID:         cloud.AuthInfo.ProjectID,
+		TenantName:       cloud.AuthInfo.ProjectName,
 	}
 
 	return ao, nil
@@ -277,104 +291,104 @@ func v3auth(cloud *Cloud, opts *ClientOpts) (*gophercloud.AuthOptions, error) {
 	}
 
 	if v := os.Getenv(envPrefix + "AUTH_URL"); v != "" {
-		cloud.Auth.AuthURL = v
+		cloud.AuthInfo.AuthURL = v
 	}
 
 	if v := os.Getenv(envPrefix + "TOKEN"); v != "" {
-		cloud.Auth.Token = v
+		cloud.AuthInfo.Token = v
 	}
 
 	if v := os.Getenv(envPrefix + "AUTH_TOKEN"); v != "" {
-		cloud.Auth.Token = v
+		cloud.AuthInfo.Token = v
 	}
 
 	if v := os.Getenv(envPrefix + "USERNAME"); v != "" {
-		cloud.Auth.Username = v
+		cloud.AuthInfo.Username = v
 	}
 
 	if v := os.Getenv(envPrefix + "USER_ID"); v != "" {
-		cloud.Auth.UserID = v
+		cloud.AuthInfo.UserID = v
 	}
 
 	if v := os.Getenv(envPrefix + "PASSWORD"); v != "" {
-		cloud.Auth.Password = v
+		cloud.AuthInfo.Password = v
 	}
 
 	if v := os.Getenv(envPrefix + "TENANT_ID"); v != "" {
-		cloud.Auth.ProjectID = v
+		cloud.AuthInfo.ProjectID = v
 	}
 
 	if v := os.Getenv(envPrefix + "PROJECT_ID"); v != "" {
-		cloud.Auth.ProjectID = v
+		cloud.AuthInfo.ProjectID = v
 	}
 
 	if v := os.Getenv(envPrefix + "TENANT_NAME"); v != "" {
-		cloud.Auth.ProjectName = v
+		cloud.AuthInfo.ProjectName = v
 	}
 
 	if v := os.Getenv(envPrefix + "PROJECT_NAME"); v != "" {
-		cloud.Auth.ProjectName = v
+		cloud.AuthInfo.ProjectName = v
 	}
 
 	if v := os.Getenv(envPrefix + "DOMAIN_ID"); v != "" {
-		cloud.Auth.DomainID = v
+		cloud.AuthInfo.DomainID = v
 	}
 
 	if v := os.Getenv(envPrefix + "DOMAIN_NAME"); v != "" {
-		cloud.Auth.DomainName = v
+		cloud.AuthInfo.DomainName = v
 	}
 
 	if v := os.Getenv(envPrefix + "PROJECT_DOMAIN_ID"); v != "" {
-		cloud.Auth.ProjectDomainID = v
+		cloud.AuthInfo.ProjectDomainID = v
 	}
 
 	if v := os.Getenv(envPrefix + "PROJECT_DOMAIN_NAME"); v != "" {
-		cloud.Auth.ProjectDomainName = v
+		cloud.AuthInfo.ProjectDomainName = v
 	}
 
 	if v := os.Getenv(envPrefix + "USER_DOMAIN_ID"); v != "" {
-		cloud.Auth.UserDomainID = v
+		cloud.AuthInfo.UserDomainID = v
 	}
 
 	if v := os.Getenv(envPrefix + "USER_DOMAIN_NAME"); v != "" {
-		cloud.Auth.UserDomainName = v
+		cloud.AuthInfo.UserDomainName = v
 	}
 
 	// Build a scope and try to do it correctly.
 	// https://github.com/openstack/os-client-config/blob/master/os_client_config/config.py#L595
 	scope := new(gophercloud.AuthScope)
 
-	if !isProjectScoped(cloud.Auth) {
-		if cloud.Auth.DomainID != "" {
-			scope.DomainID = cloud.Auth.DomainID
-		} else if cloud.Auth.DomainName != "" {
-			scope.DomainName = cloud.Auth.DomainName
+	if !isProjectScoped(cloud.AuthInfo) {
+		if cloud.AuthInfo.DomainID != "" {
+			scope.DomainID = cloud.AuthInfo.DomainID
+		} else if cloud.AuthInfo.DomainName != "" {
+			scope.DomainName = cloud.AuthInfo.DomainName
 		}
 	} else {
 		// If Domain* is set, but UserDomain* or ProjectDomain* aren't,
 		// then use Domain* as the default setting.
 		cloud = setDomainIfNeeded(cloud)
 
-		if cloud.Auth.ProjectID != "" {
-			scope.ProjectID = cloud.Auth.ProjectID
+		if cloud.AuthInfo.ProjectID != "" {
+			scope.ProjectID = cloud.AuthInfo.ProjectID
 		} else {
-			scope.ProjectName = cloud.Auth.ProjectName
-			scope.DomainID = cloud.Auth.ProjectDomainID
-			scope.DomainName = cloud.Auth.ProjectDomainName
+			scope.ProjectName = cloud.AuthInfo.ProjectName
+			scope.DomainID = cloud.AuthInfo.ProjectDomainID
+			scope.DomainName = cloud.AuthInfo.ProjectDomainName
 		}
 	}
 
 	ao := &gophercloud.AuthOptions{
 		Scope:            scope,
-		IdentityEndpoint: cloud.Auth.AuthURL,
-		TokenID:          cloud.Auth.Token,
-		Username:         cloud.Auth.Username,
-		UserID:           cloud.Auth.UserID,
-		Password:         cloud.Auth.Password,
-		TenantID:         cloud.Auth.ProjectID,
-		TenantName:       cloud.Auth.ProjectName,
-		DomainID:         cloud.Auth.UserDomainID,
-		DomainName:       cloud.Auth.UserDomainName,
+		IdentityEndpoint: cloud.AuthInfo.AuthURL,
+		TokenID:          cloud.AuthInfo.Token,
+		Username:         cloud.AuthInfo.Username,
+		UserID:           cloud.AuthInfo.UserID,
+		Password:         cloud.AuthInfo.Password,
+		TenantID:         cloud.AuthInfo.ProjectID,
+		TenantName:       cloud.AuthInfo.ProjectName,
+		DomainID:         cloud.AuthInfo.UserDomainID,
+		DomainName:       cloud.AuthInfo.UserDomainName,
 	}
 
 	// If an auth_type of "token" was specified, then make sure
@@ -382,7 +396,7 @@ func v3auth(cloud *Cloud, opts *ClientOpts) (*gophercloud.AuthOptions, error) {
 	// unsetting a few other auth options. The reason this is done
 	// here is to wait until all auth settings (both in clouds.yaml
 	// and via environment variables) are set and then unset them.
-	if strings.Contains(cloud.AuthType, "token") || ao.TokenID != "" {
+	if strings.Contains(string(cloud.AuthType), "token") || ao.TokenID != "" {
 		ao.Username = ""
 		ao.Password = ""
 		ao.UserID = ""
@@ -392,7 +406,7 @@ func v3auth(cloud *Cloud, opts *ClientOpts) (*gophercloud.AuthOptions, error) {
 
 	// Check for absolute minimum requirements.
 	if ao.IdentityEndpoint == "" {
-		err := gophercloud.ErrMissingInput{Argument: "authURL"}
+		err := gophercloud.ErrMissingInput{Argument: "auth_url"}
 		return nil, err
 	}
 
@@ -423,7 +437,7 @@ func NewServiceClient(service string, opts *ClientOpts) (*gophercloud.ServiceCli
 	}
 
 	if cloud == nil {
-		cloud.Auth = opts.Auth
+		cloud.AuthInfo = opts.AuthInfo
 	}
 
 	// Environment variable overrides.

--- a/openstack/clientconfig/results.go
+++ b/openstack/clientconfig/results.go
@@ -9,8 +9,8 @@ type Clouds struct {
 
 // Cloud represents an entry in a clouds.yaml file.
 type Cloud struct {
-	Auth       *Auth         `yaml:"auth"`
-	AuthType   string        `yaml:"auth_type"`
+	AuthInfo   *AuthInfo     `yaml:"auth"`
+	AuthType   AuthType      `yaml:"auth_type"`
 	RegionName string        `yaml:"region_name"`
 	Regions    []interface{} `yaml:"regions"`
 
@@ -21,7 +21,7 @@ type Cloud struct {
 
 // Auth represents the auth section of a cloud entry or
 // auth options entered explicitly in ClientOpts.
-type Auth struct {
+type AuthInfo struct {
 	// AuthURL is the keystone/identity endpoint URL.
 	AuthURL string `yaml:"auth_url"`
 

--- a/openstack/clientconfig/results.go
+++ b/openstack/clientconfig/results.go
@@ -10,6 +10,7 @@ type Clouds struct {
 // Cloud represents an entry in a clouds.yaml file.
 type Cloud struct {
 	Auth       *CloudAuth    `yaml:"auth"`
+	AuthType   string        `yaml:"auth_type"`
 	RegionName string        `yaml:"region_name"`
 	Regions    []interface{} `yaml:"regions"`
 
@@ -21,6 +22,7 @@ type Cloud struct {
 // CloudAuth represents the auth section of a cloud entry.
 type CloudAuth struct {
 	AuthURL           string `yaml:"auth_url"`
+	Token             string `yaml:"token"`
 	Username          string `yaml:"username"`
 	Password          string `yaml:"password"`
 	ProjectName       string `yaml:"project_name"`

--- a/openstack/clientconfig/results.go
+++ b/openstack/clientconfig/results.go
@@ -9,7 +9,7 @@ type Clouds struct {
 
 // Cloud represents an entry in a clouds.yaml file.
 type Cloud struct {
-	Auth       *CloudAuth    `yaml:"auth"`
+	Auth       *Auth         `yaml:"auth"`
 	AuthType   string        `yaml:"auth_type"`
 	RegionName string        `yaml:"region_name"`
 	Regions    []interface{} `yaml:"regions"`
@@ -19,18 +19,66 @@ type Cloud struct {
 	VolumeAPIVersion   string `yaml:"volume_api_version"`
 }
 
-// CloudAuth represents the auth section of a cloud entry.
-type CloudAuth struct {
-	AuthURL           string `yaml:"auth_url"`
-	Token             string `yaml:"token"`
-	Username          string `yaml:"username"`
-	Password          string `yaml:"password"`
-	ProjectName       string `yaml:"project_name"`
-	ProjectID         string `yaml:"project_id"`
-	DomainName        string `yaml:"domain_name"`
-	DomainID          string `yaml:"domain_id"`
-	UserDomainName    string `yaml:"user_domain_name"`
-	UserDomainID      string `yaml:"user_domain_id"`
+// Auth represents the auth section of a cloud entry or
+// auth options entered explicitly in ClientOpts.
+type Auth struct {
+	// AuthURL is the keystone/identity endpoint URL.
+	AuthURL string `yaml:"auth_url"`
+
+	// Token is a pre-generated authentication token.
+	Token string `yaml:"token"`
+
+	// Username is the username of the user.
+	Username string `yaml:"username"`
+
+	// UserID is the unique ID of a user.
+	UserID string `yaml:"user_id"`
+
+	// Password is the password of the user.
+	Password string `yaml:"password"`
+
+	// ProjectName is the common/human-readable name of a project.
+	// Users can be scoped to a project.
+	// ProjectName on its own is not enough to ensure a unique scope. It must
+	// also be combined with either a ProjectDomainName or ProjectDomainID.
+	// ProjectName cannot be combined with ProjectID in a scope.
+	ProjectName string `yaml:"project_name"`
+
+	// ProjectID is the unique ID of a project.
+	// It can be used to scope a user to a specific project.
+	ProjectID string `yaml:"project_id"`
+
+	// UserDomainName is the name of the domain where a user resides.
+	// It is used to identify the source domain of a user.
+	UserDomainName string `yaml:"user_domain_name"`
+
+	// UserDomainID is the unique ID of the domain where a user resides.
+	// It is used to identify the source domain of a user.
+	UserDomainID string `yaml:"user_domain_id"`
+
+	// ProjectDomainName is the name of the domain where a project resides.
+	// It is used to identify the source domain of a project.
+	// ProjectDomainName can be used in addition to a ProjectName when scoping
+	// a user to a specific project.
 	ProjectDomainName string `yaml:"project_domain_name"`
-	ProjectDomainID   string `yaml:"project_domain_id"`
+
+	// ProjectDomainID is the name of the domain where a project resides.
+	// It is used to identify the source domain of a project.
+	// ProjectDomainID can be used in addition to a ProjectName when scoping
+	// a user to a specific project.
+	ProjectDomainID string `yaml:"project_domain_id"`
+
+	// DomainName is the name of a domain which can be used to identify the
+	// source domain of either a user or a project.
+	// If UserDomainName and ProjectDomainName are not specified, then DomainName
+	// is used as a default choice.
+	// It can also be used be used to specify a domain-only scope.
+	DomainName string `yaml:"domain_name"`
+
+	// DomainID is the unique ID of a domain which can be used to identify the
+	// source domain of eitehr a user or a project.
+	// If UserDomainID and ProjectDomainID are not specified, then DomainID is
+	// used as a default choice.
+	// It can also be used be used to specify a domain-only scope.
+	DomainID string `yaml:"domain_id"`
 }

--- a/openstack/clientconfig/testing/clouds.yaml
+++ b/openstack/clientconfig/testing/clouds.yaml
@@ -28,4 +28,12 @@ clouds:
     regions:
       - SAN
       - LAX
-
+  arizona:
+    profile: "Some profile"
+    auth_type: "token"
+    auth:
+      auth_url: "https://az.example.com:5000/v3"
+      token: "12345"
+      project_id: "1234"
+      project_name: "Some Project"
+    region_name: "PHX"

--- a/openstack/clientconfig/testing/clouds.yaml
+++ b/openstack/clientconfig/testing/clouds.yaml
@@ -25,6 +25,7 @@ clouds:
       password: "password"
       project_name: "Some Project"
       project_domain_name: "default"
+      user_domain_name: "default"
     regions:
       - SAN
       - LAX
@@ -34,6 +35,45 @@ clouds:
     auth:
       auth_url: "https://az.example.com:5000/v3"
       token: "12345"
-      project_id: "1234"
       project_name: "Some Project"
+      domain_name: "default"
     region_name: "PHX"
+  newmexico:
+    profile: "Some profile"
+    auth_type: "password"
+    auth:
+      auth_url: "https://nm.example.com:5000/v3"
+      username: "jdoe"
+      password: "password"
+      project_name: "Some Project"
+      project_domain_name: "Some Domain"
+      user_domain_name: "Other Domain"
+      domain_name: "default"
+    region_name: "SAF"
+  nevada:
+    profile: "Some profile"
+    auth_type: "password"
+    auth:
+      auth_url: "https://nv.example.com:5000/v3"
+      user_id: "12345"
+      password: "password"
+      project_name: "Some Project"
+      project_domain_name: "Some Domain"
+    region_name: "LAS"
+  alberta:
+    profile: "Some profile"
+    auth_type: "password"
+    auth:
+      auth_url: "https://ab.example.com:5000/v2.0"
+      username: "jdoe"
+      password: "password"
+      project_name: "Some Project"
+    region_name: "YYC"
+  yukon:
+    profile: "Some profile"
+    auth_type: "v2token"
+    auth:
+      auth_url: "https://yt.example.com:5000/v2.0"
+      token: "12345"
+      project_name: "Some Project"
+    region_name: "YXY"

--- a/openstack/clientconfig/testing/fixtures.go
+++ b/openstack/clientconfig/testing/fixtures.go
@@ -7,7 +7,7 @@ import (
 
 var HawaiiCloudYAML = clientconfig.Cloud{
 	RegionName: "HNL",
-	Auth: &clientconfig.Auth{
+	AuthInfo: &clientconfig.AuthInfo{
 		AuthURL:     "https://hi.example.com:5000/v3",
 		Username:    "jdoe",
 		Password:    "password",
@@ -17,7 +17,7 @@ var HawaiiCloudYAML = clientconfig.Cloud{
 }
 
 var HawaiiClientOpts = &clientconfig.ClientOpts{
-	Auth: &clientconfig.Auth{
+	AuthInfo: &clientconfig.AuthInfo{
 		AuthURL:     "https://hi.example.com:5000/v3",
 		Username:    "jdoe",
 		Password:    "password",
@@ -48,7 +48,7 @@ var HawaiiAuthOpts = &gophercloud.AuthOptions{
 
 var FloridaCloudYAML = clientconfig.Cloud{
 	RegionName: "MIA",
-	Auth: &clientconfig.Auth{
+	AuthInfo: &clientconfig.AuthInfo{
 		AuthURL:      "https://fl.example.com:5000/v3",
 		Username:     "jdoe",
 		Password:     "password",
@@ -58,7 +58,7 @@ var FloridaCloudYAML = clientconfig.Cloud{
 }
 
 var FloridaClientOpts = &clientconfig.ClientOpts{
-	Auth: &clientconfig.Auth{
+	AuthInfo: &clientconfig.AuthInfo{
 		AuthURL:      "https://fl.example.com:5000/v3",
 		Username:     "jdoe",
 		Password:     "password",
@@ -91,7 +91,7 @@ var CaliforniaCloudYAML = clientconfig.Cloud{
 		"SAN",
 		"LAX",
 	},
-	Auth: &clientconfig.Auth{
+	AuthInfo: &clientconfig.AuthInfo{
 		AuthURL:           "https://ca.example.com:5000/v3",
 		Username:          "jdoe",
 		Password:          "password",
@@ -102,7 +102,7 @@ var CaliforniaCloudYAML = clientconfig.Cloud{
 }
 
 var CaliforniaClientOpts = &clientconfig.ClientOpts{
-	Auth: &clientconfig.Auth{
+	AuthInfo: &clientconfig.AuthInfo{
 		AuthURL:           "https://ca.example.com:5000/v3",
 		Username:          "jdoe",
 		Password:          "password",
@@ -135,8 +135,8 @@ var CaliforniaAuthOpts = &gophercloud.AuthOptions{
 
 var ArizonaCloudYAML = clientconfig.Cloud{
 	RegionName: "PHX",
-	AuthType:   "token",
-	Auth: &clientconfig.Auth{
+	AuthType:   clientconfig.AuthToken,
+	AuthInfo: &clientconfig.AuthInfo{
 		AuthURL:     "https://az.example.com:5000/v3",
 		Token:       "12345",
 		ProjectName: "Some Project",
@@ -145,7 +145,7 @@ var ArizonaCloudYAML = clientconfig.Cloud{
 }
 
 var ArizonaClientOpts = &clientconfig.ClientOpts{
-	Auth: &clientconfig.Auth{
+	AuthInfo: &clientconfig.AuthInfo{
 		AuthURL:     "https://az.example.com:5000/v3",
 		Token:       "12345",
 		ProjectName: "Some Project",
@@ -172,8 +172,8 @@ var ArizonaAuthOpts = &gophercloud.AuthOptions{
 
 var NewMexicoCloudYAML = clientconfig.Cloud{
 	RegionName: "SAF",
-	AuthType:   "password",
-	Auth: &clientconfig.Auth{
+	AuthType:   clientconfig.AuthPassword,
+	AuthInfo: &clientconfig.AuthInfo{
 		AuthURL:           "https://nm.example.com:5000/v3",
 		Username:          "jdoe",
 		Password:          "password",
@@ -185,7 +185,7 @@ var NewMexicoCloudYAML = clientconfig.Cloud{
 }
 
 var NewMexicoClientOpts = &clientconfig.ClientOpts{
-	Auth: &clientconfig.Auth{
+	AuthInfo: &clientconfig.AuthInfo{
 		AuthURL:           "https://nm.example.com:5000/v3",
 		Username:          "jdoe",
 		Password:          "password",
@@ -220,7 +220,7 @@ var NewMexicoAuthOpts = &gophercloud.AuthOptions{
 
 var NevadaCloudYAML = clientconfig.Cloud{
 	RegionName: "LAS",
-	Auth: &clientconfig.Auth{
+	AuthInfo: &clientconfig.AuthInfo{
 		AuthURL:           "https://nv.example.com:5000/v3",
 		UserID:            "12345",
 		Password:          "password",
@@ -230,7 +230,7 @@ var NevadaCloudYAML = clientconfig.Cloud{
 }
 
 var NevadaClientOpts = &clientconfig.ClientOpts{
-	Auth: &clientconfig.Auth{
+	AuthInfo: &clientconfig.AuthInfo{
 		AuthURL:           "https://nv.example.com:5000/v3",
 		UserID:            "12345",
 		Password:          "password",
@@ -271,8 +271,8 @@ var CloudYAML = clientconfig.Clouds{
 
 var AlbertaCloudYAML = clientconfig.Cloud{
 	RegionName: "YYC",
-	AuthType:   "password",
-	Auth: &clientconfig.Auth{
+	AuthType:   clientconfig.AuthPassword,
+	AuthInfo: &clientconfig.AuthInfo{
 		AuthURL:     "https://ab.example.com:5000/v2.0",
 		Username:    "jdoe",
 		Password:    "password",
@@ -281,7 +281,7 @@ var AlbertaCloudYAML = clientconfig.Cloud{
 }
 
 var AlbertaClientOpts = &clientconfig.ClientOpts{
-	Auth: &clientconfig.Auth{
+	AuthInfo: &clientconfig.AuthInfo{
 		AuthURL:     "https://ab.example.com:5000/v2.0",
 		Username:    "jdoe",
 		Password:    "password",
@@ -306,8 +306,8 @@ var AlbertaAuthOpts = &gophercloud.AuthOptions{
 
 var YukonCloudYAML = clientconfig.Cloud{
 	RegionName: "YXY",
-	AuthType:   "v2token",
-	Auth: &clientconfig.Auth{
+	AuthType:   clientconfig.AuthV2Token,
+	AuthInfo: &clientconfig.AuthInfo{
 		AuthURL:     "https://yt.example.com:5000/v2.0",
 		Token:       "12345",
 		ProjectName: "Some Project",
@@ -315,7 +315,7 @@ var YukonCloudYAML = clientconfig.Cloud{
 }
 
 var YukonClientOpts = &clientconfig.ClientOpts{
-	Auth: &clientconfig.Auth{
+	AuthInfo: &clientconfig.AuthInfo{
 		AuthURL:     "https://yt.example.com:5000/v2.0",
 		Token:       "12345",
 		ProjectName: "Some Project",

--- a/openstack/clientconfig/testing/fixtures.go
+++ b/openstack/clientconfig/testing/fixtures.go
@@ -41,11 +41,23 @@ var CloudYAMLCalifornia = clientconfig.Cloud{
 	},
 }
 
+var CloudYAMLArizona = clientconfig.Cloud{
+	RegionName: "PHX",
+	AuthType:   "token",
+	Auth: &clientconfig.CloudAuth{
+		AuthURL:     "https://az.example.com:5000/v3",
+		Token:       "12345",
+		ProjectID:   "1234",
+		ProjectName: "Some Project",
+	},
+}
+
 var CloudYAML = clientconfig.Clouds{
 	Clouds: map[string]clientconfig.Cloud{
 		"hawaii":     CloudYAMLHawaii,
 		"florida":    CloudYAMLFlorida,
 		"california": CloudYAMLCalifornia,
+		"arizona":    CloudYAMLArizona,
 	},
 }
 
@@ -55,4 +67,11 @@ var HawaiiAuthOpts = &gophercloud.AuthOptions{
 	Password:         "password",
 	TenantName:       "Some Project",
 	DomainName:       "default",
+}
+
+var ArizonaAuthOpts = &gophercloud.AuthOptions{
+	IdentityEndpoint: "https://az.example.com:5000/v3",
+	TokenID:          "12345",
+	TenantID:         "1234",
+	TenantName:       "Some Project",
 }

--- a/openstack/clientconfig/testing/fixtures.go
+++ b/openstack/clientconfig/testing/fixtures.go
@@ -5,9 +5,9 @@ import (
 	"github.com/gophercloud/utils/openstack/clientconfig"
 )
 
-var CloudYAMLHawaii = clientconfig.Cloud{
+var HawaiiCloudYAML = clientconfig.Cloud{
 	RegionName: "HNL",
-	Auth: &clientconfig.CloudAuth{
+	Auth: &clientconfig.Auth{
 		AuthURL:     "https://hi.example.com:5000/v3",
 		Username:    "jdoe",
 		Password:    "password",
@@ -16,9 +16,39 @@ var CloudYAMLHawaii = clientconfig.Cloud{
 	},
 }
 
-var CloudYAMLFlorida = clientconfig.Cloud{
+var HawaiiClientOpts = &clientconfig.ClientOpts{
+	Auth: &clientconfig.Auth{
+		AuthURL:     "https://hi.example.com:5000/v3",
+		Username:    "jdoe",
+		Password:    "password",
+		ProjectName: "Some Project",
+		DomainName:  "default",
+	},
+}
+
+var HawaiiEnvAuth = map[string]string{
+	"OS_AUTH_URL":     "https://hi.example.com:5000/v3",
+	"OS_USERNAME":     "jdoe",
+	"OS_PASSWORD":     "password",
+	"OS_PROJECT_NAME": "Some Project",
+	"OS_DOMAIN_NAME":  "default",
+}
+
+var HawaiiAuthOpts = &gophercloud.AuthOptions{
+	Scope: &gophercloud.AuthScope{
+		ProjectName: "Some Project",
+		DomainName:  "default",
+	},
+	IdentityEndpoint: "https://hi.example.com:5000/v3",
+	Username:         "jdoe",
+	Password:         "password",
+	TenantName:       "Some Project",
+	DomainName:       "default",
+}
+
+var FloridaCloudYAML = clientconfig.Cloud{
 	RegionName: "MIA",
-	Auth: &clientconfig.CloudAuth{
+	Auth: &clientconfig.Auth{
 		AuthURL:      "https://fl.example.com:5000/v3",
 		Username:     "jdoe",
 		Password:     "password",
@@ -27,51 +57,287 @@ var CloudYAMLFlorida = clientconfig.Cloud{
 	},
 }
 
-var CloudYAMLCalifornia = clientconfig.Cloud{
+var FloridaClientOpts = &clientconfig.ClientOpts{
+	Auth: &clientconfig.Auth{
+		AuthURL:      "https://fl.example.com:5000/v3",
+		Username:     "jdoe",
+		Password:     "password",
+		ProjectID:    "12345",
+		UserDomainID: "abcde",
+	},
+}
+
+var FloridaEnvAuth = map[string]string{
+	"OS_AUTH_URL":       "https://fl.example.com:5000/v3",
+	"OS_USERNAME":       "jdoe",
+	"OS_PASSWORD":       "password",
+	"OS_PROJECT_ID":     "12345",
+	"OS_USER_DOMAIN_ID": "abcde",
+}
+
+var FloridaAuthOpts = &gophercloud.AuthOptions{
+	Scope: &gophercloud.AuthScope{
+		ProjectID: "12345",
+	},
+	IdentityEndpoint: "https://fl.example.com:5000/v3",
+	Username:         "jdoe",
+	Password:         "password",
+	TenantID:         "12345",
+	DomainID:         "abcde",
+}
+
+var CaliforniaCloudYAML = clientconfig.Cloud{
 	Regions: []interface{}{
 		"SAN",
 		"LAX",
 	},
-	Auth: &clientconfig.CloudAuth{
+	Auth: &clientconfig.Auth{
 		AuthURL:           "https://ca.example.com:5000/v3",
 		Username:          "jdoe",
 		Password:          "password",
 		ProjectName:       "Some Project",
 		ProjectDomainName: "default",
+		UserDomainName:    "default",
 	},
 }
 
-var CloudYAMLArizona = clientconfig.Cloud{
-	RegionName: "PHX",
-	AuthType:   "token",
-	Auth: &clientconfig.CloudAuth{
-		AuthURL:     "https://az.example.com:5000/v3",
-		Token:       "12345",
-		ProjectID:   "1234",
+var CaliforniaClientOpts = &clientconfig.ClientOpts{
+	Auth: &clientconfig.Auth{
+		AuthURL:           "https://ca.example.com:5000/v3",
+		Username:          "jdoe",
+		Password:          "password",
+		ProjectName:       "Some Project",
+		ProjectDomainName: "default",
+		UserDomainName:    "default",
+	},
+}
+
+var CaliforniaEnvAuth = map[string]string{
+	"OS_AUTH_URL":            "https://ca.example.com:5000/v3",
+	"OS_USERNAME":            "jdoe",
+	"OS_PASSWORD":            "password",
+	"OS_PROJECT_NAME":        "Some Project",
+	"OS_PROJECT_DOMAIN_NAME": "default",
+	"OS_USER_DOMAIN_NAME":    "default",
+}
+
+var CaliforniaAuthOpts = &gophercloud.AuthOptions{
+	Scope: &gophercloud.AuthScope{
 		ProjectName: "Some Project",
+		DomainName:  "default",
 	},
-}
-
-var CloudYAML = clientconfig.Clouds{
-	Clouds: map[string]clientconfig.Cloud{
-		"hawaii":     CloudYAMLHawaii,
-		"florida":    CloudYAMLFlorida,
-		"california": CloudYAMLCalifornia,
-		"arizona":    CloudYAMLArizona,
-	},
-}
-
-var HawaiiAuthOpts = &gophercloud.AuthOptions{
-	IdentityEndpoint: "https://hi.example.com:5000/v3",
+	IdentityEndpoint: "https://ca.example.com:5000/v3",
 	Username:         "jdoe",
 	Password:         "password",
 	TenantName:       "Some Project",
 	DomainName:       "default",
 }
 
+var ArizonaCloudYAML = clientconfig.Cloud{
+	RegionName: "PHX",
+	AuthType:   "token",
+	Auth: &clientconfig.Auth{
+		AuthURL:     "https://az.example.com:5000/v3",
+		Token:       "12345",
+		ProjectName: "Some Project",
+		DomainName:  "default",
+	},
+}
+
+var ArizonaClientOpts = &clientconfig.ClientOpts{
+	Auth: &clientconfig.Auth{
+		AuthURL:     "https://az.example.com:5000/v3",
+		Token:       "12345",
+		ProjectName: "Some Project",
+		DomainName:  "default",
+	},
+}
+
+var ArizonaEnvAuth = map[string]string{
+	"OS_AUTH_URL":     "https://az.example.com:5000/v3",
+	"OS_TOKEN":        "12345",
+	"OS_PROJECT_NAME": "Some Project",
+	"OS_DOMAIN_NAME":  "default",
+}
+
 var ArizonaAuthOpts = &gophercloud.AuthOptions{
+	Scope: &gophercloud.AuthScope{
+		ProjectName: "Some Project",
+		DomainName:  "default",
+	},
 	IdentityEndpoint: "https://az.example.com:5000/v3",
 	TokenID:          "12345",
-	TenantID:         "1234",
 	TenantName:       "Some Project",
+}
+
+var NewMexicoCloudYAML = clientconfig.Cloud{
+	RegionName: "SAF",
+	AuthType:   "password",
+	Auth: &clientconfig.Auth{
+		AuthURL:           "https://nm.example.com:5000/v3",
+		Username:          "jdoe",
+		Password:          "password",
+		ProjectName:       "Some Project",
+		ProjectDomainName: "Some Domain",
+		UserDomainName:    "Some OtherDomain",
+		DomainName:        "default",
+	},
+}
+
+var NewMexicoClientOpts = &clientconfig.ClientOpts{
+	Auth: &clientconfig.Auth{
+		AuthURL:           "https://nm.example.com:5000/v3",
+		Username:          "jdoe",
+		Password:          "password",
+		ProjectName:       "Some Project",
+		ProjectDomainName: "Some Domain",
+		UserDomainName:    "Other Domain",
+		DomainName:        "default",
+	},
+}
+
+var NewMexicoEnvAuth = map[string]string{
+	"OS_AUTH_URL":            "https://nm.example.com:5000/v3",
+	"OS_USERNAME":            "jdoe",
+	"OS_PASSWORD":            "password",
+	"OS_PROJECT_NAME":        "Some Project",
+	"OS_PROJECT_DOMAIN_NAME": "Some Domain",
+	"OS_USER_DOMAIN_NAME":    "Other Domain",
+	"OS_DOMAIN_NAME":         "default",
+}
+
+var NewMexicoAuthOpts = &gophercloud.AuthOptions{
+	Scope: &gophercloud.AuthScope{
+		ProjectName: "Some Project",
+		DomainName:  "Some Domain",
+	},
+	IdentityEndpoint: "https://nm.example.com:5000/v3",
+	Username:         "jdoe",
+	Password:         "password",
+	TenantName:       "Some Project",
+	DomainName:       "Other Domain",
+}
+
+var NevadaCloudYAML = clientconfig.Cloud{
+	RegionName: "LAS",
+	Auth: &clientconfig.Auth{
+		AuthURL:           "https://nv.example.com:5000/v3",
+		UserID:            "12345",
+		Password:          "password",
+		ProjectName:       "Some Project",
+		ProjectDomainName: "Some Domain",
+	},
+}
+
+var NevadaClientOpts = &clientconfig.ClientOpts{
+	Auth: &clientconfig.Auth{
+		AuthURL:           "https://nv.example.com:5000/v3",
+		UserID:            "12345",
+		Password:          "password",
+		ProjectName:       "Some Project",
+		ProjectDomainName: "Some Domain",
+	},
+}
+
+var NevadaEnvAuth = map[string]string{
+	"OS_AUTH_URL":            "https://nv.example.com:5000/v3",
+	"OS_USER_ID":             "12345",
+	"OS_PASSWORD":            "password",
+	"OS_PROJECT_NAME":        "Some Project",
+	"OS_PROJECT_DOMAIN_NAME": "Some Domain",
+}
+
+var NevadaAuthOpts = &gophercloud.AuthOptions{
+	Scope: &gophercloud.AuthScope{
+		ProjectName: "Some Project",
+		DomainName:  "Some Domain",
+	},
+	IdentityEndpoint: "https://nv.example.com:5000/v3",
+	UserID:           "12345",
+	Password:         "password",
+	TenantName:       "Some Project",
+}
+
+var CloudYAML = clientconfig.Clouds{
+	Clouds: map[string]clientconfig.Cloud{
+		"hawaii":     HawaiiCloudYAML,
+		"florida":    FloridaCloudYAML,
+		"california": CaliforniaCloudYAML,
+		"arizona":    ArizonaCloudYAML,
+		"newmexico":  NewMexicoCloudYAML,
+		"nevada":     NevadaCloudYAML,
+	},
+}
+
+var AlbertaCloudYAML = clientconfig.Cloud{
+	RegionName: "YYC",
+	AuthType:   "password",
+	Auth: &clientconfig.Auth{
+		AuthURL:     "https://ab.example.com:5000/v2.0",
+		Username:    "jdoe",
+		Password:    "password",
+		ProjectName: "Some Project",
+	},
+}
+
+var AlbertaClientOpts = &clientconfig.ClientOpts{
+	Auth: &clientconfig.Auth{
+		AuthURL:     "https://ab.example.com:5000/v2.0",
+		Username:    "jdoe",
+		Password:    "password",
+		ProjectName: "Some Project",
+	},
+}
+
+var AlbertaEnvAuth = map[string]string{
+	"OS_AUTH_URL":             "https://ab.example.com:5000/v2.0",
+	"OS_USERNAME":             "jdoe",
+	"OS_PASSWORD":             "password",
+	"OS_PROJECT_NAME":         "Some Project",
+	"OS_IDENTITY_API_VERSION": "2.0",
+}
+
+var AlbertaAuthOpts = &gophercloud.AuthOptions{
+	IdentityEndpoint: "https://ab.example.com:5000/v2.0",
+	Username:         "jdoe",
+	Password:         "password",
+	TenantName:       "Some Project",
+}
+
+var YukonCloudYAML = clientconfig.Cloud{
+	RegionName: "YXY",
+	AuthType:   "v2token",
+	Auth: &clientconfig.Auth{
+		AuthURL:     "https://yt.example.com:5000/v2.0",
+		Token:       "12345",
+		ProjectName: "Some Project",
+	},
+}
+
+var YukonClientOpts = &clientconfig.ClientOpts{
+	Auth: &clientconfig.Auth{
+		AuthURL:     "https://yt.example.com:5000/v2.0",
+		Token:       "12345",
+		ProjectName: "Some Project",
+	},
+}
+
+var YukonEnvAuth = map[string]string{
+	"OS_AUTH_URL":             "https://yt.example.com:5000/v2.0",
+	"OS_TOKEN":                "12345",
+	"OS_PROJECT_NAME":         "Some Project",
+	"OS_IDENTITY_API_VERSION": "2.0",
+}
+
+var YukonAuthOpts = &gophercloud.AuthOptions{
+	IdentityEndpoint: "https://yt.example.com:5000/v2.0",
+	TokenID:          "12345",
+	TenantName:       "Some Project",
+}
+
+var LegacyCloudYAML = clientconfig.Clouds{
+	Clouds: map[string]clientconfig.Cloud{
+		"alberta": AlbertaCloudYAML,
+		"yukon":   YukonCloudYAML,
+	},
 }

--- a/openstack/clientconfig/testing/requests_test.go
+++ b/openstack/clientconfig/testing/requests_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/utils/openstack/clientconfig"
 
 	th "github.com/gophercloud/gophercloud/testhelper"
@@ -17,7 +18,7 @@ func TestGetCloudFromYAML(t *testing.T) {
 
 	actual, err := clientconfig.GetCloudFromYAML(clientOpts)
 	th.AssertNoErr(t, err)
-	th.AssertDeepEquals(t, &CloudYAMLHawaii, actual)
+	th.AssertDeepEquals(t, &HawaiiCloudYAML, actual)
 
 	clientOpts = &clientconfig.ClientOpts{
 		Cloud:     "california",
@@ -26,13 +27,14 @@ func TestGetCloudFromYAML(t *testing.T) {
 
 	actual, err = clientconfig.GetCloudFromYAML(clientOpts)
 	th.AssertNoErr(t, err)
-	th.AssertDeepEquals(t, &CloudYAMLCalifornia, actual)
+	th.AssertDeepEquals(t, &CaliforniaCloudYAML, actual)
 }
 
 func TestAuthOptionsExplicitCloud(t *testing.T) {
+	os.Unsetenv("OS_CLOUD")
+
 	clientOpts := &clientconfig.ClientOpts{
-		Cloud:     "hawaii",
-		EnvPrefix: "FOO",
+		Cloud: "hawaii",
 	}
 
 	actual, err := clientconfig.AuthOptions(clientOpts)
@@ -44,10 +46,10 @@ func TestAuthOptionsExplicitCloud(t *testing.T) {
 }
 
 func TestAuthOptionsOSCLOUD(t *testing.T) {
-	os.Setenv("OS_CLOUD", "hawaii")
+	os.Setenv("FOO_CLOUD", "hawaii")
 
 	clientOpts := &clientconfig.ClientOpts{
-		EnvPrefix: "FOO",
+		EnvPrefix: "FOO_",
 	}
 
 	actual, err := clientconfig.AuthOptions(clientOpts)
@@ -56,19 +58,169 @@ func TestAuthOptionsOSCLOUD(t *testing.T) {
 	}
 
 	th.AssertDeepEquals(t, HawaiiAuthOpts, actual)
+
+	os.Unsetenv("FOO_CLOUD")
 }
 
-func TestAuthOptionsToken(t *testing.T) {
-	os.Setenv("OS_CLOUD", "arizona")
+func TestAuthOptionsCreationFromCloudsYAML(t *testing.T) {
+	os.Unsetenv("OS_CLOUD")
 
-	clientOpts := &clientconfig.ClientOpts{
-		Cloud: "arizona",
+	allClouds := map[string]*gophercloud.AuthOptions{
+		"hawaii":     HawaiiAuthOpts,
+		"florida":    FloridaAuthOpts,
+		"california": CaliforniaAuthOpts,
+		"arizona":    ArizonaAuthOpts,
+		"newmexico":  NewMexicoAuthOpts,
+		"nevada":     NevadaAuthOpts,
 	}
 
-	actual, err := clientconfig.AuthOptions(clientOpts)
-	if err != nil {
-		t.Fatal(err)
+	for cloud, expected := range allClouds {
+		clientOpts := &clientconfig.ClientOpts{
+			Cloud: cloud,
+		}
+
+		actual, err := clientconfig.AuthOptions(clientOpts)
+		th.AssertNoErr(t, err)
+		th.AssertDeepEquals(t, expected, actual)
+
+		scope, err := expected.ToTokenV3ScopeMap()
+		th.AssertNoErr(t, err)
+
+		_, err = expected.ToTokenV3CreateMap(scope)
+		th.AssertNoErr(t, err)
+	}
+}
+
+func TestAuthOptionsCreationFromLegacyCloudsYAML(t *testing.T) {
+	os.Unsetenv("OS_CLOUD")
+
+	allClouds := map[string]*gophercloud.AuthOptions{
+		"alberta": AlbertaAuthOpts,
+		"yukon":   YukonAuthOpts,
 	}
 
-	th.AssertDeepEquals(t, ArizonaAuthOpts, actual)
+	for cloud, expected := range allClouds {
+		clientOpts := &clientconfig.ClientOpts{
+			Cloud: cloud,
+		}
+
+		actual, err := clientconfig.AuthOptions(clientOpts)
+		th.AssertNoErr(t, err)
+		th.AssertDeepEquals(t, expected, actual)
+
+		_, err = expected.ToTokenV2CreateMap()
+		th.AssertNoErr(t, err)
+	}
+}
+
+func TestAuthOptionsCreationFromClientConfig(t *testing.T) {
+	os.Unsetenv("OS_CLOUD")
+
+	expectedAuthOpts := map[string]*gophercloud.AuthOptions{
+		"hawaii":     HawaiiAuthOpts,
+		"florida":    FloridaAuthOpts,
+		"california": CaliforniaAuthOpts,
+		"arizona":    ArizonaAuthOpts,
+		"newmexico":  NewMexicoAuthOpts,
+		"nevada":     NevadaAuthOpts,
+	}
+
+	allClientOpts := map[string]*clientconfig.ClientOpts{
+		"hawaii":     HawaiiClientOpts,
+		"florida":    FloridaClientOpts,
+		"california": CaliforniaClientOpts,
+		"arizona":    ArizonaClientOpts,
+		"newmexico":  NewMexicoClientOpts,
+		"nevada":     NevadaClientOpts,
+	}
+
+	for cloud, clientOpts := range allClientOpts {
+		actualAuthOpts, err := clientconfig.AuthOptions(clientOpts)
+		th.AssertNoErr(t, err)
+		th.AssertDeepEquals(t, expectedAuthOpts[cloud], actualAuthOpts)
+	}
+}
+
+func TestAuthOptionsCreationFromLegacyClientConfig(t *testing.T) {
+	os.Unsetenv("OS_CLOUD")
+
+	expectedAuthOpts := map[string]*gophercloud.AuthOptions{
+		"alberta": AlbertaAuthOpts,
+		"yukon":   YukonAuthOpts,
+	}
+
+	allClientOpts := map[string]*clientconfig.ClientOpts{
+		"alberta": AlbertaClientOpts,
+		"yukon":   YukonClientOpts,
+	}
+
+	for cloud, clientOpts := range allClientOpts {
+		actualAuthOpts, err := clientconfig.AuthOptions(clientOpts)
+		th.AssertNoErr(t, err)
+		th.AssertDeepEquals(t, expectedAuthOpts[cloud], actualAuthOpts)
+	}
+}
+
+func TestAuthOptionsCreationFromEnv(t *testing.T) {
+	os.Unsetenv("OS_CLOUD")
+
+	allEnvVars := map[string]map[string]string{
+		"hawaii":     HawaiiEnvAuth,
+		"florida":    FloridaEnvAuth,
+		"california": CaliforniaEnvAuth,
+		"arizona":    ArizonaEnvAuth,
+		"newmexico":  NewMexicoEnvAuth,
+		"nevada":     NevadaEnvAuth,
+	}
+
+	expectedAuthOpts := map[string]*gophercloud.AuthOptions{
+		"hawaii":     HawaiiAuthOpts,
+		"florida":    FloridaAuthOpts,
+		"california": CaliforniaAuthOpts,
+		"arizona":    ArizonaAuthOpts,
+		"newmexico":  NewMexicoAuthOpts,
+		"nevada":     NevadaAuthOpts,
+	}
+
+	for cloud, envVars := range allEnvVars {
+		for k, v := range envVars {
+			os.Setenv(k, v)
+		}
+
+		actualAuthOpts, err := clientconfig.AuthOptions(nil)
+		th.AssertNoErr(t, err)
+		th.AssertDeepEquals(t, expectedAuthOpts[cloud], actualAuthOpts)
+
+		for k, _ := range envVars {
+			os.Unsetenv(k)
+		}
+	}
+}
+
+func TestAuthOptionsCreationFromLegacyEnv(t *testing.T) {
+	os.Unsetenv("OS_CLOUD")
+
+	allEnvVars := map[string]map[string]string{
+		"alberta": AlbertaEnvAuth,
+		"yukon":   YukonEnvAuth,
+	}
+
+	expectedAuthOpts := map[string]*gophercloud.AuthOptions{
+		"alberta": AlbertaAuthOpts,
+		"yukon":   YukonAuthOpts,
+	}
+
+	for cloud, envVars := range allEnvVars {
+		for k, v := range envVars {
+			os.Setenv(k, v)
+		}
+
+		actualAuthOpts, err := clientconfig.AuthOptions(nil)
+		th.AssertNoErr(t, err)
+		th.AssertDeepEquals(t, expectedAuthOpts[cloud], actualAuthOpts)
+
+		for k, _ := range envVars {
+			os.Unsetenv(k)
+		}
+	}
 }

--- a/openstack/clientconfig/testing/requests_test.go
+++ b/openstack/clientconfig/testing/requests_test.go
@@ -57,3 +57,18 @@ func TestAuthOptionsOSCLOUD(t *testing.T) {
 
 	th.AssertDeepEquals(t, HawaiiAuthOpts, actual)
 }
+
+func TestAuthOptionsToken(t *testing.T) {
+	os.Setenv("OS_CLOUD", "arizona")
+
+	clientOpts := &clientconfig.ClientOpts{
+		Cloud: "arizona",
+	}
+
+	actual, err := clientconfig.AuthOptions(clientOpts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	th.AssertDeepEquals(t, ArizonaAuthOpts, actual)
+}

--- a/openstack/clientconfig/utils.go
+++ b/openstack/clientconfig/utils.go
@@ -67,8 +67,8 @@ func fileExists(filename string) bool {
 }
 
 // isProjectScoped determines if an auth struct is project scoped.
-func isProjectScoped(auth *Auth) bool {
-	if auth.ProjectID == "" && auth.ProjectName == "" {
+func isProjectScoped(authInfo *AuthInfo) bool {
+	if authInfo.ProjectID == "" && authInfo.ProjectName == "" {
 		return false
 	}
 
@@ -78,28 +78,28 @@ func isProjectScoped(auth *Auth) bool {
 // setDomainIfNeeded will set a DomainID and DomainName
 // to ProjectDomain* and UserDomain* if not already set.
 func setDomainIfNeeded(cloud *Cloud) *Cloud {
-	if cloud.Auth.DomainID != "" {
-		if cloud.Auth.UserDomainID == "" {
-			cloud.Auth.UserDomainID = cloud.Auth.DomainID
+	if cloud.AuthInfo.DomainID != "" {
+		if cloud.AuthInfo.UserDomainID == "" {
+			cloud.AuthInfo.UserDomainID = cloud.AuthInfo.DomainID
 		}
 
-		if cloud.Auth.ProjectDomainID == "" {
-			cloud.Auth.ProjectDomainID = cloud.Auth.DomainID
+		if cloud.AuthInfo.ProjectDomainID == "" {
+			cloud.AuthInfo.ProjectDomainID = cloud.AuthInfo.DomainID
 		}
 
-		cloud.Auth.DomainID = ""
+		cloud.AuthInfo.DomainID = ""
 	}
 
-	if cloud.Auth.DomainName != "" {
-		if cloud.Auth.UserDomainName == "" {
-			cloud.Auth.UserDomainName = cloud.Auth.DomainName
+	if cloud.AuthInfo.DomainName != "" {
+		if cloud.AuthInfo.UserDomainName == "" {
+			cloud.AuthInfo.UserDomainName = cloud.AuthInfo.DomainName
 		}
 
-		if cloud.Auth.ProjectDomainName == "" {
-			cloud.Auth.ProjectDomainName = cloud.Auth.DomainName
+		if cloud.AuthInfo.ProjectDomainName == "" {
+			cloud.AuthInfo.ProjectDomainName = cloud.AuthInfo.DomainName
 		}
 
-		cloud.Auth.DomainName = ""
+		cloud.AuthInfo.DomainName = ""
 	}
 
 	return cloud

--- a/openstack/clientconfig/utils.go
+++ b/openstack/clientconfig/utils.go
@@ -65,3 +65,42 @@ func fileExists(filename string) bool {
 	}
 	return false
 }
+
+// isProjectScoped determines if an auth struct is project scoped.
+func isProjectScoped(auth *Auth) bool {
+	if auth.ProjectID == "" && auth.ProjectName == "" {
+		return false
+	}
+
+	return true
+}
+
+// setDomainIfNeeded will set a DomainID and DomainName
+// to ProjectDomain* and UserDomain* if not already set.
+func setDomainIfNeeded(cloud *Cloud) *Cloud {
+	if cloud.Auth.DomainID != "" {
+		if cloud.Auth.UserDomainID == "" {
+			cloud.Auth.UserDomainID = cloud.Auth.DomainID
+		}
+
+		if cloud.Auth.ProjectDomainID == "" {
+			cloud.Auth.ProjectDomainID = cloud.Auth.DomainID
+		}
+
+		cloud.Auth.DomainID = ""
+	}
+
+	if cloud.Auth.DomainName != "" {
+		if cloud.Auth.UserDomainName == "" {
+			cloud.Auth.UserDomainName = cloud.Auth.DomainName
+		}
+
+		if cloud.Auth.ProjectDomainName == "" {
+			cloud.Auth.ProjectDomainName = cloud.Auth.DomainName
+		}
+
+		cloud.Auth.DomainName = ""
+	}
+
+	return cloud
+}


### PR DESCRIPTION
This commit is a large refactor of the clientconfig package.

It attempts to become a single point of entry for all OpenStack
authentication, supporting authentication from clouds.yaml,
explicit authentication parameters, and environment variables.

Supersedes #26 

Requires https://github.com/gophercloud/gophercloud/pull/896

For https://github.com/gophercloud/gophercloud/issues/252