### PR TITLE
Gnocchi: add Resourcetypes Get method

### DIFF
--- a/gnocchi/metric/v1/resourcetypes/doc.go
+++ b/gnocchi/metric/v1/resourcetypes/doc.go
@@ -16,5 +16,13 @@ Example of Listing resource types
   for _, resourceType := range allResourceTypes {
     fmt.Printf("%+v\n", resourceType)
   }
+
+Example of Getting a resource type
+
+  resourceTypeName := "compute_instance"
+  resourceType, err := resourcetypes.Get(gnocchiClient, resourceTypeName).Extract()
+  if err != nil {
+    panic(err)
+  }
 */
 package resourcetypes

--- a/gnocchi/metric/v1/resourcetypes/requests.go
+++ b/gnocchi/metric/v1/resourcetypes/requests.go
@@ -11,3 +11,9 @@ func List(client *gophercloud.ServiceClient) pagination.Pager {
 		return ResourceTypePage{pagination.SinglePageBase(r)}
 	})
 }
+
+// Get retrieves a specific Gnocchi resource type based on its name.
+func Get(c *gophercloud.ServiceClient, resourceTypeName string) (r GetResult) {
+	_, r.Err = c.Get(getURL(c, resourceTypeName), &r.Body, nil)
+	return
+}

--- a/gnocchi/metric/v1/resourcetypes/testing/fixtures.go
+++ b/gnocchi/metric/v1/resourcetypes/testing/fixtures.go
@@ -69,3 +69,23 @@ var ResourceType3 = resourcetypes.ResourceType{
 		},
 	},
 }
+
+// ResourceTypeGetResult represents raw server response from a server to a get requrest.
+const ResourceTypeGetResult = `
+{
+    "attributes": {
+        "host": {
+            "min_length": 0,
+            "max_length": 255,
+            "type": "string",
+            "required": true
+        },
+        "image_ref": {
+            "type": "uuid",
+            "required": false
+        }
+    },
+    "state": "active",
+    "name": "compute_instance"
+}
+`

--- a/gnocchi/metric/v1/resourcetypes/testing/requests_test.go
+++ b/gnocchi/metric/v1/resourcetypes/testing/requests_test.go
@@ -50,3 +50,40 @@ func TestList(t *testing.T) {
 		t.Errorf("Expected 1 page, got %d", count)
 	}
 }
+
+func TestGet(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v1/resource_type/compute_instance", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, ResourceTypeGetResult)
+	})
+
+	s, err := resourcetypes.Get(fake.ServiceClient(), "compute_instance").Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, s.Name, "compute_instance")
+	th.AssertEquals(t, s.State, "active")
+	th.AssertDeepEquals(t, s.Attributes, map[string]resourcetypes.Attribute{
+		"host": resourcetypes.Attribute{
+			Type: "string",
+			Details: map[string]interface{}{
+				"max_length": float64(255),
+				"min_length": float64(0),
+				"required":   true,
+			},
+		},
+		"image_ref": resourcetypes.Attribute{
+			Type: "uuid",
+			Details: map[string]interface{}{
+				"required": false,
+			},
+		},
+	})
+}

--- a/gnocchi/metric/v1/resourcetypes/urls.go
+++ b/gnocchi/metric/v1/resourcetypes/urls.go
@@ -8,6 +8,14 @@ func rootURL(c *gophercloud.ServiceClient) string {
 	return c.ServiceURL(resourcePath)
 }
 
+func resourceURL(c *gophercloud.ServiceClient, resourceTypeName string) string {
+	return c.ServiceURL(resourcePath, resourceTypeName)
+}
+
 func listURL(c *gophercloud.ServiceClient) string {
 	return rootURL(c)
+}
+
+func getURL(c *gophercloud.ServiceClient, resourceTypeName string) string {
+	return resourceURL(c, resourceTypeName)
 }


### PR DESCRIPTION
Provide a method go get a single resource type. Add unit test and documentation.

Code references:
https://github.com/gnocchixyz/gnocchi/blob/stable/4.2/gnocchi/rest/api.py#L849
https://github.com/gnocchixyz/gnocchi/blob/stable/4.2/gnocchi/indexer/sqlalchemy.py#L452
https://github.com/gnocchixyz/gnocchi/blob/stable/4.2/gnocchi/resource_type.py#L264

For #54