### PR TITLE
Enable go modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,14 @@ language: go
 sudo: false
 install:
 - go get -v ./...
-- go get golang.org/x/tools/cmd/goimports
+- GO111MODULE=off go get golang.org/x/tools/cmd/goimports
+env:
+  global:
+  - GO111MODULE=on
 go:
 - 1.9
+- "1.10"
+- 1.11
 - tip
 before_script:
 - go vet ./...

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,7 @@
+module github.com/gophercloud/utils
+
+require (
+	github.com/gophercloud/gophercloud v0.0.0-20190212181753-892256c46858
+	github.com/hashicorp/go-uuid v1.0.1
+	gopkg.in/yaml.v2 v2.2.2
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/gophercloud/gophercloud v0.0.0-20190212181753-892256c46858 h1:QBK4YvYPJGsghVtVJcEZcQ70UNGFnWUCjtv2NTcEFHA=
+github.com/gophercloud/gophercloud v0.0.0-20190212181753-892256c46858/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
+github.com/hashicorp/go-uuid v1.0.1 h1:fv1ep09latC32wFoVwnqcnKJGnMSdBanPczbHAYm1BE=
+github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
+golang.org/x/crypto v0.0.0-20190211182817-74369b46fc67 h1:ng3VDlRp5/DHpSWl02R4rM9I+8M2rhmsuLwAMmkLQWE=
+golang.org/x/crypto v0.0.0-20190211182817-74369b46fc67/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/sys v0.0.0-20190209173611-3b5209105503 h1:5SvYFrOM3W8Mexn9/oA44Ji7vhXAZQ9hiP+1Q/DMrWg=
+golang.org/x/sys v0.0.0-20190209173611-3b5209105503/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
This is in preparation to switching [Terraform OpenStack provider](https://github.com/terraform-providers/terraform-provider-openstack) to go modules (see https://github.com/terraform-providers/terraform-provider-openstack/issues/656).

Enabling go modules throughout the dependency tree of the provider will make the switch and future upgrades easier.

This PR is a result of the following commands (in a clean Go `1.11.5` environment):

```sh
go mod init
go get ./...
go mod tidy
```