### PR TITLE
clientconfig: Add support for SSL setting to disable verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 **/*.swp
 .idea
 .vscode
+debug.test

--- a/openstack/clientconfig/requests.go
+++ b/openstack/clientconfig/requests.go
@@ -15,14 +15,20 @@ import (
 type AuthType string
 
 const (
+	// AuthPassword defines an unknown version of the password
 	AuthPassword AuthType = "password"
-	AuthToken    AuthType = "token"
+	// AuthToken defined an unknown version of the token
+	AuthToken AuthType = "token"
 
+	// AuthV2Password defines version 2 of the password
 	AuthV2Password AuthType = "v2password"
-	AuthV2Token    AuthType = "v2token"
+	// AuthV2Token defines version 2 of the token
+	AuthV2Token AuthType = "v2token"
 
+	// AuthV3Password defines version 3 of the password
 	AuthV3Password AuthType = "v3password"
-	AuthV3Token    AuthType = "v3token"
+	// AuthV3Token defines version 3 of the token
+	AuthV3Token AuthType = "v3token"
 )
 
 // ClientOpts represents options to customize the way a client is
@@ -103,6 +109,11 @@ func GetCloudFromYAML(opts *ClientOpts) (*Cloud, error) {
 
 	if cloud == nil {
 		return nil, fmt.Errorf("Unable to determine a valid entry in clouds.yaml")
+	}
+
+	// Default is to verify SSL API requests
+	if cloud.Verify == nil {
+		cloud.Verify = true
 	}
 
 	return cloud, nil

--- a/openstack/clientconfig/requests.go
+++ b/openstack/clientconfig/requests.go
@@ -113,7 +113,8 @@ func GetCloudFromYAML(opts *ClientOpts) (*Cloud, error) {
 
 	// Default is to verify SSL API requests
 	if cloud.Verify == nil {
-		cloud.Verify = true
+		iTrue := true
+		cloud.Verify = &iTrue
 	}
 
 	return cloud, nil

--- a/openstack/clientconfig/results.go
+++ b/openstack/clientconfig/results.go
@@ -19,8 +19,7 @@ type Cloud struct {
 	VolumeAPIVersion   string `yaml:"volume_api_version"`
 
 	// Verify whether or not SSL API requests should be verified.
-	// Note! Type is not set to bool to be able to set correct default value.
-	Verify interface{} `yaml:"verify"`
+	Verify *bool `yaml:"verify"`
 
 	// CACertFile a path to a CA Cert bundle that can be used as part of
 	// verifying SSL API requests.

--- a/openstack/clientconfig/results.go
+++ b/openstack/clientconfig/results.go
@@ -17,9 +17,25 @@ type Cloud struct {
 	// API Version overrides.
 	IdentityAPIVersion string `yaml:"identity_api_version"`
 	VolumeAPIVersion   string `yaml:"volume_api_version"`
+
+	// Verify whether or not SSL API requests should be verified.
+	// Note! Type is not set to bool to be able to set correct default value.
+	Verify interface{} `yaml:"verify"`
+
+	// CACertFile a path to a CA Cert bundle that can be used as part of
+	// verifying SSL API requests.
+	CACertFile string `yaml:"cacert"`
+
+	// ClientCertFile a path to a client certificate to use as part of the SSL
+	// transaction.
+	ClientCertFile string `yaml:"cert"`
+
+	// ClientKeyFile a path to a client key to use as part of the SSL
+	// transaction.
+	ClientKeyFile string `yaml:"key"`
 }
 
-// Auth represents the auth section of a cloud entry or
+// AuthInfo represents the auth section of a cloud entry or
 // auth options entered explicitly in ClientOpts.
 type AuthInfo struct {
 	// AuthURL is the keystone/identity endpoint URL.

--- a/openstack/clientconfig/testing/clouds.yaml
+++ b/openstack/clientconfig/testing/clouds.yaml
@@ -87,3 +87,24 @@ clouds:
       token: "12345"
       project_name: "Some Project"
     region_name: "YXY"
+  florida_insecure:
+    profile: "Some profile"
+    auth:
+      auth_url: "https://fl.example.com:5000/v3"
+      username: "jdoe"
+      password: "password"
+      project_id: "12345"
+      user_domain_id: "abcde"
+    region_name: "MIA"
+    verify: False
+  florida_secure:
+    auth:
+      auth_url: "https://fl.example.com:5000/v3"
+      username: "jdoe"
+      password: "password"
+      project_id: "12345"
+      user_domain_id: "abcde"
+    region_name: "MIA"
+    key: /home/myhome/client-cert.key
+    cert: /home/myhome/client-cert.crt
+    cacert: /home/myhome/ca.crt

--- a/openstack/clientconfig/testing/fixtures.go
+++ b/openstack/clientconfig/testing/fixtures.go
@@ -5,6 +5,9 @@ import (
 	"github.com/gophercloud/utils/openstack/clientconfig"
 )
 
+var iTrue = true
+var iFalse = false
+
 var HawaiiCloudYAML = clientconfig.Cloud{
 	RegionName: "HNL",
 	AuthInfo: &clientconfig.AuthInfo{
@@ -14,7 +17,7 @@ var HawaiiCloudYAML = clientconfig.Cloud{
 		ProjectName: "Some Project",
 		DomainName:  "default",
 	},
-	Verify: true,
+	Verify: &iTrue,
 }
 
 var HawaiiClientOpts = &clientconfig.ClientOpts{
@@ -56,7 +59,7 @@ var FloridaCloudYAML = clientconfig.Cloud{
 		ProjectID:    "12345",
 		UserDomainID: "abcde",
 	},
-	Verify: true,
+	Verify: &iTrue,
 }
 
 var InsecureFloridaCloudYAML = clientconfig.Cloud{
@@ -68,7 +71,7 @@ var InsecureFloridaCloudYAML = clientconfig.Cloud{
 		ProjectID:    "12345",
 		UserDomainID: "abcde",
 	},
-	Verify:         false,
+	Verify:         &iFalse,
 	ClientKeyFile:  "",
 	ClientCertFile: "",
 	CACertFile:     "",
@@ -83,7 +86,7 @@ var SecureFloridaCloudYAML = clientconfig.Cloud{
 		ProjectID:    "12345",
 		UserDomainID: "abcde",
 	},
-	Verify:         true,
+	Verify:         &iTrue,
 	ClientKeyFile:  "/home/myhome/client-cert.key",
 	ClientCertFile: "/home/myhome/client-cert.crt",
 	CACertFile:     "/home/myhome/ca.crt",
@@ -131,7 +134,7 @@ var CaliforniaCloudYAML = clientconfig.Cloud{
 		ProjectDomainName: "default",
 		UserDomainName:    "default",
 	},
-	Verify: true,
+	Verify: &iTrue,
 }
 
 var CaliforniaClientOpts = &clientconfig.ClientOpts{
@@ -175,7 +178,7 @@ var ArizonaCloudYAML = clientconfig.Cloud{
 		ProjectName: "Some Project",
 		DomainName:  "default",
 	},
-	Verify: true,
+	Verify: &iTrue,
 }
 
 var ArizonaClientOpts = &clientconfig.ClientOpts{
@@ -216,7 +219,7 @@ var NewMexicoCloudYAML = clientconfig.Cloud{
 		UserDomainName:    "Some OtherDomain",
 		DomainName:        "default",
 	},
-	Verify: true,
+	Verify: &iTrue,
 }
 
 var NewMexicoClientOpts = &clientconfig.ClientOpts{
@@ -262,7 +265,7 @@ var NevadaCloudYAML = clientconfig.Cloud{
 		ProjectName:       "Some Project",
 		ProjectDomainName: "Some Domain",
 	},
-	Verify: true,
+	Verify: &iTrue,
 }
 
 var NevadaClientOpts = &clientconfig.ClientOpts{
@@ -304,7 +307,7 @@ var TexasCloudYAML = clientconfig.Cloud{
 		UserDomainName: "Some Domain",
 		DefaultDomain:  "default",
 	},
-	Verify: true,
+	Verify: &iTrue,
 }
 
 var TexasClientOpts = &clientconfig.ClientOpts{
@@ -360,7 +363,7 @@ var AlbertaCloudYAML = clientconfig.Cloud{
 		Password:    "password",
 		ProjectName: "Some Project",
 	},
-	Verify: true,
+	Verify: &iTrue,
 }
 
 var AlbertaClientOpts = &clientconfig.ClientOpts{
@@ -395,7 +398,7 @@ var YukonCloudYAML = clientconfig.Cloud{
 		Token:       "12345",
 		ProjectName: "Some Project",
 	},
-	Verify: true,
+	Verify: &iTrue,
 }
 
 var YukonClientOpts = &clientconfig.ClientOpts{

--- a/openstack/clientconfig/testing/fixtures.go
+++ b/openstack/clientconfig/testing/fixtures.go
@@ -14,6 +14,7 @@ var HawaiiCloudYAML = clientconfig.Cloud{
 		ProjectName: "Some Project",
 		DomainName:  "default",
 	},
+	Verify: true,
 }
 
 var HawaiiClientOpts = &clientconfig.ClientOpts{
@@ -55,6 +56,37 @@ var FloridaCloudYAML = clientconfig.Cloud{
 		ProjectID:    "12345",
 		UserDomainID: "abcde",
 	},
+	Verify: true,
+}
+
+var InsecureFloridaCloudYAML = clientconfig.Cloud{
+	RegionName: "MIA",
+	AuthInfo: &clientconfig.AuthInfo{
+		AuthURL:      "https://fl.example.com:5000/v3",
+		Username:     "jdoe",
+		Password:     "password",
+		ProjectID:    "12345",
+		UserDomainID: "abcde",
+	},
+	Verify:         false,
+	ClientKeyFile:  "",
+	ClientCertFile: "",
+	CACertFile:     "",
+}
+
+var SecureFloridaCloudYAML = clientconfig.Cloud{
+	RegionName: "MIA",
+	AuthInfo: &clientconfig.AuthInfo{
+		AuthURL:      "https://fl.example.com:5000/v3",
+		Username:     "jdoe",
+		Password:     "password",
+		ProjectID:    "12345",
+		UserDomainID: "abcde",
+	},
+	Verify:         true,
+	ClientKeyFile:  "/home/myhome/client-cert.key",
+	ClientCertFile: "/home/myhome/client-cert.crt",
+	CACertFile:     "/home/myhome/ca.crt",
 }
 
 var FloridaClientOpts = &clientconfig.ClientOpts{
@@ -99,6 +131,7 @@ var CaliforniaCloudYAML = clientconfig.Cloud{
 		ProjectDomainName: "default",
 		UserDomainName:    "default",
 	},
+	Verify: true,
 }
 
 var CaliforniaClientOpts = &clientconfig.ClientOpts{
@@ -142,6 +175,7 @@ var ArizonaCloudYAML = clientconfig.Cloud{
 		ProjectName: "Some Project",
 		DomainName:  "default",
 	},
+	Verify: true,
 }
 
 var ArizonaClientOpts = &clientconfig.ClientOpts{
@@ -182,6 +216,7 @@ var NewMexicoCloudYAML = clientconfig.Cloud{
 		UserDomainName:    "Some OtherDomain",
 		DomainName:        "default",
 	},
+	Verify: true,
 }
 
 var NewMexicoClientOpts = &clientconfig.ClientOpts{
@@ -227,6 +262,7 @@ var NevadaCloudYAML = clientconfig.Cloud{
 		ProjectName:       "Some Project",
 		ProjectDomainName: "Some Domain",
 	},
+	Verify: true,
 }
 
 var NevadaClientOpts = &clientconfig.ClientOpts{
@@ -268,6 +304,7 @@ var TexasCloudYAML = clientconfig.Cloud{
 		UserDomainName: "Some Domain",
 		DefaultDomain:  "default",
 	},
+	Verify: true,
 }
 
 var TexasClientOpts = &clientconfig.ClientOpts{
@@ -323,6 +360,7 @@ var AlbertaCloudYAML = clientconfig.Cloud{
 		Password:    "password",
 		ProjectName: "Some Project",
 	},
+	Verify: true,
 }
 
 var AlbertaClientOpts = &clientconfig.ClientOpts{
@@ -357,6 +395,7 @@ var YukonCloudYAML = clientconfig.Cloud{
 		Token:       "12345",
 		ProjectName: "Some Project",
 	},
+	Verify: true,
 }
 
 var YukonClientOpts = &clientconfig.ClientOpts{

--- a/openstack/clientconfig/testing/requests_test.go
+++ b/openstack/clientconfig/testing/requests_test.go
@@ -11,23 +11,36 @@ import (
 )
 
 func TestGetCloudFromYAML(t *testing.T) {
-	clientOpts := &clientconfig.ClientOpts{
-		Cloud:     "hawaii",
-		EnvPrefix: "FOO",
+
+	allClientOpts := map[string]*clientconfig.ClientOpts{
+		"hawaii": &clientconfig.ClientOpts{
+			Cloud:     "hawaii",
+			EnvPrefix: "FOO",
+		},
+		"california": &clientconfig.ClientOpts{
+			Cloud:     "california",
+			EnvPrefix: "FOO",
+		},
+		"florida_insecure": &clientconfig.ClientOpts{
+			Cloud: "florida_insecure",
+		},
+		"florida_secure": &clientconfig.ClientOpts{
+			Cloud: "florida_secure",
+		},
 	}
 
-	actual, err := clientconfig.GetCloudFromYAML(clientOpts)
-	th.AssertNoErr(t, err)
-	th.AssertDeepEquals(t, &HawaiiCloudYAML, actual)
-
-	clientOpts = &clientconfig.ClientOpts{
-		Cloud:     "california",
-		EnvPrefix: "FOO",
+	expectedClouds := map[string]*clientconfig.Cloud{
+		"hawaii":           &HawaiiCloudYAML,
+		"california":       &CaliforniaCloudYAML,
+		"florida_insecure": &InsecureFloridaCloudYAML,
+		"florida_secure":   &SecureFloridaCloudYAML,
 	}
 
-	actual, err = clientconfig.GetCloudFromYAML(clientOpts)
-	th.AssertNoErr(t, err)
-	th.AssertDeepEquals(t, &CaliforniaCloudYAML, actual)
+	for cloud, clientOpts := range allClientOpts {
+		actual, err := clientconfig.GetCloudFromYAML(clientOpts)
+		th.AssertNoErr(t, err)
+		th.AssertDeepEquals(t, expectedClouds[cloud], actual)
+	}
 }
 
 func TestAuthOptionsExplicitCloud(t *testing.T) {
@@ -196,7 +209,7 @@ func TestAuthOptionsCreationFromEnv(t *testing.T) {
 		th.AssertNoErr(t, err)
 		th.AssertDeepEquals(t, expectedAuthOpts[cloud], actualAuthOpts)
 
-		for k, _ := range envVars {
+		for k := range envVars {
 			os.Unsetenv(k)
 		}
 	}
@@ -224,7 +237,7 @@ func TestAuthOptionsCreationFromLegacyEnv(t *testing.T) {
 		th.AssertNoErr(t, err)
 		th.AssertDeepEquals(t, expectedAuthOpts[cloud], actualAuthOpts)
 
-		for k, _ := range envVars {
+		for k := range envVars {
 			os.Unsetenv(k)
 		}
 	}


### PR DESCRIPTION
For #45

@jtopjian : Please review when you got time. I was a bit unsure here what shall be done here. For example in Terraform Cloud struct is fetched [here](https://github.com/terraform-providers/terraform-provider-openstack/blob/master/openstack/config.go#L76) then it is easy to just fetch the values directly. Or shall some function be introduced? 