### PR TITLE
Log json patch request instead of response

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -211,7 +211,7 @@ func (rt *RoundTripper) RoundTrip(request *http.Request) (*http.Response, error)
 // If the body is JSON, it will attempt to be pretty-formatted.
 func (rt *RoundTripper) logRequest(original io.ReadCloser, contentType string) (io.ReadCloser, error) {
 	// Handle request contentType
-	if strings.HasPrefix(contentType, "application/json") {
+	if strings.HasPrefix(contentType, "application/json") || (strings.HasPrefix(contentType, "application/") && strings.HasSuffix(contentType, "-json-patch")) {
 		var bs bytes.Buffer
 		defer original.Close()
 
@@ -236,7 +236,7 @@ func (rt *RoundTripper) logRequest(original io.ReadCloser, contentType string) (
 // logResponse will log the HTTP Response details.
 // If the body is JSON, it will attempt to be pretty-formatted.
 func (rt *RoundTripper) logResponse(original io.ReadCloser, contentType string) (io.ReadCloser, error) {
-	if strings.HasPrefix(contentType, "application/json") || (strings.HasPrefix(contentType, "application/") && strings.HasSuffix(contentType, "-json-patch")) {
+	if strings.HasPrefix(contentType, "application/json") {
 		var bs bytes.Buffer
 		defer original.Close()
 


### PR DESCRIPTION
Followup for #109. I had to put a condition into a `logRequest` instead of `logResponse`.