### PR TITLE
Don't fail if USER is not defined

### DIFF
--- a/openstack/clientconfig/utils.go
+++ b/openstack/clientconfig/utils.go
@@ -128,16 +128,13 @@ func findAndReadYAML(yamlFile string) ([]byte, error) {
 	}
 
 	// unix user config directory: ~/.config/openstack.
-	currentUser, err := user.Current()
-	if err != nil {
-		return nil, fmt.Errorf("unable to get current user: %s", err)
-	}
-
-	homeDir := currentUser.HomeDir
-	if homeDir != "" {
-		filename := filepath.Join(homeDir, ".config/openstack/"+yamlFile)
-		if ok := fileExists(filename); ok {
-			return ioutil.ReadFile(filename)
+	if currentUser, err := user.Current(); err == nil {
+		homeDir := currentUser.HomeDir
+		if homeDir != "" {
+			filename := filepath.Join(homeDir, ".config/openstack/"+yamlFile)
+			if ok := fileExists(filename); ok {
+				return ioutil.ReadFile(filename)
+			}
 		}
 	}
 


### PR DESCRIPTION
There's a way to workaround this issue by setting OS_CLIENT_CONFIG_FILE
to the right path, it's still not ok to fail when a USER is not defined
in the system. This can happen in various scenarios, including running
within a container.

OS_CLIENT_CONFIG_FILE should be a feature and not a workaround for this
problem. If USER is not defined or the `~/.config/openstack` dir
doesn't exist, we should just move on.