### PR TITLE
Add "omitempty" tag to marshal clouds right

### DIFF
--- a/openstack/clientconfig/results.go
+++ b/openstack/clientconfig/results.go
@@ -16,112 +16,112 @@ type Clouds struct {
 
 // Cloud represents an entry in a clouds.yaml/public-clouds.yaml/secure.yaml file.
 type Cloud struct {
-	Cloud      string        `yaml:"cloud" json:"cloud"`
-	Profile    string        `yaml:"profile" json:"profile"`
-	AuthInfo   *AuthInfo     `yaml:"auth" json:"auth"`
-	AuthType   AuthType      `yaml:"auth_type" json:"auth_type"`
-	RegionName string        `yaml:"region_name" json:"region_name"`
-	Regions    []interface{} `yaml:"regions" json:"regions"`
+	Cloud      string        `yaml:"cloud,omitempty" json:"cloud,omitempty"`
+	Profile    string        `yaml:"profile,omitempty" json:"profile,omitempty"`
+	AuthInfo   *AuthInfo     `yaml:"auth,omitempty" json:"auth,omitempty"`
+	AuthType   AuthType      `yaml:"auth_type,omitempty" json:"auth_type,omitempty"`
+	RegionName string        `yaml:"region_name,omitempty" json:"region_name,omitempty"`
+	Regions    []interface{} `yaml:"regions,omitempty" json:"regions,omitempty"`
 
 	// EndpointType and Interface both specify whether to use the public, internal,
 	// or admin interface of a service. They should be considered synonymous, but
 	// EndpointType will take precedence when both are specified.
-	EndpointType string `yaml:"endpoint_type" json:"endpoint_type"`
-	Interface    string `yaml:"interface" json:"interface"`
+	EndpointType string `yaml:"endpoint_type,omitempty" json:"endpoint_type,omitempty"`
+	Interface    string `yaml:"interface,omitempty" json:"interface,omitempty"`
 
 	// API Version overrides.
-	IdentityAPIVersion string `yaml:"identity_api_version" json:"identity_api_version"`
-	VolumeAPIVersion   string `yaml:"volume_api_version" json:"volume_api_version"`
+	IdentityAPIVersion string `yaml:"identity_api_version,omitempty" json:"identity_api_version,omitempty"`
+	VolumeAPIVersion   string `yaml:"volume_api_version,omitempty" json:"volume_api_version,omitempty"`
 
 	// Verify whether or not SSL API requests should be verified.
-	Verify *bool `yaml:"verify" json:"verify"`
+	Verify *bool `yaml:"verify,omitempty" json:"verify,omitempty"`
 
 	// CACertFile a path to a CA Cert bundle that can be used as part of
 	// verifying SSL API requests.
-	CACertFile string `yaml:"cacert" json:"cacert"`
+	CACertFile string `yaml:"cacert,omitempty" json:"cacert,omitempty"`
 
 	// ClientCertFile a path to a client certificate to use as part of the SSL
 	// transaction.
-	ClientCertFile string `yaml:"cert" json:"cert"`
+	ClientCertFile string `yaml:"cert,omitempty" json:"cert,omitempty"`
 
 	// ClientKeyFile a path to a client key to use as part of the SSL
 	// transaction.
-	ClientKeyFile string `yaml:"key" json:"key"`
+	ClientKeyFile string `yaml:"key,omitempty" json:"key,omitempty"`
 }
 
 // AuthInfo represents the auth section of a cloud entry or
 // auth options entered explicitly in ClientOpts.
 type AuthInfo struct {
 	// AuthURL is the keystone/identity endpoint URL.
-	AuthURL string `yaml:"auth_url" json:"auth_url"`
+	AuthURL string `yaml:"auth_url,omitempty" json:"auth_url,omitempty"`
 
 	// Token is a pre-generated authentication token.
-	Token string `yaml:"token" json:"token"`
+	Token string `yaml:"token,omitempty" json:"token,omitempty"`
 
 	// Username is the username of the user.
-	Username string `yaml:"username" json:"username"`
+	Username string `yaml:"username,omitempty" json:"username,omitempty"`
 
 	// UserID is the unique ID of a user.
-	UserID string `yaml:"user_id" json:"user_id"`
+	UserID string `yaml:"user_id,omitempty" json:"user_id,omitempty"`
 
 	// Password is the password of the user.
-	Password string `yaml:"password" json:"password"`
+	Password string `yaml:"password,omitempty" json:"password,omitempty"`
 
 	// Application Credential ID to login with.
-	ApplicationCredentialID string `yaml:"application_credential_id" json:"application_credential_id"`
+	ApplicationCredentialID string `yaml:"application_credential_id,omitempty" json:"application_credential_id,omitempty"`
 
 	// Application Credential name to login with.
-	ApplicationCredentialName string `yaml:"application_credential_name" json:"application_credential_name"`
+	ApplicationCredentialName string `yaml:"application_credential_name,omitempty" json:"application_credential_name,omitempty"`
 
 	// Application Credential secret to login with.
-	ApplicationCredentialSecret string `yaml:"application_credential_secret" json:"application_credential_secret"`
+	ApplicationCredentialSecret string `yaml:"application_credential_secret,omitempty" json:"application_credential_secret,omitempty"`
 
 	// ProjectName is the common/human-readable name of a project.
 	// Users can be scoped to a project.
 	// ProjectName on its own is not enough to ensure a unique scope. It must
 	// also be combined with either a ProjectDomainName or ProjectDomainID.
 	// ProjectName cannot be combined with ProjectID in a scope.
-	ProjectName string `yaml:"project_name" json:"project_name"`
+	ProjectName string `yaml:"project_name,omitempty" json:"project_name,omitempty"`
 
 	// ProjectID is the unique ID of a project.
 	// It can be used to scope a user to a specific project.
-	ProjectID string `yaml:"project_id" json:"project_id"`
+	ProjectID string `yaml:"project_id,omitempty" json:"project_id,omitempty"`
 
 	// UserDomainName is the name of the domain where a user resides.
 	// It is used to identify the source domain of a user.
-	UserDomainName string `yaml:"user_domain_name" json:"user_domain_name"`
+	UserDomainName string `yaml:"user_domain_name,omitempty" json:"user_domain_name,omitempty"`
 
 	// UserDomainID is the unique ID of the domain where a user resides.
 	// It is used to identify the source domain of a user.
-	UserDomainID string `yaml:"user_domain_id" json:"user_domain_id"`
+	UserDomainID string `yaml:"user_domain_id,omitempty" json:"user_domain_id,omitempty"`
 
 	// ProjectDomainName is the name of the domain where a project resides.
 	// It is used to identify the source domain of a project.
 	// ProjectDomainName can be used in addition to a ProjectName when scoping
 	// a user to a specific project.
-	ProjectDomainName string `yaml:"project_domain_name" json:"project_domain_name"`
+	ProjectDomainName string `yaml:"project_domain_name,omitempty" json:"project_domain_name,omitempty"`
 
 	// ProjectDomainID is the name of the domain where a project resides.
 	// It is used to identify the source domain of a project.
 	// ProjectDomainID can be used in addition to a ProjectName when scoping
 	// a user to a specific project.
-	ProjectDomainID string `yaml:"project_domain_id" json:"project_domain_id"`
+	ProjectDomainID string `yaml:"project_domain_id,omitempty" json:"project_domain_id,omitempty"`
 
 	// DomainName is the name of a domain which can be used to identify the
 	// source domain of either a user or a project.
 	// If UserDomainName and ProjectDomainName are not specified, then DomainName
 	// is used as a default choice.
 	// It can also be used be used to specify a domain-only scope.
-	DomainName string `yaml:"domain_name" json:"domain_name"`
+	DomainName string `yaml:"domain_name,omitempty" json:"domain_name,omitempty"`
 
 	// DomainID is the unique ID of a domain which can be used to identify the
 	// source domain of eitehr a user or a project.
 	// If UserDomainID and ProjectDomainID are not specified, then DomainID is
 	// used as a default choice.
 	// It can also be used be used to specify a domain-only scope.
-	DomainID string `yaml:"domain_id" json:"domain_id"`
+	DomainID string `yaml:"domain_id,omitempty" json:"domain_id,omitempty"`
 
 	// DefaultDomain is the domain ID to fall back on if no other domain has
 	// been specified and a domain is required for scope.
-	DefaultDomain string `yaml:"default_domain" json:"default_domain"`
+	DefaultDomain string `yaml:"default_domain,omitempty" json:"default_domain,omitempty"`
 }

--- a/openstack/clientconfig/testing/results_test.go
+++ b/openstack/clientconfig/testing/results_test.go
@@ -1,0 +1,54 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/gophercloud/utils/openstack/clientconfig"
+
+	th "github.com/gophercloud/gophercloud/testhelper"
+	yaml "gopkg.in/yaml.v2"
+)
+
+var VirginiaExpected = `clouds:
+  virginia:
+    auth:
+      auth_url: https://va.example.com:5000/v3
+      application_credential_id: app-cred-id
+      application_credential_secret: secret
+    auth_type: v3applicationcredential
+    region_name: VA
+    verify: true
+`
+
+var HawaiiExpected = `clouds:
+  hawaii:
+    auth:
+      auth_url: https://hi.example.com:5000/v3
+      username: jdoe
+      password: password
+      project_name: Some Project
+      domain_name: default
+    region_name: HNL
+    verify: true
+`
+
+func TestMarshallCloudToYaml(t *testing.T) {
+	clouds := make(map[string]map[string]*clientconfig.Cloud)
+	clouds["clouds"] = map[string]*clientconfig.Cloud{
+		"virginia": &VirginiaCloudYAML,
+	}
+
+	marshalled, err := yaml.Marshal(clouds)
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, VirginiaExpected, string(marshalled))
+
+	clouds["clouds"] = map[string]*clientconfig.Cloud{
+		"hawaii": &HawaiiCloudYAML,
+	}
+
+	marshalled, err = yaml.Marshal(clouds)
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, HawaiiExpected, string(marshalled))
+}


### PR DESCRIPTION
Currently when we try to marshal Clouds, it produces a lot of fields with empty strings, which is not correct.

This patch adds "omitempty" tag to all Cloud fields to allow correct marshalling of the structure.