### PR TITLE
Gnocchi: rename MetricD to Metricd

### DIFF
--- a/gnocchi/metric/v1/status/results.go
+++ b/gnocchi/metric/v1/status/results.go
@@ -21,15 +21,15 @@ type GetResult struct {
 
 // Status represents a Gnocchi status of measurements processing.
 type Status struct {
-	// MetricD represents all running Gnocchi metricd daemons.
-	MetricD MetricD `json:"metricd"`
+	// Metricd represents all running Gnocchi metricd daemons.
+	Metricd Metricd `json:"metricd"`
 
 	// Storage contains Gnocchi storage data of measures backlog.
 	Storage Storage `json:"storage"`
 }
 
-// MetricD represents all running Gnocchi metricd daemons.
-type MetricD struct {
+// Metricd represents all running Gnocchi metricd daemons.
+type Metricd struct {
 	// Processors represents a list of running Gnocchi metricd processors.
 	Processors []string `json:"processors"`
 }

--- a/gnocchi/metric/v1/status/testing/fixtures.go
+++ b/gnocchi/metric/v1/status/testing/fixtures.go
@@ -53,7 +53,7 @@ const StatusGetWithoutDetailsResult = `
 // GetStatusWithDetailsExpected represents an expected response with all status
 // attributes from a get request.
 var GetStatusWithDetailsExpected = status.Status{
-	MetricD: status.MetricD{
+	Metricd: status.Metricd{
 		Processors: []string{
 			"node-stat1.27.ce1da3c9-6c8c-490d-b256-3ba1e2bceb7b",
 			"node-stat1.10.9d9a99b2-f0ac-496b-36f3-115b84304a84",
@@ -79,7 +79,7 @@ var GetStatusWithDetailsExpected = status.Status{
 // GetStatusWithoutDetailsExpected represents an expected response without details
 // from a get request.
 var GetStatusWithoutDetailsExpected = status.Status{
-	MetricD: status.MetricD{
+	Metricd: status.Metricd{
 		Processors: []string{
 			"node-stat1.27.ce1da3c9-6c8c-490d-b256-3ba1e2bceb7b",
 			"node-stat1.10.9d9a99b2-f0ac-496b-36f3-115b84304a84",

--- a/gnocchi/metric/v1/status/testing/requests_test.go
+++ b/gnocchi/metric/v1/status/testing/requests_test.go
@@ -32,7 +32,7 @@ func TestGetWithDetails(t *testing.T) {
 
 	s, err := status.Get(fake.ServiceClient(), getOpts).Extract()
 	th.AssertNoErr(t, err)
-	th.AssertDeepEquals(t, s.MetricD, GetStatusWithDetailsExpected.MetricD)
+	th.AssertDeepEquals(t, s.Metricd, GetStatusWithDetailsExpected.Metricd)
 	th.AssertDeepEquals(t, s.Storage, GetStatusWithDetailsExpected.Storage)
 }
 
@@ -58,6 +58,6 @@ func TestGetWithoutDetails(t *testing.T) {
 
 	s, err := status.Get(fake.ServiceClient(), getOpts).Extract()
 	th.AssertNoErr(t, err)
-	th.AssertDeepEquals(t, s.MetricD, GetStatusWithoutDetailsExpected.MetricD)
+	th.AssertDeepEquals(t, s.Metricd, GetStatusWithoutDetailsExpected.Metricd)
 	th.AssertDeepEquals(t, s.Storage, GetStatusWithoutDetailsExpected.Storage)
 }


### PR DESCRIPTION
Rename MetricD to Metricd in status package.
Update tests and fixtures.

Documentation reference:
https://gnocchi.xyz/operating.html#metricd

For #85 