### PR TITLE
terraform: export more methods, deduplicate client funcs

### DIFF
--- a/terraform/auth/config.go
+++ b/terraform/auth/config.go
@@ -238,7 +238,7 @@ func (c *Config) LoadAndValidate() error {
 	return nil
 }
 
-func (c *Config) authenticate() error {
+func (c *Config) Authenticate() error {
 	if !c.DelayedAuth {
 		return nil
 	}
@@ -263,7 +263,7 @@ func (c *Config) authenticate() error {
 
 // determineEndpoint is a helper method to determine if the user wants to
 // override an endpoint returned from the catalog.
-func (c *Config) determineEndpoint(client *gophercloud.ServiceClient, service string) *gophercloud.ServiceClient {
+func (c *Config) DetermineEndpoint(client *gophercloud.ServiceClient, service string) *gophercloud.ServiceClient {
 	finalEndpoint := client.ResourceBaseURL()
 
 	if v, ok := c.EndpointOverrides[service]; ok {
@@ -281,7 +281,7 @@ func (c *Config) determineEndpoint(client *gophercloud.ServiceClient, service st
 
 // determineRegion is a helper method to determine the region based on
 // the user's settings.
-func (c *Config) determineRegion(region string) string {
+func (c *Config) DetermineRegion(region string) string {
 	// If a resource-level region was not specified, and a provider-level region was set,
 	// use the provider-level region.
 	if region == "" && c.Region != "" {
@@ -295,13 +295,15 @@ func (c *Config) determineRegion(region string) string {
 // The following methods assist with the creation of individual Service Clients
 // which interact with the various OpenStack services.
 
-func (c *Config) BlockStorageV1Client(region string) (*gophercloud.ServiceClient, error) {
-	if err := c.authenticate(); err != nil {
+type commonCommonServiceClientInitFunc func(*gophercloud.ProviderClient, gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error)
+
+func (c *Config) CommonServiceClientInit(newClient commonCommonServiceClientInitFunc, region, service string) (*gophercloud.ServiceClient, error) {
+	if err := c.Authenticate(); err != nil {
 		return nil, err
 	}
 
-	client, err := openstack.NewBlockStorageV1(c.OsClient, gophercloud.EndpointOpts{
-		Region:       c.determineRegion(region),
+	client, err := newClient(c.OsClient, gophercloud.EndpointOpts{
+		Region:       c.DetermineRegion(region),
 		Availability: clientconfig.GetEndpointType(c.EndpointType),
 	})
 
@@ -310,138 +312,46 @@ func (c *Config) BlockStorageV1Client(region string) (*gophercloud.ServiceClient
 	}
 
 	// Check if an endpoint override was specified for the volume service.
-	client = c.determineEndpoint(client, "volume")
+	client = c.DetermineEndpoint(client, service)
 
 	return client, nil
+}
+
+func (c *Config) BlockStorageV1Client(region string) (*gophercloud.ServiceClient, error) {
+	return c.CommonServiceClientInit(openstack.NewBlockStorageV1, region, "volume")
 }
 
 func (c *Config) BlockStorageV2Client(region string) (*gophercloud.ServiceClient, error) {
-	if err := c.authenticate(); err != nil {
-		return nil, err
-	}
-
-	client, err := openstack.NewBlockStorageV2(c.OsClient, gophercloud.EndpointOpts{
-		Region:       c.determineRegion(region),
-		Availability: clientconfig.GetEndpointType(c.EndpointType),
-	})
-
-	if err != nil {
-		return client, err
-	}
-
-	// Check if an endpoint override was specified for the volumev2 service.
-	client = c.determineEndpoint(client, "volumev2")
-
-	return client, nil
+	return c.CommonServiceClientInit(openstack.NewBlockStorageV2, region, "volumev2")
 }
 
 func (c *Config) BlockStorageV3Client(region string) (*gophercloud.ServiceClient, error) {
-	if err := c.authenticate(); err != nil {
-		return nil, err
-	}
-
-	client, err := openstack.NewBlockStorageV3(c.OsClient, gophercloud.EndpointOpts{
-		Region:       c.determineRegion(region),
-		Availability: clientconfig.GetEndpointType(c.EndpointType),
-	})
-
-	if err != nil {
-		return client, err
-	}
-
-	// Check if an endpoint override was specified for the volumev3 service.
-	client = c.determineEndpoint(client, "volumev3")
-
-	return client, nil
+	return c.CommonServiceClientInit(openstack.NewBlockStorageV3, region, "volumev3")
 }
 
 func (c *Config) ComputeV2Client(region string) (*gophercloud.ServiceClient, error) {
-	if err := c.authenticate(); err != nil {
-		return nil, err
-	}
-
-	client, err := openstack.NewComputeV2(c.OsClient, gophercloud.EndpointOpts{
-		Region:       c.determineRegion(region),
-		Availability: clientconfig.GetEndpointType(c.EndpointType),
-	})
-
-	if err != nil {
-		return client, err
-	}
-
-	// Check if an endpoint override was specified for the compute service.
-	client = c.determineEndpoint(client, "compute")
-
-	return client, nil
+	return c.CommonServiceClientInit(openstack.NewComputeV2, region, "compute")
 }
 
 func (c *Config) DNSV2Client(region string) (*gophercloud.ServiceClient, error) {
-	if err := c.authenticate(); err != nil {
-		return nil, err
-	}
-
-	client, err := openstack.NewDNSV2(c.OsClient, gophercloud.EndpointOpts{
-		Region:       c.determineRegion(region),
-		Availability: clientconfig.GetEndpointType(c.EndpointType),
-	})
-
-	if err != nil {
-		return client, err
-	}
-
-	// Check if an endpoint override was specified for the dns service.
-	client = c.determineEndpoint(client, "dns")
-
-	return client, nil
+	return c.CommonServiceClientInit(openstack.NewDNSV2, region, "dns")
 }
 
 func (c *Config) IdentityV3Client(region string) (*gophercloud.ServiceClient, error) {
-	if err := c.authenticate(); err != nil {
-		return nil, err
-	}
-
-	client, err := openstack.NewIdentityV3(c.OsClient, gophercloud.EndpointOpts{
-		Region:       c.determineRegion(region),
-		Availability: clientconfig.GetEndpointType(c.EndpointType),
-	})
-
-	if err != nil {
-		return client, err
-	}
-
-	// Check if an endpoint override was specified for the identity service.
-	client = c.determineEndpoint(client, "identity")
-
-	return client, nil
+	return c.CommonServiceClientInit(openstack.NewIdentityV3, region, "identity")
 }
 
 func (c *Config) ImageV2Client(region string) (*gophercloud.ServiceClient, error) {
-	if err := c.authenticate(); err != nil {
-		return nil, err
-	}
-
-	client, err := openstack.NewImageServiceV2(c.OsClient, gophercloud.EndpointOpts{
-		Region:       c.determineRegion(region),
-		Availability: clientconfig.GetEndpointType(c.EndpointType),
-	})
-
-	if err != nil {
-		return client, err
-	}
-
-	// Check if an endpoint override was specified for the image service.
-	client = c.determineEndpoint(client, "image")
-
-	return client, nil
+	return c.CommonServiceClientInit(openstack.NewImageServiceV2, region, "image")
 }
 
 func (c *Config) MessagingV2Client(region string) (*gophercloud.ServiceClient, error) {
-	if err := c.authenticate(); err != nil {
+	if err := c.Authenticate(); err != nil {
 		return nil, err
 	}
 
 	client, err := openstack.NewMessagingV2(c.OsClient, "", gophercloud.EndpointOpts{
-		Region:       c.determineRegion(region),
+		Region:       c.DetermineRegion(region),
 		Availability: clientconfig.GetEndpointType(c.EndpointType),
 	})
 
@@ -450,29 +360,13 @@ func (c *Config) MessagingV2Client(region string) (*gophercloud.ServiceClient, e
 	}
 
 	// Check if an endpoint override was specified for the messaging service.
-	client = c.determineEndpoint(client, "message")
+	client = c.DetermineEndpoint(client, "message")
 
 	return client, nil
 }
 
 func (c *Config) NetworkingV2Client(region string) (*gophercloud.ServiceClient, error) {
-	if err := c.authenticate(); err != nil {
-		return nil, err
-	}
-
-	client, err := openstack.NewNetworkV2(c.OsClient, gophercloud.EndpointOpts{
-		Region:       c.determineRegion(region),
-		Availability: clientconfig.GetEndpointType(c.EndpointType),
-	})
-
-	if err != nil {
-		return client, err
-	}
-
-	// Check if an endpoint override was specified for the network service.
-	client = c.determineEndpoint(client, "network")
-
-	return client, nil
+	return c.CommonServiceClientInit(openstack.NewNetworkV2, region, "network")
 }
 
 func (c *Config) ObjectStorageV1Client(region string) (*gophercloud.ServiceClient, error) {
@@ -510,12 +404,12 @@ func (c *Config) ObjectStorageV1Client(region string) (*gophercloud.ServiceClien
 			client = c.swClient
 		}
 	} else {
-		if err := c.authenticate(); err != nil {
+		if err := c.Authenticate(); err != nil {
 			return nil, err
 		}
 
 		client, err = openstack.NewObjectStorageV1(c.OsClient, gophercloud.EndpointOpts{
-			Region:       c.determineRegion(region),
+			Region:       c.DetermineRegion(region),
 			Availability: clientconfig.GetEndpointType(c.EndpointType),
 		})
 
@@ -525,127 +419,31 @@ func (c *Config) ObjectStorageV1Client(region string) (*gophercloud.ServiceClien
 	}
 
 	// Check if an endpoint override was specified for the object-store service.
-	client = c.determineEndpoint(client, "object-store")
+	client = c.DetermineEndpoint(client, "object-store")
 
 	return client, nil
 }
 
 func (c *Config) OrchestrationV1Client(region string) (*gophercloud.ServiceClient, error) {
-	if err := c.authenticate(); err != nil {
-		return nil, err
-	}
-
-	client, err := openstack.NewOrchestrationV1(c.OsClient, gophercloud.EndpointOpts{
-		Region:       c.determineRegion(region),
-		Availability: clientconfig.GetEndpointType(c.EndpointType),
-	})
-
-	if err != nil {
-		return client, err
-	}
-
-	// Check if an endpoint override was specified for the orchestration service.
-	client = c.determineEndpoint(client, "orchestration")
-
-	return client, nil
+	return c.CommonServiceClientInit(openstack.NewOrchestrationV1, region, "orchestration")
 }
 
 func (c *Config) LoadBalancerV2Client(region string) (*gophercloud.ServiceClient, error) {
-	if err := c.authenticate(); err != nil {
-		return nil, err
-	}
-
-	client, err := openstack.NewLoadBalancerV2(c.OsClient, gophercloud.EndpointOpts{
-		Region:       c.determineRegion(region),
-		Availability: clientconfig.GetEndpointType(c.EndpointType),
-	})
-
-	if err != nil {
-		return client, err
-	}
-
-	// Check if an endpoint override was specified for the octavia service.
-	client = c.determineEndpoint(client, "octavia")
-
-	return client, nil
+	return c.CommonServiceClientInit(openstack.NewLoadBalancerV2, region, "octavia")
 }
 
 func (c *Config) DatabaseV1Client(region string) (*gophercloud.ServiceClient, error) {
-	if err := c.authenticate(); err != nil {
-		return nil, err
-	}
-
-	client, err := openstack.NewDBV1(c.OsClient, gophercloud.EndpointOpts{
-		Region:       c.determineRegion(region),
-		Availability: clientconfig.GetEndpointType(c.EndpointType),
-	})
-
-	if err != nil {
-		return client, err
-	}
-
-	// Check if an endpoint override was specified for the database service.
-	client = c.determineEndpoint(client, "database")
-
-	return client, nil
+	return c.CommonServiceClientInit(openstack.NewDBV1, region, "database")
 }
 
 func (c *Config) ContainerInfraV1Client(region string) (*gophercloud.ServiceClient, error) {
-	if err := c.authenticate(); err != nil {
-		return nil, err
-	}
-
-	client, err := openstack.NewContainerInfraV1(c.OsClient, gophercloud.EndpointOpts{
-		Region:       c.determineRegion(region),
-		Availability: clientconfig.GetEndpointType(c.EndpointType),
-	})
-
-	if err != nil {
-		return client, err
-	}
-
-	// Check if an endpoint override was specified for the container-infra service.
-	client = c.determineEndpoint(client, "container-infra")
-
-	return client, nil
+	return c.CommonServiceClientInit(openstack.NewContainerInfraV1, region, "container-infra")
 }
 
 func (c *Config) SharedfilesystemV2Client(region string) (*gophercloud.ServiceClient, error) {
-	if err := c.authenticate(); err != nil {
-		return nil, err
-	}
-
-	client, err := openstack.NewSharedFileSystemV2(c.OsClient, gophercloud.EndpointOpts{
-		Region:       c.determineRegion(region),
-		Availability: clientconfig.GetEndpointType(c.EndpointType),
-	})
-
-	if err != nil {
-		return client, err
-	}
-
-	// Check if an endpoint override was specified for the sharev2 service.
-	client = c.determineEndpoint(client, "sharev2")
-
-	return client, nil
+	return c.CommonServiceClientInit(openstack.NewSharedFileSystemV2, region, "sharev2")
 }
 
 func (c *Config) KeyManagerV1Client(region string) (*gophercloud.ServiceClient, error) {
-	if err := c.authenticate(); err != nil {
-		return nil, err
-	}
-
-	client, err := openstack.NewKeyManagerV1(c.OsClient, gophercloud.EndpointOpts{
-		Region:       c.determineRegion(region),
-		Availability: clientconfig.GetEndpointType(c.EndpointType),
-	})
-
-	if err != nil {
-		return client, err
-	}
-
-	// Check if an endpoint override was specified for the keymanager service.
-	client = c.determineEndpoint(client, "key-manager")
-
-	return client, nil
+	return c.CommonServiceClientInit(openstack.NewKeyManagerV1, region, "key-manager")
 }


### PR DESCRIPTION
@jtopjian this PR allows external openstack based provider to use config methods + removed duplicate code for simple openstack service client.