### PR TITLE
Terraform Authentication

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,5 +3,6 @@ module github.com/gophercloud/utils
 require (
 	github.com/gophercloud/gophercloud v0.0.0-20190212181753-892256c46858
 	github.com/hashicorp/go-uuid v1.0.1
+	github.com/mitchellh/go-homedir v1.1.0
 	gopkg.in/yaml.v2 v2.2.2
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/gophercloud/gophercloud v0.0.0-20190212181753-892256c46858 h1:QBK4YvY
 github.com/gophercloud/gophercloud v0.0.0-20190212181753-892256c46858/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
 github.com/hashicorp/go-uuid v1.0.1 h1:fv1ep09latC32wFoVwnqcnKJGnMSdBanPczbHAYm1BE=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
+github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
+github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 golang.org/x/crypto v0.0.0-20190211182817-74369b46fc67 h1:ng3VDlRp5/DHpSWl02R4rM9I+8M2rhmsuLwAMmkLQWE=
 golang.org/x/crypto v0.0.0-20190211182817-74369b46fc67/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/sys v0.0.0-20190209173611-3b5209105503 h1:5SvYFrOM3W8Mexn9/oA44Ji7vhXAZQ9hiP+1Q/DMrWg=

--- a/terraform/auth/config.go
+++ b/terraform/auth/config.go
@@ -1,0 +1,476 @@
+package auth
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack"
+	"github.com/gophercloud/gophercloud/openstack/objectstorage/v1/swauth"
+	"github.com/gophercloud/utils/openstack/clientconfig"
+)
+
+type Config struct {
+	CACertFile                  string
+	ClientCertFile              string
+	ClientKeyFile               string
+	Cloud                       string
+	DefaultDomain               string
+	DomainID                    string
+	DomainName                  string
+	EndpointOverrides           map[string]interface{}
+	EndpointType                string
+	IdentityEndpoint            string
+	Insecure                    *bool
+	Password                    string
+	ProjectDomainName           string
+	ProjectDomainID             string
+	Region                      string
+	Swauth                      bool
+	TenantID                    string
+	TenantName                  string
+	Token                       string
+	UserDomainName              string
+	UserDomainID                string
+	Username                    string
+	UserID                      string
+	ApplicationCredentialID     string
+	ApplicationCredentialName   string
+	ApplicationCredentialSecret string
+	UseOctavia                  bool
+	MaxRetries                  int
+
+	OsClient *gophercloud.ProviderClient
+}
+
+// LoadAndValidate performs the authentication and initial configuration
+// of an OpenStack Provider Client. This sets up the HTTP client and
+// authenticates to an OpenStack cloud.
+//
+// Individual Service Clients are created later in this file.
+func (c *Config) LoadAndValidate() error {
+	// Make sure at least one of auth_url or cloud was specified.
+	if c.IdentityEndpoint == "" && c.Cloud == "" {
+		return fmt.Errorf("One of 'auth_url' or 'cloud' must be specified")
+	}
+
+	validEndpoint := false
+	validEndpoints := []string{
+		"internal", "internalURL",
+		"admin", "adminURL",
+		"public", "publicURL",
+		"",
+	}
+
+	for _, endpoint := range validEndpoints {
+		if c.EndpointType == endpoint {
+			validEndpoint = true
+		}
+	}
+
+	if !validEndpoint {
+		return fmt.Errorf("Invalid endpoint type provided")
+	}
+
+	clientOpts := new(clientconfig.ClientOpts)
+
+	// If a cloud entry was given, base AuthOptions on a clouds.yaml file.
+	if c.Cloud != "" {
+		clientOpts.Cloud = c.Cloud
+
+		cloud, err := clientconfig.GetCloudFromYAML(clientOpts)
+		if err != nil {
+			return err
+		}
+
+		if c.Region == "" && cloud.RegionName != "" {
+			c.Region = cloud.RegionName
+		}
+
+		if c.CACertFile == "" && cloud.CACertFile != "" {
+			c.CACertFile = cloud.CACertFile
+		}
+
+		if c.ClientCertFile == "" && cloud.ClientCertFile != "" {
+			c.ClientCertFile = cloud.ClientCertFile
+		}
+
+		if c.ClientKeyFile == "" && cloud.ClientKeyFile != "" {
+			c.ClientKeyFile = cloud.ClientKeyFile
+		}
+
+		if c.Insecure == nil && cloud.Verify != nil {
+			v := (!*cloud.Verify)
+			c.Insecure = &v
+		}
+	} else {
+		authInfo := &clientconfig.AuthInfo{
+			AuthURL:                     c.IdentityEndpoint,
+			DefaultDomain:               c.DefaultDomain,
+			DomainID:                    c.DomainID,
+			DomainName:                  c.DomainName,
+			Password:                    c.Password,
+			ProjectDomainID:             c.ProjectDomainID,
+			ProjectDomainName:           c.ProjectDomainName,
+			ProjectID:                   c.TenantID,
+			ProjectName:                 c.TenantName,
+			Token:                       c.Token,
+			UserDomainID:                c.UserDomainID,
+			UserDomainName:              c.UserDomainName,
+			Username:                    c.Username,
+			UserID:                      c.UserID,
+			ApplicationCredentialID:     c.ApplicationCredentialID,
+			ApplicationCredentialName:   c.ApplicationCredentialName,
+			ApplicationCredentialSecret: c.ApplicationCredentialSecret,
+		}
+		clientOpts.AuthInfo = authInfo
+	}
+
+	ao, err := clientconfig.AuthOptions(clientOpts)
+	if err != nil {
+		return err
+	}
+
+	client, err := openstack.NewClient(ao.IdentityEndpoint)
+	if err != nil {
+		return err
+	}
+
+	config := &tls.Config{}
+	if c.CACertFile != "" {
+		caCert, _, err := pathOrContents(c.CACertFile)
+		if err != nil {
+			return fmt.Errorf("Error reading CA Cert: %s", err)
+		}
+
+		caCertPool := x509.NewCertPool()
+		caCertPool.AppendCertsFromPEM([]byte(caCert))
+		config.RootCAs = caCertPool
+	}
+
+	if c.Insecure == nil {
+		config.InsecureSkipVerify = false
+	} else {
+		config.InsecureSkipVerify = *c.Insecure
+	}
+
+	if c.ClientCertFile != "" && c.ClientKeyFile != "" {
+		clientCert, _, err := pathOrContents(c.ClientCertFile)
+		if err != nil {
+			return fmt.Errorf("Error reading Client Cert: %s", err)
+		}
+		clientKey, _, err := pathOrContents(c.ClientKeyFile)
+		if err != nil {
+			return fmt.Errorf("Error reading Client Key: %s", err)
+		}
+
+		cert, err := tls.X509KeyPair([]byte(clientCert), []byte(clientKey))
+		if err != nil {
+			return err
+		}
+
+		config.Certificates = []tls.Certificate{cert}
+		config.BuildNameToCertificate()
+	}
+
+	// if OS_DEBUG is set, log the requests and responses
+	var osDebug bool
+	if os.Getenv("OS_DEBUG") != "" {
+		osDebug = true
+	}
+
+	transport := &http.Transport{Proxy: http.ProxyFromEnvironment, TLSClientConfig: config}
+	client.HTTPClient = http.Client{
+		Transport: &LogRoundTripper{
+			Rt:         transport,
+			OsDebug:    osDebug,
+			MaxRetries: c.MaxRetries,
+		},
+	}
+
+	// If using Swift Authentication, there's no need to validate authentication normally.
+	if !c.Swauth {
+		err = openstack.Authenticate(client, *ao)
+		if err != nil {
+			return err
+		}
+	}
+
+	if c.MaxRetries < 0 {
+		return fmt.Errorf("max_retries should be a positive value")
+	}
+
+	c.OsClient = client
+
+	return nil
+}
+
+// determineEndpoint is a helper method to determine if the user wants to
+// override an endpoint returned from the catalog.
+func (c *Config) determineEndpoint(client *gophercloud.ServiceClient, service string) *gophercloud.ServiceClient {
+	finalEndpoint := client.ResourceBaseURL()
+
+	if v, ok := c.EndpointOverrides[service]; ok {
+		if endpoint, ok := v.(string); ok && endpoint != "" {
+			finalEndpoint = endpoint
+			client.Endpoint = endpoint
+			client.ResourceBase = ""
+		}
+	}
+
+	log.Printf("[DEBUG] OpenStack Endpoint for %s: %s", service, finalEndpoint)
+
+	return client
+}
+
+// determineRegion is a helper method to determine the region based on
+// the user's settings.
+func (c *Config) determineRegion(region string) string {
+	// If a resource-level region was not specified, and a provider-level region was set,
+	// use the provider-level region.
+	if region == "" && c.Region != "" {
+		region = c.Region
+	}
+
+	log.Printf("[DEBUG] OpenStack Region is: %s", region)
+	return region
+}
+
+// getEndpointType is a helper method to determine the endpoint type
+// requested by the user.
+func (c *Config) getEndpointType() gophercloud.Availability {
+	if c.EndpointType == "internal" || c.EndpointType == "internalURL" {
+		return gophercloud.AvailabilityInternal
+	}
+	if c.EndpointType == "admin" || c.EndpointType == "adminURL" {
+		return gophercloud.AvailabilityAdmin
+	}
+	return gophercloud.AvailabilityPublic
+}
+
+// The following methods assist with the creation of individual Service Clients
+// which interact with the various OpenStack services.
+
+func (c *Config) BlockStorageV1Client(region string) (*gophercloud.ServiceClient, error) {
+	client, err := openstack.NewBlockStorageV1(c.OsClient, gophercloud.EndpointOpts{
+		Region:       c.determineRegion(region),
+		Availability: c.getEndpointType(),
+	})
+
+	if err != nil {
+		return client, err
+	}
+
+	// Check if an endpoint override was specified for the volume service.
+	client = c.determineEndpoint(client, "volume")
+
+	return client, nil
+}
+
+func (c *Config) BlockStorageV2Client(region string) (*gophercloud.ServiceClient, error) {
+	client, err := openstack.NewBlockStorageV2(c.OsClient, gophercloud.EndpointOpts{
+		Region:       c.determineRegion(region),
+		Availability: c.getEndpointType(),
+	})
+
+	if err != nil {
+		return client, err
+	}
+
+	// Check if an endpoint override was specified for the volumev2 service.
+	client = c.determineEndpoint(client, "volumev2")
+
+	return client, nil
+}
+
+func (c *Config) BlockStorageV3Client(region string) (*gophercloud.ServiceClient, error) {
+	client, err := openstack.NewBlockStorageV3(c.OsClient, gophercloud.EndpointOpts{
+		Region:       c.determineRegion(region),
+		Availability: c.getEndpointType(),
+	})
+
+	if err != nil {
+		return client, err
+	}
+
+	// Check if an endpoint override was specified for the volumev3 service.
+	client = c.determineEndpoint(client, "volumev3")
+
+	return client, nil
+}
+
+func (c *Config) ComputeV2Client(region string) (*gophercloud.ServiceClient, error) {
+	client, err := openstack.NewComputeV2(c.OsClient, gophercloud.EndpointOpts{
+		Region:       c.determineRegion(region),
+		Availability: c.getEndpointType(),
+	})
+
+	if err != nil {
+		return client, err
+	}
+
+	// Check if an endpoint override was specified for the compute service.
+	client = c.determineEndpoint(client, "compute")
+
+	return client, nil
+}
+
+func (c *Config) DNSV2Client(region string) (*gophercloud.ServiceClient, error) {
+	client, err := openstack.NewDNSV2(c.OsClient, gophercloud.EndpointOpts{
+		Region:       c.determineRegion(region),
+		Availability: c.getEndpointType(),
+	})
+
+	if err != nil {
+		return client, err
+	}
+
+	// Check if an endpoint override was specified for the dns service.
+	client = c.determineEndpoint(client, "dns")
+
+	return client, nil
+}
+
+func (c *Config) IdentityV3Client(region string) (*gophercloud.ServiceClient, error) {
+	client, err := openstack.NewIdentityV3(c.OsClient, gophercloud.EndpointOpts{
+		Region:       c.determineRegion(region),
+		Availability: c.getEndpointType(),
+	})
+
+	if err != nil {
+		return client, err
+	}
+
+	// Check if an endpoint override was specified for the identity service.
+	client = c.determineEndpoint(client, "identity")
+
+	return client, nil
+}
+
+func (c *Config) ImageV2Client(region string) (*gophercloud.ServiceClient, error) {
+	client, err := openstack.NewImageServiceV2(c.OsClient, gophercloud.EndpointOpts{
+		Region:       c.determineRegion(region),
+		Availability: c.getEndpointType(),
+	})
+
+	if err != nil {
+		return client, err
+	}
+
+	// Check if an endpoint override was specified for the image service.
+	client = c.determineEndpoint(client, "image")
+
+	return client, nil
+}
+
+func (c *Config) NetworkingV2Client(region string) (*gophercloud.ServiceClient, error) {
+	client, err := openstack.NewNetworkV2(c.OsClient, gophercloud.EndpointOpts{
+		Region:       c.determineRegion(region),
+		Availability: c.getEndpointType(),
+	})
+
+	if err != nil {
+		return client, err
+	}
+
+	// Check if an endpoint override was specified for the network service.
+	client = c.determineEndpoint(client, "network")
+
+	return client, nil
+}
+
+func (c *Config) ObjectStorageV1Client(region string) (*gophercloud.ServiceClient, error) {
+	var client *gophercloud.ServiceClient
+	var err error
+
+	// If Swift Authentication is being used, return a swauth client.
+	// Otherwise, use a Keystone-based client.
+	if c.Swauth {
+		client, err = swauth.NewObjectStorageV1(c.OsClient, swauth.AuthOpts{
+			User: c.Username,
+			Key:  c.Password,
+		})
+	} else {
+		client, err = openstack.NewObjectStorageV1(c.OsClient, gophercloud.EndpointOpts{
+			Region:       c.determineRegion(region),
+			Availability: c.getEndpointType(),
+		})
+	}
+
+	if err != nil {
+		return client, err
+	}
+
+	// Check if an endpoint override was specified for the object-store service.
+	client = c.determineEndpoint(client, "object-store")
+
+	return client, nil
+}
+
+func (c *Config) LoadBalancerV2Client(region string) (*gophercloud.ServiceClient, error) {
+	client, err := openstack.NewLoadBalancerV2(c.OsClient, gophercloud.EndpointOpts{
+		Region:       c.determineRegion(region),
+		Availability: c.getEndpointType(),
+	})
+
+	if err != nil {
+		return client, err
+	}
+
+	// Check if an endpoint override was specified for the octavia service.
+	client = c.determineEndpoint(client, "octavia")
+
+	return client, nil
+}
+
+func (c *Config) DatabaseV1Client(region string) (*gophercloud.ServiceClient, error) {
+	client, err := openstack.NewDBV1(c.OsClient, gophercloud.EndpointOpts{
+		Region:       c.determineRegion(region),
+		Availability: c.getEndpointType(),
+	})
+
+	if err != nil {
+		return client, err
+	}
+
+	// Check if an endpoint override was specified for the database service.
+	client = c.determineEndpoint(client, "database")
+
+	return client, nil
+}
+
+func (c *Config) ContainerInfraV1Client(region string) (*gophercloud.ServiceClient, error) {
+	client, err := openstack.NewContainerInfraV1(c.OsClient, gophercloud.EndpointOpts{
+		Region:       c.determineRegion(region),
+		Availability: c.getEndpointType(),
+	})
+
+	if err != nil {
+		return client, err
+	}
+
+	// Check if an endpoint override was specified for the container-infra service.
+	client = c.determineEndpoint(client, "container-infra")
+
+	return client, nil
+}
+
+func (c *Config) SharedfilesystemV2Client(region string) (*gophercloud.ServiceClient, error) {
+	client, err := openstack.NewSharedFileSystemV2(c.OsClient, gophercloud.EndpointOpts{
+		Region:       c.determineRegion(region),
+		Availability: c.getEndpointType(),
+	})
+
+	if err != nil {
+		return client, err
+	}
+
+	// Check if an endpoint override was specified for the sharev2 service.
+	client = c.determineEndpoint(client, "sharev2")
+
+	return client, nil
+}

--- a/terraform/auth/doc.go
+++ b/terraform/auth/doc.go
@@ -1,0 +1,11 @@
+/*
+Package auth provides common functionality for Terraform and Terraform
+plugins to authenticate with OpenStack.
+
+It includes a wide array of features, such as flexible authentication,
+debugging, client creation, endpoint customization and more.
+
+While this package is specific to Terraform, it can be used for any kind
+of Terraform feature: core, backend, and plugins.
+*/
+package auth

--- a/terraform/auth/types.go
+++ b/terraform/auth/types.go
@@ -1,0 +1,160 @@
+package auth
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"strings"
+)
+
+// LogRoundTripper satisfies the http.RoundTripper interface and is used to
+// customize the default http client RoundTripper to allow for logging.
+type LogRoundTripper struct {
+	Rt         http.RoundTripper
+	OsDebug    bool
+	MaxRetries int
+}
+
+// RoundTrip performs a round-trip HTTP request and logs relevant information about it.
+func (lrt *LogRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
+	defer func() {
+		if request.Body != nil {
+			request.Body.Close()
+		}
+	}()
+
+	// for future reference, this is how to access the Transport struct:
+	//tlsconfig := lrt.Rt.(*http.Transport).TLSClientConfig
+
+	var err error
+
+	if lrt.OsDebug {
+		log.Printf("[DEBUG] OpenStack Request URL: %s %s", request.Method, request.URL)
+		log.Printf("[DEBUG] OpenStack Request Headers:\n%s", FormatHeaders(request.Header, "\n"))
+
+		if request.Body != nil {
+			request.Body, err = lrt.logRequest(request.Body, request.Header.Get("Content-Type"))
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	response, err := lrt.Rt.RoundTrip(request)
+
+	// If the first request didn't return a response, retry up to `max_retries`.
+	retry := 1
+	for response == nil {
+		if retry > lrt.MaxRetries {
+			if lrt.OsDebug {
+				log.Printf("[DEBUG] OpenStack connection error, retries exhausted. Aborting")
+			}
+			err = fmt.Errorf("OpenStack connection error, retries exhausted. Aborting. Last error was: %s", err)
+			return nil, err
+		}
+
+		if lrt.OsDebug {
+			log.Printf("[DEBUG] OpenStack connection error, retry number %d: %s", retry, err)
+		}
+		response, err = lrt.Rt.RoundTrip(request)
+		retry += 1
+	}
+
+	if lrt.OsDebug {
+		log.Printf("[DEBUG] OpenStack Response Code: %d", response.StatusCode)
+		log.Printf("[DEBUG] OpenStack Response Headers:\n%s", FormatHeaders(response.Header, "\n"))
+
+		response.Body, err = lrt.logResponse(response.Body, response.Header.Get("Content-Type"))
+	}
+
+	return response, err
+}
+
+// logRequest will log the HTTP Request details.
+// If the body is JSON, it will attempt to be pretty-formatted.
+func (lrt *LogRoundTripper) logRequest(original io.ReadCloser, contentType string) (io.ReadCloser, error) {
+	defer original.Close()
+
+	var bs bytes.Buffer
+	_, err := io.Copy(&bs, original)
+	if err != nil {
+		return nil, err
+	}
+
+	// Handle request contentType
+	if strings.HasPrefix(contentType, "application/json") {
+		debugInfo := lrt.formatJSON(bs.Bytes())
+		log.Printf("[DEBUG] OpenStack Request Body: %s", debugInfo)
+	}
+
+	return ioutil.NopCloser(strings.NewReader(bs.String())), nil
+}
+
+// logResponse will log the HTTP Response details.
+// If the body is JSON, it will attempt to be pretty-formatted.
+func (lrt *LogRoundTripper) logResponse(original io.ReadCloser, contentType string) (io.ReadCloser, error) {
+	if strings.HasPrefix(contentType, "application/json") {
+		var bs bytes.Buffer
+		defer original.Close()
+		_, err := io.Copy(&bs, original)
+		if err != nil {
+			return nil, err
+		}
+		debugInfo := lrt.formatJSON(bs.Bytes())
+		if debugInfo != "" {
+			log.Printf("[DEBUG] OpenStack Response Body: %s", debugInfo)
+		}
+		return ioutil.NopCloser(strings.NewReader(bs.String())), nil
+	}
+
+	log.Printf("[DEBUG] Not logging because OpenStack response body isn't JSON")
+	return original, nil
+}
+
+// formatJSON will try to pretty-format a JSON body.
+// It will also mask known fields which contain sensitive information.
+func (lrt *LogRoundTripper) formatJSON(raw []byte) string {
+	var data map[string]interface{}
+
+	err := json.Unmarshal(raw, &data)
+	if err != nil {
+		log.Printf("[DEBUG] Unable to parse OpenStack JSON: %s", err)
+		return string(raw)
+	}
+
+	// Mask known password fields
+	if v, ok := data["auth"].(map[string]interface{}); ok {
+		if v, ok := v["identity"].(map[string]interface{}); ok {
+			if v, ok := v["password"].(map[string]interface{}); ok {
+				if v, ok := v["user"].(map[string]interface{}); ok {
+					v["password"] = "***"
+				}
+			}
+			if v, ok := v["application_credential"].(map[string]interface{}); ok {
+				v["secret"] = "***"
+			}
+			if v, ok := v["token"].(map[string]interface{}); ok {
+				v["id"] = "***"
+			}
+		}
+	}
+
+	// Ignore the catalog
+	if v, ok := data["token"].(map[string]interface{}); ok {
+		if _, ok := v["catalog"]; ok {
+			return ""
+		}
+	}
+
+	pretty, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		log.Printf("[DEBUG] Unable to re-marshal OpenStack JSON: %s", err)
+		return string(raw)
+	}
+
+	return string(pretty)
+}

--- a/terraform/auth/util.go
+++ b/terraform/auth/util.go
@@ -1,0 +1,78 @@
+package auth
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/mitchellh/go-homedir"
+)
+
+// List of headers that need to be redacted
+var REDACT_HEADERS = []string{"x-auth-token", "x-auth-key", "x-service-token",
+	"x-storage-token", "x-account-meta-temp-url-key", "x-account-meta-temp-url-key-2",
+	"x-container-meta-temp-url-key", "x-container-meta-temp-url-key-2", "set-cookie",
+	"x-subject-token"}
+
+// RedactHeaders processes a headers object, returning a redacted list
+func RedactHeaders(headers http.Header) (processedHeaders []string) {
+	for name, header := range headers {
+		for _, v := range header {
+			if sliceContainsStr(REDACT_HEADERS, name) {
+				processedHeaders = append(processedHeaders, fmt.Sprintf("%v: %v", name, "***"))
+			} else {
+				processedHeaders = append(processedHeaders, fmt.Sprintf("%v: %v", name, v))
+			}
+		}
+	}
+	return
+}
+
+// FormatHeaders processes a headers object plus a deliminator, returning a string
+func FormatHeaders(headers http.Header, seperator string) string {
+	redactedHeaders := RedactHeaders(headers)
+	sort.Strings(redactedHeaders)
+
+	return strings.Join(redactedHeaders, seperator)
+}
+
+func sliceContainsStr(haystack []string, needle string) bool {
+	for _, v := range haystack {
+		if v == needle {
+			return true
+		}
+
+	}
+	return false
+}
+
+// This is copied directly from Terraform in order to remove a single legacy
+// vendor dependency.
+// https://github.com/hashicorp/terraform/tree/master/helper/pathorcontents
+func pathOrContents(poc string) (string, bool, error) {
+	if len(poc) == 0 {
+		return poc, false, nil
+	}
+
+	path := poc
+	if path[0] == '~' {
+		var err error
+		path, err = homedir.Expand(path)
+		if err != nil {
+			return path, true, err
+		}
+	}
+
+	if _, err := os.Stat(path); err == nil {
+		contents, err := ioutil.ReadFile(path)
+		if err != nil {
+			return string(contents), true, err
+		}
+		return string(contents), true, nil
+	}
+
+	return poc, false, nil
+}


### PR DESCRIPTION
This commit adds initial support for Terraform authentication.

The primary reason for this feature is to decouple the Terraform
Swift Remote State backend support from the Terraform OpenStack
Provider, thus reducing Terraform core's dependency of the OpenStack
Provider.

However, this package can also be used in any other situation where
a user wants to make an OpenStack-based Terraform provider/tool.

For https://github.com/terraform-providers/terraform-provider-openstack/issues/686