### PR TITLE
Do not set required tag on the MeasureOpts.Value

### DIFF
--- a/gnocchi/metric/v1/measures/requests.go
+++ b/gnocchi/metric/v1/measures/requests.go
@@ -86,7 +86,7 @@ type MeasureOpts struct {
 	Timestamp *time.Time `json:"-" required:"true"`
 
 	// Value represents a measure data value.
-	Value float64 `json:"value" required:"true"`
+	Value float64 `json:"value"`
 }
 
 // ToMap is a helper function to convert individual MeasureOpts structure into a sub-map.


### PR DESCRIPTION
Gnocchi measures value can contain 0. It's completely normal and
expected situation.

For #28 