### PR TITLE
Documentation fix-up

### DIFF
--- a/openstack/clientconfig/doc.go
+++ b/openstack/clientconfig/doc.go
@@ -7,7 +7,7 @@ See https://docs.openstack.org/os-client-config/latest for details.
 Example to Create a Provider Client From clouds.yaml
 
 	opts := &clientconfig.ClientOpts{
-		Name: "hawaii",
+		Cloud: "hawaii",
 	}
 
 	pClient, err := clientconfig.AuthenticatedClient(opts)


### PR DESCRIPTION
Recently tried following this, Name is not valid but Cloud is.