### PR TITLE
Gnocchi: implement archive policy Delete method

### DIFF
--- a/acceptance/gnocchi/metric/v1/archivepolicies.go
+++ b/acceptance/gnocchi/metric/v1/archivepolicies.go
@@ -39,3 +39,16 @@ func CreateArchivePolicy(t *testing.T, client *gophercloud.ServiceClient) (*arch
 	t.Logf("Successfully created the Gnocchi archive policy.")
 	return archivePolicy, nil
 }
+
+// DeleteArchivePolicy will delete a Gnocchi archive policy.
+// A fatal error will occur if the delete was not successful.
+func DeleteArchivePolicy(t *testing.T, client *gophercloud.ServiceClient, archivePolicyName string) {
+	t.Logf("Attempting to delete the Gnocchi archive policy: %s", archivePolicyName)
+
+	err := archivepolicies.Delete(client, archivePolicyName).ExtractErr()
+	if err != nil {
+		t.Fatalf("Unable to delete the Gnocchi archive policy %s: %v", archivePolicyName, err)
+	}
+
+	t.Logf("Deleted the Gnocchi archive policy: %s", archivePolicyName)
+}

--- a/acceptance/gnocchi/metric/v1/archivepolicies_test.go
+++ b/acceptance/gnocchi/metric/v1/archivepolicies_test.go
@@ -23,6 +23,26 @@ func TestArchivePoliciesCRUD(t *testing.T) {
 	// defer DeleteArchivePolicy(t, client, archivePolicy.ID)
 
 	tools.PrintResource(t, archivePolicy)
+
+	updateOpts := archivepolicies.UpdateOpts{
+		Definition: []archivepolicies.ArchivePolicyDefinitionOpts{
+			{
+				Granularity: "1:00:00",
+				TimeSpan:    "90 days, 0:00:00",
+			},
+			{
+				Granularity: "24:00:00",
+				TimeSpan:    "365 days, 0:00:00",
+			},
+		},
+	}
+	t.Logf("Attempting to update an archive policy %s", archivePolicy.Name)
+	newArchivePolicy, err := archivepolicies.Update(client, archivePolicy.Name, updateOpts).Extract()
+	if err != nil {
+		t.Fatalf("Unable to update a Gnocchi archive policy: %v", err)
+	}
+
+	tools.PrintResource(t, newArchivePolicy)
 }
 
 func TestArchivePoliciesList(t *testing.T) {

--- a/acceptance/gnocchi/metric/v1/archivepolicies_test.go
+++ b/acceptance/gnocchi/metric/v1/archivepolicies_test.go
@@ -20,7 +20,7 @@ func TestArchivePoliciesCRUD(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to create a Gnocchi archive policy: %v", err)
 	}
-	// defer DeleteArchivePolicy(t, client, archivePolicy.ID)
+	defer DeleteArchivePolicy(t, client, archivePolicy.Name)
 
 	tools.PrintResource(t, archivePolicy)
 

--- a/gnocchi/metric/v1/archivepolicies/doc.go
+++ b/gnocchi/metric/v1/archivepolicies/doc.go
@@ -51,5 +51,24 @@ Example of Creating an archive policy
   if err != nil {
     panic(err)
   }
+
+Example of Updating an archive policy
+
+  updateOpts := archivepolicies.UpdateOpts{
+    Definition: []archivepolicies.ArchivePolicyDefinitionOpts{
+      {
+        Granularity: "12:00:00",
+        TimeSpan:    "30 days, 0:00:00",
+      },
+      {
+        Granularity: "1 day, 0:00:00",
+        TimeSpan:    "90 days, 0:00:00",
+      },
+    },
+  }
+  archivePolicy, err := archivepolicies.Update(gnocchiClient, "test_policy", updateOpts).Extract()
+  if err != nil {
+    panic(err)
+  }
 */
 package archivepolicies

--- a/gnocchi/metric/v1/archivepolicies/doc.go
+++ b/gnocchi/metric/v1/archivepolicies/doc.go
@@ -70,5 +70,12 @@ Example of Updating an archive policy
   if err != nil {
     panic(err)
   }
+
+Example of Deleting a Gnocchi archive policy
+
+  err := archivepolicies.Delete(gnocchiClient, "test_policy").ExtractErr()
+  if err != nil {
+    panic(err)
+  }
 */
 package archivepolicies

--- a/gnocchi/metric/v1/archivepolicies/requests.go
+++ b/gnocchi/metric/v1/archivepolicies/requests.go
@@ -107,3 +107,14 @@ func Update(client *gophercloud.ServiceClient, archivePolicyName string, opts Up
 
 	return
 }
+
+// Delete accepts a Gnocchi archive policy by its name.
+func Delete(c *gophercloud.ServiceClient, archivePolicyName string) (r DeleteResult) {
+	requestOpts := &gophercloud.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Accept": "application/json, */*",
+		},
+	}
+	_, r.Err = c.Delete(deleteURL(c, archivePolicyName), requestOpts)
+	return
+}

--- a/gnocchi/metric/v1/archivepolicies/requests.go
+++ b/gnocchi/metric/v1/archivepolicies/requests.go
@@ -76,3 +76,34 @@ func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r Create
 
 	return
 }
+
+// UpdateOptsBuilder allows extensions to add additional parameters to the Update request.
+type UpdateOptsBuilder interface {
+	ToArchivePolicyUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts represents options used to update an archive policy.
+type UpdateOpts struct {
+	// Definition is a list of parameters that configures
+	// archive policy precision and timespan.
+	Definition []ArchivePolicyDefinitionOpts `json:"definition"`
+}
+
+// ToArchivePolicyUpdateMap constructs a request body from UpdateOpts.
+func (opts UpdateOpts) ToArchivePolicyUpdateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "")
+}
+
+// Update accepts a UpdateOpts and updates an existing Gnocchi archive policy using the values provided.
+func Update(client *gophercloud.ServiceClient, archivePolicyName string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToArchivePolicyUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Patch(updateURL(client, archivePolicyName), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+
+	return
+}

--- a/gnocchi/metric/v1/archivepolicies/results.go
+++ b/gnocchi/metric/v1/archivepolicies/results.go
@@ -34,6 +34,12 @@ type UpdateResult struct {
 	commonResult
 }
 
+// DeleteResult represents the result of a delete operation. Call its
+// ExtractErr method to determine if the request succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
 // ArchivePolicy represents a Gnocchi archive policy.
 // Archive policy is an aggregate storage policy attached to a metric.
 // It determines how long aggregates will be kept in a metric and how they will be aggregated.

--- a/gnocchi/metric/v1/archivepolicies/results.go
+++ b/gnocchi/metric/v1/archivepolicies/results.go
@@ -28,6 +28,12 @@ type CreateResult struct {
 	commonResult
 }
 
+// UpdateResult represents the result of an update operation. Call its Extract
+// method to interpret it as a Gnocchi archive policy.
+type UpdateResult struct {
+	commonResult
+}
+
 // ArchivePolicy represents a Gnocchi archive policy.
 // Archive policy is an aggregate storage policy attached to a metric.
 // It determines how long aggregates will be kept in a metric and how they will be aggregated.

--- a/gnocchi/metric/v1/archivepolicies/testing/fixtures.go
+++ b/gnocchi/metric/v1/archivepolicies/testing/fixtures.go
@@ -174,3 +174,42 @@ const ArchivePolicyCreateResponse = `
     "name": "test_policy"
 }
 `
+
+// ArchivePolicyUpdateRequest represents a raw update request.
+const ArchivePolicyUpdateRequest = `
+{
+    "definition": [
+        {
+            "timespan": "30 days, 0:00:00",
+            "granularity": "12:00:00"
+        },
+        {
+            "timespan": "90 days, 0:00:00",
+            "granularity": "1 day, 0:00:00"
+        }
+    ]
+}
+`
+
+// ArchivePolicyUpdateResponse represents a raw server response from a server to an update request.
+const ArchivePolicyUpdateResponse = `
+{
+    "definition": [
+        {
+            "points": 60,
+            "timespan": "30 days, 0:00:00",
+            "granularity": "12:00:00"
+        },
+        {
+            "points": 90,
+            "timespan": "90 days, 0:00:00",
+            "granularity": "1 day, 0:00:00"
+        }
+    ],
+    "back_window": 0,
+    "name": "test_policy",
+    "aggregation_methods": [
+        "max"
+    ]
+}
+`

--- a/gnocchi/metric/v1/archivepolicies/testing/requests_test.go
+++ b/gnocchi/metric/v1/archivepolicies/testing/requests_test.go
@@ -212,3 +212,17 @@ func TestUpdateArchivePolicy(t *testing.T) {
 	})
 	th.AssertEquals(t, s.Name, "test_policy")
 }
+
+func TestDelete(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v1/archive_policy/test_policy", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	res := archivepolicies.Delete(fake.ServiceClient(), "test_policy")
+	th.AssertNoErr(t, res.Err)
+}

--- a/gnocchi/metric/v1/archivepolicies/testing/requests_test.go
+++ b/gnocchi/metric/v1/archivepolicies/testing/requests_test.go
@@ -161,3 +161,54 @@ func TestCreate(t *testing.T) {
 	})
 	th.AssertEquals(t, s.Name, "test_policy")
 }
+
+func TestUpdateArchivePolicy(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v1/archive_policy/test_policy", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PATCH")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, ArchivePolicyUpdateRequest)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, ArchivePolicyUpdateResponse)
+	})
+
+	updateOpts := archivepolicies.UpdateOpts{
+		Definition: []archivepolicies.ArchivePolicyDefinitionOpts{
+			{
+				Granularity: "12:00:00",
+				TimeSpan:    "30 days, 0:00:00",
+			},
+			{
+				Granularity: "1 day, 0:00:00",
+				TimeSpan:    "90 days, 0:00:00",
+			},
+		},
+	}
+	s, err := archivepolicies.Update(fake.ServiceClient(), "test_policy", updateOpts).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertDeepEquals(t, s.AggregationMethods, []string{
+		"max",
+	})
+	th.AssertEquals(t, s.BackWindow, 0)
+	th.AssertDeepEquals(t, s.Definition, []archivepolicies.ArchivePolicyDefinition{
+		{
+			Granularity: "12:00:00",
+			Points:      60,
+			TimeSpan:    "30 days, 0:00:00",
+		},
+		{
+			Granularity: "1 day, 0:00:00",
+			Points:      90,
+			TimeSpan:    "90 days, 0:00:00",
+		},
+	})
+	th.AssertEquals(t, s.Name, "test_policy")
+}

--- a/gnocchi/metric/v1/archivepolicies/urls.go
+++ b/gnocchi/metric/v1/archivepolicies/urls.go
@@ -23,3 +23,7 @@ func getURL(c *gophercloud.ServiceClient, archivePolicyName string) string {
 func createURL(c *gophercloud.ServiceClient) string {
 	return rootURL(c)
 }
+
+func updateURL(c *gophercloud.ServiceClient, archivePolicyName string) string {
+	return resourceURL(c, archivePolicyName)
+}

--- a/gnocchi/metric/v1/archivepolicies/urls.go
+++ b/gnocchi/metric/v1/archivepolicies/urls.go
@@ -27,3 +27,7 @@ func createURL(c *gophercloud.ServiceClient) string {
 func updateURL(c *gophercloud.ServiceClient, archivePolicyName string) string {
 	return resourceURL(c, archivePolicyName)
 }
+
+func deleteURL(c *gophercloud.ServiceClient, archivePolicyName string) string {
+	return resourceURL(c, archivePolicyName)
+}


### PR DESCRIPTION
Add the Delete method to the archivepolicies package with tests and documentation example.

For #42

API reference:
https://gnocchi.xyz/rest.html#id5

Code references:
https://github.com/gnocchixyz/gnocchi/blob/stable/4.2/gnocchi/rest/api.py#L299
https://github.com/gnocchixyz/gnocchi/blob/stable/4.2/gnocchi/indexer/sqlalchemy.py#L592