### PR TITLE
Support for secure.yaml and public-clouds.yaml

### DIFF
--- a/openstack/clientconfig/requests.go
+++ b/openstack/clientconfig/requests.go
@@ -3,13 +3,13 @@ package clientconfig
 import (
 	"fmt"
 	"os"
+	"reflect"
 	"strings"
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"
 
 	"gopkg.in/yaml.v2"
-	"reflect"
 )
 
 // AuthType respresents a valid method of authentication.
@@ -161,11 +161,6 @@ func GetCloudFromYAML(opts *ClientOpts) (*Cloud, error) {
 		cloudIsInCloudsYaml = false
 	} else {
 		cloudIsInCloudsYaml = true
-		// Default is to verify SSL API requests
-		if cloud.Verify == nil {
-			iTrue := true
-			cloud.Verify = &iTrue
-		}
 	}
 
 	publicClouds, err := LoadPublicCloudsYAML()
@@ -206,6 +201,12 @@ func GetCloudFromYAML(opts *ClientOpts) (*Cloud, error) {
 				return nil, fmt.Errorf("unable to merge information from clouds.yaml and secure.yaml")
 			}
 		}
+	}
+
+	// Default is to verify SSL API requests
+	if cloud.Verify == nil {
+		iTrue := true
+		cloud.Verify = &iTrue
 	}
 
 	// TODO: this is where reading vendor files should go be considered when not found in

--- a/openstack/clientconfig/requests.go
+++ b/openstack/clientconfig/requests.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gophercloud/gophercloud/openstack"
 
 	"gopkg.in/yaml.v2"
+	"reflect"
 )
 
 // AuthType respresents a valid method of authentication.
@@ -70,8 +71,28 @@ func LoadCloudsYAML() (map[string]Cloud, error) {
 	return clouds.Clouds, nil
 }
 
-// LoadPublicCloudsYAML will load a clouds.yaml file and return the full config.
-func LoadPublicCloudsYAML() (map[string]PublicCloud, error) {
+// LoadSecureCloudsYAML will load a secure.yaml file and return the full config.
+func LoadSecureCloudsYAML() (map[string]Cloud, error) {
+	content, err := findAndReadSecureCloudsYAML()
+	if err != nil {
+		return nil, err
+	}
+
+	var secureClouds Clouds
+	err = yaml.Unmarshal(content, &secureClouds)
+	if err != nil {
+		if err.Error() == "no secure.yaml file found" {
+			// secure.yaml is optional so just ignore read error
+			return secureClouds.Clouds, nil
+		}
+		return nil, err
+	}
+
+	return secureClouds.Clouds, nil
+}
+
+// LoadPublicCloudsYAML will load a public-clouds.yaml file and return the full config.
+func LoadPublicCloudsYAML() (map[string]Cloud, error) {
 	var publicClouds PublicClouds
 
 	content, err := findAndReadPublicCloudsYAML()
@@ -134,14 +155,17 @@ func GetCloudFromYAML(opts *ClientOpts) (*Cloud, error) {
 		}
 	}
 
+	var cloudIsInCloudsYaml bool
 	if cloud == nil {
-		return nil, fmt.Errorf("Unable to determine a valid entry in clouds.yaml")
-	}
-
-	// Default is to verify SSL API requests
-	if cloud.Verify == nil {
-		iTrue := true
-		cloud.Verify = &iTrue
+		// not an immediate error as it might still be defined in secure.yaml
+		cloudIsInCloudsYaml = false
+	} else {
+		cloudIsInCloudsYaml = true
+		// Default is to verify SSL API requests
+		if cloud.Verify == nil {
+			iTrue := true
+			cloud.Verify = &iTrue
+		}
 	}
 
 	publicClouds, err := LoadPublicCloudsYAML()
@@ -155,8 +179,33 @@ func GetCloudFromYAML(opts *ClientOpts) (*Cloud, error) {
 		if !ok {
 			return nil, fmt.Errorf("cloud %s does not exist in clouds-public.yaml", profileName)
 		}
+		cloud, err = mergeClouds(cloud, publicCloud)
+		if err != nil {
+			return nil, fmt.Errorf("Could not merge information from clouds.yaml and clouds-public.yaml for cloud %s", profileName)
+		}
+	}
 
-		updateAuthInfo(cloud, &publicCloud)
+	secureClouds, err := LoadSecureCloudsYAML()
+	if err != nil {
+		return nil, fmt.Errorf("unable to load secure.yaml: %s", err)
+	}
+
+	if secureClouds != nil {
+		secureCloud, ok := secureClouds[cloudName]
+		if !ok && !cloudIsInCloudsYaml {
+			return nil, fmt.Errorf("Could not find cloud %s", cloudName)
+		}
+		if cloudName == "" && len(secureClouds) == 1 {
+			for _, v := range clouds {
+				cloud = &v
+			}
+		}
+		if !reflect.DeepEqual((Cloud{}), secureCloud) {
+			cloud, err = mergeClouds(secureCloud, cloud)
+			if err != nil {
+				return nil, fmt.Errorf("unable to merge information from clouds.yaml and secure.yaml")
+			}
+		}
 	}
 
 	// TODO: this is where reading vendor files should go be considered when not found in

--- a/openstack/clientconfig/results.go
+++ b/openstack/clientconfig/results.go
@@ -1,15 +1,10 @@
 package clientconfig
 
-// PublicClouds represents a collection of PublicCloud entries in clouds-public.yml file.
+// PublicClouds represents a collection of PublicCloud entries in clouds-public.yaml file.
 // The format of the clouds-public.yml is documented at
 // https://docs.openstack.org/python-openstackclient/latest/configuration/
 type PublicClouds struct {
-	Clouds map[string]PublicCloud `yaml:"public-clouds"`
-}
-
-// PublicCloud represents an entry in a clouds-public.yml file.
-type PublicCloud struct {
-	AuthInfo *AuthInfo `yaml:"auth"`
+	Clouds map[string]Cloud `yaml:"public-clouds"`
 }
 
 // Clouds represents a collection of Cloud entries in a clouds.yaml file.
@@ -19,7 +14,7 @@ type Clouds struct {
 	Clouds map[string]Cloud `yaml:"clouds"`
 }
 
-// Cloud represents an entry in a clouds.yaml file.
+// Cloud represents an entry in a clouds.yaml/public-clouds.yaml/secure.yaml file.
 type Cloud struct {
 	Cloud      string        `yaml:"cloud"`
 	Profile    string        `yaml:"profile"`

--- a/openstack/clientconfig/testing/clouds.yaml
+++ b/openstack/clientconfig/testing/clouds.yaml
@@ -101,7 +101,6 @@ clouds:
   chicago:
     profile: rackspace
     auth:
-      auth_url: "https://shall.be.overritten.by.public.cloud/"
       username: "jdoe"
       password: "password"
       project_name: "Some Project"
@@ -109,7 +108,6 @@ clouds:
   chicago_legacy:
     cloud: rackspace
     auth:
-      auth_url: "https://shall.be.overritten.by.public.cloud/"
       username: "jdoe"
       password: "password"
       project_name: "Some Project"
@@ -118,8 +116,15 @@ clouds:
     profile: rackspace
     cloud: rackspace
     auth:
-      auth_url: "https://shall.be.overritten.by.public.cloud/"
       username: "jdoe"
       password: "password"
       project_name: "Some Project"
     region_name: "ORD"
+  philadelphia:
+    auth:
+      auth_url: "https://phl.example.com:5000/v3"
+      username: "jdoe"
+      password: "this should be overwritten by secure.yaml"
+      project_name: "Some Project"
+    region_name: "PHL"
+

--- a/openstack/clientconfig/testing/fixtures.go
+++ b/openstack/clientconfig/testing/fixtures.go
@@ -8,6 +8,18 @@ import (
 var iTrue = true
 var iFalse = false
 
+var PhiladelphiaCloudYAML = clientconfig.Cloud{
+	RegionName: "PHL",
+	AuthInfo: &clientconfig.AuthInfo{
+		AuthURL:     "https://phl.example.com:5000/v3",
+		Username:    "admin",
+		Password:    "password",
+		ProjectName: "Some Project",
+	},
+	Verify:   &iTrue,
+	AuthType: "password",
+}
+
 var ChicagoCloudYAML = clientconfig.Cloud{
 	Profile:    "rackspace",
 	RegionName: "ORD",
@@ -39,7 +51,7 @@ var ChicagoCloudUseProfileYAML = clientconfig.Cloud{
 	AuthInfo: &clientconfig.AuthInfo{
 		AuthURL:     "https://identity.api.rackspacecloud.com/v2.0/",
 		Username:    "jdoe",
-		Password:    "password",
+		Password:    "securepassword",
 		ProjectName: "Some Project",
 	},
 	Verify: &iTrue,

--- a/openstack/clientconfig/testing/requests_test.go
+++ b/openstack/clientconfig/testing/requests_test.go
@@ -26,6 +26,7 @@ func TestGetCloudFromYAML(t *testing.T) {
 		"chicago":            &clientconfig.ClientOpts{Cloud: "chicago"},
 		"chicago_legacy":     &clientconfig.ClientOpts{Cloud: "chicago_legacy"},
 		"chicago_useprofile": &clientconfig.ClientOpts{Cloud: "chicago_useprofile"},
+		"philadelphia":       &clientconfig.ClientOpts{Cloud: "philadelphia"},
 	}
 
 	expectedClouds := map[string]*clientconfig.Cloud{
@@ -36,6 +37,7 @@ func TestGetCloudFromYAML(t *testing.T) {
 		"chicago":            &ChicagoCloudYAML,
 		"chicago_legacy":     &ChicagoCloudLegacyYAML,
 		"chicago_useprofile": &ChicagoCloudUseProfileYAML,
+		"philadelphia":       &PhiladelphiaCloudYAML,
 	}
 
 	for cloud, clientOpts := range allClientOpts {

--- a/openstack/clientconfig/testing/secure.yaml
+++ b/openstack/clientconfig/testing/secure.yaml
@@ -1,0 +1,12 @@
+clouds:
+  philadelphia:
+    auth:
+      username: "admin"
+      password: "password"
+    auth_type: "password"
+
+  chicago_useprofile:
+    auth:
+      password: "securepassword"
+
+


### PR DESCRIPTION
For #41 
This PR introduces secure.yaml for clientconfig and also fixes the behaviour of clientconfig when reading public-clouds.yaml as observed by @haxorof in #41 