### PR TITLE
Gnocchi: add Update method for Resource types

### DIFF
--- a/acceptance/gnocchi/metric/v1/resourcetypes_test.go
+++ b/acceptance/gnocchi/metric/v1/resourcetypes_test.go
@@ -44,4 +44,66 @@ func TestResourceTypesCRUD(t *testing.T) {
 	// defer DeleteResourceType(t, client, resourceType.Name)
 
 	tools.PrintResource(t, resourceType)
+
+	// Populate attributes that will be deleted.
+	attributesToDelete := []string{}
+	for attributeName := range resourceType.Attributes {
+		attributesToDelete = append(attributesToDelete, attributeName)
+	}
+
+	// New string attribute parameters.
+	newStringAttributeOpts := resourcetypes.AttributeOpts{
+		Details: map[string]interface{}{
+			"required":   false,
+			"min_length": 32,
+			"max_length": 64,
+		},
+		Type: "string",
+	}
+	newStringAttributeOptsName := tools.RandomString("TESTACCT-ATTRIBUTE-", 8)
+
+	// New datetime attribute parameters.
+	newDatetimeAttributeOpts := resourcetypes.AttributeOpts{
+		Details: map[string]interface{}{
+			"required": true,
+			"options": map[string]interface{}{
+				"fill": "2018-07-28T00:01:01Z",
+			},
+		},
+		Type: "datetime",
+	}
+	newDatetimeAttributeOptsName := tools.RandomString("TESTACCT-ATTRIBUTE-", 8)
+
+	// Initial options for the Update request with the new resource type attributes.
+	updateOpts := resourcetypes.UpdateOpts{
+		Attributes: []resourcetypes.AttributeUpdateOpts{
+			{
+				Name:      newStringAttributeOptsName,
+				Operation: resourcetypes.AttributeAdd,
+				Value:     &newStringAttributeOpts,
+			},
+			{
+				Name:      newDatetimeAttributeOptsName,
+				Operation: resourcetypes.AttributeAdd,
+				Value:     &newDatetimeAttributeOpts,
+			},
+		},
+	}
+
+	// Add options to delete attributes.
+	for _, attributeToDelete := range attributesToDelete {
+		updateOpts.Attributes = append(updateOpts.Attributes, resourcetypes.AttributeUpdateOpts{
+			Name:      attributeToDelete,
+			Operation: resourcetypes.AttributeRemove,
+		})
+	}
+
+	t.Logf("Attempting to update a Gnocchi resource type \"%s\".", resourceType.Name)
+	newResourceType, err := resourcetypes.Update(client, resourceType.Name, updateOpts).Extract()
+	if err != nil {
+		t.Fatalf("Unable to update a Gnocchi resource type: %v", err)
+	}
+	t.Logf("Successfully updated the Gnocchi resource type \"%s\".", resourceType.Name)
+
+	tools.PrintResource(t, newResourceType)
 }

--- a/gnocchi/metric/v1/resourcetypes/doc.go
+++ b/gnocchi/metric/v1/resourcetypes/doc.go
@@ -49,5 +49,45 @@ Example of Creating a resource type
   if err != nil {
     panic(err)
   }
+
+Example of Updating a resource type
+
+  enabledAttributeOptions := resourcetypes.AttributeOpts{
+    Details: map[string]interface{}{
+      "required": true,
+      "options": map[string]interface{}{
+        "fill": true,
+      },
+    },
+    Type: "bool",
+  }
+  parendIDAttributeOptions := resourcetypes.AttributeOpts{
+    Details: map[string]interface{}{
+      "required": false,
+    },
+    Type: "uuid",
+  }
+  resourceTypeOpts := resourcetypes.UpdateOpts{
+    Attributes: []resourcetypes.AttributeUpdateOpts{
+      {
+        Name:      "enabled",
+        Operation: resourcetypes.AttributeAdd,
+        Value:     &enabledAttributeOptions,
+      },
+      {
+        Name:      "parent_id",
+        Operation: resourcetypes.AttributeAdd,
+        Value:     &parendIDAttributeOptions,
+      },
+      {
+        Name:      "domain_id",
+        Operation: resourcetypes.AttributeRemove,
+      },
+    },
+  }
+  resourceType, err := resourcetypes.Update(gnocchiClient, resourceTypeOpts).Extract()
+  if err != nil {
+    panic(err)
+  }
 */
 package resourcetypes

--- a/gnocchi/metric/v1/resourcetypes/requests.go
+++ b/gnocchi/metric/v1/resourcetypes/requests.go
@@ -1,6 +1,9 @@
 package resourcetypes
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/pagination"
 )
@@ -90,6 +93,99 @@ func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r Create
 	}
 	_, r.Err = client.Post(createURL(client), b, &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{201},
+	})
+	return
+}
+
+// AttributeOperation represents a type of operation that can be performed over
+// Gnocchi resource type attribute.
+type AttributeOperation string
+
+const (
+	// AttributeAdd represents Gnocchi resource type attribute add operation.
+	AttributeAdd AttributeOperation = "add"
+
+	// AttributeRemove represents Gnocchi resource type attribute remove operation.
+	AttributeRemove AttributeOperation = "remove"
+
+	// AttributeCommonPath represents a prefix for every attribute in the Gnocchi
+	// resource type.
+	AttributeCommonPath = "/attributes"
+)
+
+// UpdateOptsBuilder allows to add additional parameters to the Update request.
+type UpdateOptsBuilder interface {
+	ToResourceTypeUpdateMap() ([]map[string]interface{}, error)
+}
+
+// UpdateOpts specifies parameters for a Gnocchi resource type update request.
+type UpdateOpts struct {
+	// AttributesOperations is a collection of operations that need to be performed
+	// over Gnocchi resource type attributes.
+	Attributes []AttributeUpdateOpts `json:"-"`
+}
+
+// AttributeUpdateOpts represents update options over a single Gnocchi resource
+// type attribute.
+type AttributeUpdateOpts struct {
+	// Name is a human-readable name of an attribute that needs to be added or removed.
+	Name string `json:"-" required:"true"`
+
+	// Operation represent action that needs to be performed over the attribute.
+	Operation AttributeOperation `json:"-" required:"true"`
+
+	// Value is an attribute options.
+	Value *AttributeOpts `json:"-"`
+}
+
+// ToResourceTypeUpdateMap constructs a request body from UpdateOpts.
+func (opts UpdateOpts) ToResourceTypeUpdateMap() ([]map[string]interface{}, error) {
+	if len(opts.Attributes) == 0 {
+		return nil, fmt.Errorf("provided Gnocchi resource type UpdateOpts is empty")
+	}
+
+	updateOptsMaps := make([]map[string]interface{}, len(opts.Attributes))
+
+	// Populate a map for every attribute.
+	for i, attributeUpdateOpts := range opts.Attributes {
+		attributeUpdateOptsMap := make(map[string]interface{})
+
+		// Populate attribute value map if provided.
+		if attributeUpdateOpts.Value != nil {
+			attributeValue, err := attributeUpdateOpts.Value.ToMap()
+			if err != nil {
+				return nil, err
+			}
+			attributeUpdateOptsMap["value"] = attributeValue
+		}
+
+		// Populate attribute update operation.
+		attributeUpdateOptsMap["op"] = attributeUpdateOpts.Operation
+
+		// Populate attribute path from its name.
+		attributeUpdateOptsMap["path"] = strings.Join([]string{
+			AttributeCommonPath,
+			attributeUpdateOpts.Name,
+		}, "/")
+
+		updateOptsMaps[i] = attributeUpdateOptsMap
+	}
+
+	return updateOptsMaps, nil
+}
+
+// Update requests the update operation over existsing Gnocchi resource type.
+func Update(client *gophercloud.ServiceClient, resourceTypeName string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToResourceTypeUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Patch(updateURL(client, resourceTypeName), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json-patch+json",
+		},
 	})
 	return
 }

--- a/gnocchi/metric/v1/resourcetypes/results.go
+++ b/gnocchi/metric/v1/resourcetypes/results.go
@@ -30,6 +30,12 @@ type CreateResult struct {
 	commonResult
 }
 
+// UpdateResult represents the result of an update operation. Call its Extract
+// method to interpret it as a Gnocchi resource type.
+type UpdateResult struct {
+	commonResult
+}
+
 // ResourceType represents custom Gnocchi resource type.
 type ResourceType struct {
 	// Attributes is a collection of keys and values of different resource types.

--- a/gnocchi/metric/v1/resourcetypes/testing/fixtures.go
+++ b/gnocchi/metric/v1/resourcetypes/testing/fixtures.go
@@ -70,7 +70,7 @@ var ResourceType3 = resourcetypes.ResourceType{
 	},
 }
 
-// ResourceTypeGetResult represents raw server response from a server to a get requrest.
+// ResourceTypeGetResult represents raw server response from a server to a get request.
 const ResourceTypeGetResult = `
 {
     "attributes": {
@@ -141,5 +141,58 @@ const ResourceTypeCreateWithAttributesResult = `
     },
     "state": "active",
     "name": "compute_instance_network"
+}
+`
+
+// ResourceTypeUpdateRequest represents a request to update a resource type.
+const ResourceTypeUpdateRequest = `
+[
+    {
+        "op": "add",
+        "path": "/attributes/enabled",
+        "value": {
+            "options": {
+                "fill": true
+            },
+            "required": true,
+            "type": "bool"
+        }
+    },
+    {
+        "op": "add",
+        "path": "/attributes/parent_id",
+        "value": {
+            "required": false,
+            "type": "uuid"
+        }
+    },
+    {
+        "op": "remove",
+        "path": "/attributes/domain_id"
+    }
+]
+`
+
+// ResourceTypeUpdateResult represents a raw server response to the ResourceTypeUpdateRequest.
+const ResourceTypeUpdateResult = `
+{
+    "attributes": {
+        "enabled": {
+            "required": true,
+            "type": "bool"
+        },
+        "parent_id": {
+            "type": "uuid",
+            "required": false
+        },
+        "name": {
+            "required": true,
+            "type": "string",
+            "min_length": 0,
+            "max_length": 128
+        }
+    },
+    "state": "active",
+    "name": "identity_project"
 }
 `

--- a/gnocchi/metric/v1/resourcetypes/testing/requests_test.go
+++ b/gnocchi/metric/v1/resourcetypes/testing/requests_test.go
@@ -173,3 +173,83 @@ func TestCreateWithAttributes(t *testing.T) {
 		},
 	})
 }
+
+func TestUpdate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v1/resource_type/identity_project", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PATCH")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json-patch+json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, ResourceTypeUpdateRequest)
+
+		w.Header().Add("Content-Type", "application/json-patch+json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, ResourceTypeUpdateResult)
+	})
+
+	enabledAttributeOptions := resourcetypes.AttributeOpts{
+		Details: map[string]interface{}{
+			"required": true,
+			"options": map[string]interface{}{
+				"fill": true,
+			},
+		},
+		Type: "bool",
+	}
+	parendIDAttributeOptions := resourcetypes.AttributeOpts{
+		Details: map[string]interface{}{
+			"required": false,
+		},
+		Type: "uuid",
+	}
+	opts := resourcetypes.UpdateOpts{
+		Attributes: []resourcetypes.AttributeUpdateOpts{
+			{
+				Name:      "enabled",
+				Operation: resourcetypes.AttributeAdd,
+				Value:     &enabledAttributeOptions,
+			},
+			{
+				Name:      "parent_id",
+				Operation: resourcetypes.AttributeAdd,
+				Value:     &parendIDAttributeOptions,
+			},
+			{
+				Name:      "domain_id",
+				Operation: resourcetypes.AttributeRemove,
+			},
+		},
+	}
+
+	s, err := resourcetypes.Update(fake.ServiceClient(), "identity_project", opts).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, s.Name, "identity_project")
+	th.AssertEquals(t, s.State, "active")
+	th.AssertDeepEquals(t, s.Attributes, map[string]resourcetypes.Attribute{
+		"enabled": resourcetypes.Attribute{
+			Type: "bool",
+			Details: map[string]interface{}{
+				"required": true,
+			},
+		},
+		"parent_id": resourcetypes.Attribute{
+			Type: "uuid",
+			Details: map[string]interface{}{
+				"required": false,
+			},
+		},
+		"name": resourcetypes.Attribute{
+			Type: "string",
+			Details: map[string]interface{}{
+				"required":   true,
+				"min_length": float64(0),
+				"max_length": float64(128),
+			},
+		},
+	})
+}

--- a/gnocchi/metric/v1/resourcetypes/urls.go
+++ b/gnocchi/metric/v1/resourcetypes/urls.go
@@ -23,3 +23,7 @@ func getURL(c *gophercloud.ServiceClient, resourceTypeName string) string {
 func createURL(c *gophercloud.ServiceClient) string {
 	return rootURL(c)
 }
+
+func updateURL(c *gophercloud.ServiceClient, resourceTypeName string) string {
+	return resourceURL(c, resourceTypeName)
+}


### PR DESCRIPTION
Implement Update method in the resourcetypes package.
Add unit and acceptance tests with documentation.

Code references:
https://github.com/gnocchixyz/gnocchi/blob/stable/4.2/gnocchi/rest/api.py#L858
https://github.com/gnocchixyz/gnocchi/blob/stable/4.2/gnocchi/indexer/sqlalchemy.py#L385
https://github.com/gnocchixyz/gnocchi/blob/stable/4.2/gnocchi/resource_type.py#L264

For #54