### PR TITLE
Log json-patch content type

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -236,7 +236,7 @@ func (rt *RoundTripper) logRequest(original io.ReadCloser, contentType string) (
 // logResponse will log the HTTP Response details.
 // If the body is JSON, it will attempt to be pretty-formatted.
 func (rt *RoundTripper) logResponse(original io.ReadCloser, contentType string) (io.ReadCloser, error) {
-	if strings.HasPrefix(contentType, "application/json") {
+	if strings.HasPrefix(contentType, "application/json") || (strings.HasPrefix(contentType, "application/") && strings.HasSuffix(contentType, "-json-patch")) {
 		var bs bytes.Buffer
 		defer original.Close()
 


### PR DESCRIPTION
Allow JSON patch logging in debug.

For example these requests: https://docs.openstack.org/api-ref/image/v2/?expanded=update-image-detail#update-image