### PR TITLE
Fixes incorrect error when clouds-public.yaml is not found

### DIFF
--- a/openstack/clientconfig/requests.go
+++ b/openstack/clientconfig/requests.go
@@ -76,7 +76,7 @@ func LoadPublicCloudsYAML() (map[string]PublicCloud, error) {
 
 	content, err := findAndReadPublicCloudsYAML()
 	if err != nil {
-		if err.Error() == "no clouds-public.yaml found" {
+		if err.Error() == "no clouds-public.yaml file found" {
 			// clouds-public.yaml is optional so just ignore read error
 			return publicClouds.Clouds, nil
 		}


### PR DESCRIPTION
Noticed a small bug which was introduced in PR #51 which generate error if clouds-public.yaml does not exists.