### PR TITLE
Gnocchi: add Create method for Resource types

### DIFF
--- a/acceptance/gnocchi/metric/v1/resourcetypes.go
+++ b/acceptance/gnocchi/metric/v1/resourcetypes.go
@@ -1,0 +1,45 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/acceptance/tools"
+	"github.com/gophercloud/utils/gnocchi/metric/v1/resourcetypes"
+)
+
+// CreateResourceType creates Gnocchi resource type. An error will be returned if the
+// resource type could not be created.
+func CreateResourceType(t *testing.T, client *gophercloud.ServiceClient) (*resourcetypes.ResourceType, error) {
+	resourceTypeName := tools.RandomString("TESTACCT-", 8)
+	attributeStringName := tools.RandomString("TESTACCT-ATTRIBUTE-", 8)
+	attributeUUIDName := tools.RandomString("TESTACCT-ATTRIBUTE-", 8)
+
+	createOpts := resourcetypes.CreateOpts{
+		Name: resourceTypeName,
+		Attributes: map[string]resourcetypes.AttributeOpts{
+			attributeStringName: resourcetypes.AttributeOpts{
+				Type: "string",
+				Details: map[string]interface{}{
+					"max_length": 128,
+					"required":   false,
+				},
+			},
+			attributeUUIDName: resourcetypes.AttributeOpts{
+				Type: "uuid",
+				Details: map[string]interface{}{
+					"required": true,
+				},
+			},
+		},
+	}
+	t.Logf("Attempting to create a Gnocchi resource type")
+
+	resourceType, err := resourcetypes.Create(client, createOpts).Extract()
+	if err != nil {
+		return nil, err
+	}
+
+	t.Logf("Successfully created the Gnocchi resource type.")
+	return resourceType, nil
+}

--- a/acceptance/gnocchi/metric/v1/resourcetypes_test.go
+++ b/acceptance/gnocchi/metric/v1/resourcetypes_test.go
@@ -30,3 +30,18 @@ func TestResourceTypesList(t *testing.T) {
 		tools.PrintResource(t, resourceType)
 	}
 }
+
+func TestResourceTypesCRUD(t *testing.T) {
+	client, err := clients.NewGnocchiV1Client()
+	if err != nil {
+		t.Fatalf("Unable to create a Gnocchi client: %v", err)
+	}
+
+	resourceType, err := CreateResourceType(t, client)
+	if err != nil {
+		t.Fatalf("Unable to create a Gnocchi resource type: %v", err)
+	}
+	// defer DeleteResourceType(t, client, resourceType.Name)
+
+	tools.PrintResource(t, resourceType)
+}

--- a/gnocchi/metric/v1/resourcetypes/doc.go
+++ b/gnocchi/metric/v1/resourcetypes/doc.go
@@ -24,5 +24,30 @@ Example of Getting a resource type
   if err != nil {
     panic(err)
   }
+
+Example of Creating a resource type
+
+  resourceTypeOpts := resourcetypes.CreateOpts{
+    Name: "compute_instance_network",
+    Attributes: map[string]resourcetypes.AttributeOpts{
+      "port_name": resourcetypes.AttributeOpts{
+        Type: "string",
+        Details: map[string]interface{}{
+          "max_length": 128,
+          "required":   false,
+        },
+      },
+      "port_id": resourcetypes.AttributeOpts{
+        Type: "uuid",
+        Details: map[string]interface{}{
+          "required": true,
+        },
+      },
+    },
+  }
+  resourceType, err := resourcetypes.Create(gnocchiClient, resourceTypeOpts).Extract()
+  if err != nil {
+    panic(err)
+  }
 */
 package resourcetypes

--- a/gnocchi/metric/v1/resourcetypes/doc.go
+++ b/gnocchi/metric/v1/resourcetypes/doc.go
@@ -16,5 +16,13 @@ Example of Listing resource types
   for _, resourceType := range allResourceTypes {
     fmt.Printf("%+v\n", resourceType)
   }
+
+Example of Getting a resource type
+
+  resourceTypeName := "compute_instance"
+  resourceType, err := resourcetypes.Get(gnocchiClient, resourceTypeName).Extract()
+  if err != nil {
+    panic(err)
+  }
 */
 package resourcetypes

--- a/gnocchi/metric/v1/resourcetypes/requests.go
+++ b/gnocchi/metric/v1/resourcetypes/requests.go
@@ -11,3 +11,9 @@ func List(client *gophercloud.ServiceClient) pagination.Pager {
 		return ResourceTypePage{pagination.SinglePageBase(r)}
 	})
 }
+
+// Get retrieves a specific Gnocchi resource type based on its name.
+func Get(c *gophercloud.ServiceClient, resourceTypeName string) (r GetResult) {
+	_, r.Err = c.Get(getURL(c, resourceTypeName), &r.Body, nil)
+	return
+}

--- a/gnocchi/metric/v1/resourcetypes/requests.go
+++ b/gnocchi/metric/v1/resourcetypes/requests.go
@@ -17,3 +17,79 @@ func Get(c *gophercloud.ServiceClient, resourceTypeName string) (r GetResult) {
 	_, r.Err = c.Get(getURL(c, resourceTypeName), &r.Body, nil)
 	return
 }
+
+// CreateOptsBuilder allows to add additional parameters to the Create request.
+type CreateOptsBuilder interface {
+	ToResourceTypeCreateMap() (map[string]interface{}, error)
+}
+
+// AttributeOpts represents options of a single resource type attribute that
+// can be created in the Gnocchi.
+type AttributeOpts struct {
+	// Type is an attribute type.
+	Type string `json:"type"`
+
+	// Details represents different attribute fields.
+	Details map[string]interface{} `json:"-"`
+}
+
+// ToMap is a helper function to convert individual AttributeOpts structure into a sub-map.
+func (opts AttributeOpts) ToMap() (map[string]interface{}, error) {
+	b, err := gophercloud.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+	if opts.Details != nil {
+		for k, v := range opts.Details {
+			b[k] = v
+		}
+	}
+	return b, nil
+}
+
+// CreateOpts specifies parameters of a new Gnocchi resource type.
+type CreateOpts struct {
+	// Attributes is a collection of keys and values of different resource types.
+	Attributes map[string]AttributeOpts `json:"-"`
+
+	// Name is a human-readable resource type identifier.
+	Name string `json:"name" required:"true"`
+}
+
+// ToResourceTypeCreateMap constructs a request body from CreateOpts.
+func (opts CreateOpts) ToResourceTypeCreateMap() (map[string]interface{}, error) {
+	b, err := gophercloud.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	// Create resource type without attributes if they're omitted.
+	if opts.Attributes == nil {
+		return b, nil
+	}
+
+	attributes := make(map[string]interface{}, len(opts.Attributes))
+	for k, v := range opts.Attributes {
+		attributesMap, err := v.ToMap()
+		if err != nil {
+			return nil, err
+		}
+		attributes[k] = attributesMap
+	}
+
+	b["attributes"] = attributes
+	return b, nil
+}
+
+// Create requests the creation of a new Gnocchi resource type on the server.
+func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToResourceTypeCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(createURL(client), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{201},
+	})
+	return
+}

--- a/gnocchi/metric/v1/resourcetypes/results.go
+++ b/gnocchi/metric/v1/resourcetypes/results.go
@@ -24,6 +24,12 @@ type GetResult struct {
 	commonResult
 }
 
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a Gnocchi resource type.
+type CreateResult struct {
+	commonResult
+}
+
 // ResourceType represents custom Gnocchi resource type.
 type ResourceType struct {
 	// Attributes is a collection of keys and values of different resource types.

--- a/gnocchi/metric/v1/resourcetypes/testing/fixtures.go
+++ b/gnocchi/metric/v1/resourcetypes/testing/fixtures.go
@@ -69,3 +69,23 @@ var ResourceType3 = resourcetypes.ResourceType{
 		},
 	},
 }
+
+// ResourceTypeGetResult represents raw server response from a server to a get requrest.
+const ResourceTypeGetResult = `
+{
+    "attributes": {
+        "host": {
+            "min_length": 0,
+            "max_length": 255,
+            "type": "string",
+            "required": true
+        },
+        "image_ref": {
+            "type": "uuid",
+            "required": false
+        }
+    },
+    "state": "active",
+    "name": "compute_instance"
+}
+`

--- a/gnocchi/metric/v1/resourcetypes/testing/fixtures.go
+++ b/gnocchi/metric/v1/resourcetypes/testing/fixtures.go
@@ -89,3 +89,57 @@ const ResourceTypeGetResult = `
     "name": "compute_instance"
 }
 `
+
+// ResourceTypeCreateWithoutAttributesRequest represents a request to create a resource type without attributes.
+const ResourceTypeCreateWithoutAttributesRequest = `
+{
+    "name":"identity_project"
+}
+`
+
+// ResourceTypeCreateWithoutAttributesResult represents a raw server response to the ResourceTypeCreateWithoutAttributesRequest.
+const ResourceTypeCreateWithoutAttributesResult = `
+{
+    "attributes": {},
+    "state": "active",
+    "name": "identity_project"
+}
+`
+
+// ResourceTypeCreateWithAttributesRequest represents a request to create a resource type with attributes.
+const ResourceTypeCreateWithAttributesRequest = `
+{
+    "attributes": {
+        "port_name": {
+            "max_length": 128,
+            "required": false,
+            "type": "string"
+        },
+        "port_id": {
+            "required": true,
+            "type": "uuid"
+        }
+    },
+    "name": "compute_instance_network"
+}
+`
+
+// ResourceTypeCreateWithAttributesResult represents a raw server response to the ResourceTypeCreateWithAttributesRequest.
+const ResourceTypeCreateWithAttributesResult = `
+{
+    "attributes": {
+        "port_id": {
+            "required": true,
+            "type": "uuid"
+        },
+        "port_name": {
+            "min_length": 0,
+            "max_length": 128,
+            "type": "string",
+            "required": false
+        }
+    },
+    "state": "active",
+    "name": "compute_instance_network"
+}
+`

--- a/gnocchi/metric/v1/resourcetypes/testing/requests_test.go
+++ b/gnocchi/metric/v1/resourcetypes/testing/requests_test.go
@@ -50,3 +50,40 @@ func TestList(t *testing.T) {
 		t.Errorf("Expected 1 page, got %d", count)
 	}
 }
+
+func TestGet(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v1/resource_type/compute_instance", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, ResourceTypeGetResult)
+	})
+
+	s, err := resourcetypes.Get(fake.ServiceClient(), "compute_instance").Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, s.Name, "compute_instance")
+	th.AssertEquals(t, s.State, "active")
+	th.AssertDeepEquals(t, s.Attributes, map[string]resourcetypes.Attribute{
+		"host": resourcetypes.Attribute{
+			Type: "string",
+			Details: map[string]interface{}{
+				"max_length": float64(255),
+				"min_length": float64(0),
+				"required":   true,
+			},
+		},
+		"image_ref": resourcetypes.Attribute{
+			Type: "uuid",
+			Details: map[string]interface{}{
+				"required": false,
+			},
+		},
+	})
+}

--- a/gnocchi/metric/v1/resourcetypes/urls.go
+++ b/gnocchi/metric/v1/resourcetypes/urls.go
@@ -8,6 +8,14 @@ func rootURL(c *gophercloud.ServiceClient) string {
 	return c.ServiceURL(resourcePath)
 }
 
+func resourceURL(c *gophercloud.ServiceClient, resourceTypeName string) string {
+	return c.ServiceURL(resourcePath, resourceTypeName)
+}
+
 func listURL(c *gophercloud.ServiceClient) string {
 	return rootURL(c)
+}
+
+func getURL(c *gophercloud.ServiceClient, resourceTypeName string) string {
+	return resourceURL(c, resourceTypeName)
 }

--- a/gnocchi/metric/v1/resourcetypes/urls.go
+++ b/gnocchi/metric/v1/resourcetypes/urls.go
@@ -19,3 +19,7 @@ func listURL(c *gophercloud.ServiceClient) string {
 func getURL(c *gophercloud.ServiceClient, resourceTypeName string) string {
 	return resourceURL(c, resourceTypeName)
 }
+
+func createURL(c *gophercloud.ServiceClient) string {
+	return rootURL(c)
+}


### PR DESCRIPTION
Implement Create method in the resourcetypes package.
Add unit and acceptance tests with documentation.

Code references:
https://github.com/gnocchixyz/gnocchi/blob/stable/4.2/gnocchi/rest/api.py#L933
https://github.com/gnocchixyz/gnocchi/blob/stable/4.2/gnocchi/indexer/sqlalchemy.py#L354
https://github.com/gnocchixyz/gnocchi/blob/stable/4.2/gnocchi/resource_type.py#L264

For #54