### PR TITLE
Fix an issue on environments where user.Current() is not implemented.

### DIFF
--- a/openstack/clientconfig/utils.go
+++ b/openstack/clientconfig/utils.go
@@ -129,15 +129,13 @@ func findAndReadYAML(yamlFile string) ([]byte, error) {
 
 	// unix user config directory: ~/.config/openstack.
 	currentUser, err := user.Current()
-	if err != nil {
-		return nil, fmt.Errorf("unable to get current user: %s", err)
-	}
-
-	homeDir := currentUser.HomeDir
-	if homeDir != "" {
-		filename := filepath.Join(homeDir, ".config/openstack/"+yamlFile)
-		if ok := fileExists(filename); ok {
-			return ioutil.ReadFile(filename)
+	if err == nil {
+		homeDir := currentUser.HomeDir
+		if homeDir != "" {
+			filename := filepath.Join(homeDir, ".config/openstack/"+yamlFile)
+			if ok := fileExists(filename); ok {
+				return ioutil.ReadFile(filename)
+			}
 		}
 	}
 


### PR DESCRIPTION
When we call `findAndReadCloudsYAML()` on an environment where user.Current() is not implemented, such as "scratch" Docker container, the function returns an error `unable to get current user: ...`.

However, even on such environments, if we have clouds.yaml on `/etc/openstack/`, the function should load the contents from the file.