### PR TITLE
Fixed gnocchi metrics and resources list pager

### DIFF
--- a/gnocchi/metric/v1/metrics/requests.go
+++ b/gnocchi/metric/v1/metrics/requests.go
@@ -57,9 +57,14 @@ func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 		}
 		url += query
 	}
-	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
-		return MetricPage{pagination.SinglePageBase(r)}
+
+	pager := pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		p := MetricPage{pagination.MarkerPageBase{PageResult: r}}
+		p.MarkerPageBase.Owner = p
+		return p
 	})
+
+	return pager
 }
 
 // Get retrieves a specific Gnocchi metric based on its id.

--- a/gnocchi/metric/v1/metrics/results.go
+++ b/gnocchi/metric/v1/metrics/results.go
@@ -83,13 +83,25 @@ type Metric struct {
 // MetricPage is the page returned by a pager when traversing over a collection
 // of metrics.
 type MetricPage struct {
-	pagination.SinglePageBase
+	pagination.MarkerPageBase
 }
 
 // IsEmpty checks whether a MetricPage struct is empty.
 func (r MetricPage) IsEmpty() (bool, error) {
 	is, err := ExtractMetrics(r)
 	return len(is) == 0, err
+}
+
+// LastMarker returns the last metric ID in a ListResult.
+func (r MetricPage) LastMarker() (string, error) {
+	metrics, err := ExtractMetrics(r)
+	if err != nil {
+		return "", err
+	}
+	if len(metrics) == 0 {
+		return "", nil
+	}
+	return metrics[len(metrics)-1].ID, nil
 }
 
 // ExtractMetrics interprets the results of a single page from a List() call,

--- a/gnocchi/metric/v1/resources/requests.go
+++ b/gnocchi/metric/v1/resources/requests.go
@@ -52,9 +52,13 @@ func List(c *gophercloud.ServiceClient, opts ListOptsBuilder, resourceType strin
 		}
 		url += query
 	}
-	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
-		return ResourcePage{pagination.SinglePageBase(r)}
+	pager := pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		p := ResourcePage{pagination.MarkerPageBase{PageResult: r}}
+		p.MarkerPageBase.Owner = p
+		return p
 	})
+
+	return pager
 }
 
 // Get retrieves a specific Gnocchi resource based on its type and ID.

--- a/gnocchi/metric/v1/resources/results.go
+++ b/gnocchi/metric/v1/resources/results.go
@@ -150,13 +150,25 @@ func (r *Resource) UnmarshalJSON(b []byte) error {
 // returned to the client, you may only safely access the data provided through
 // the ExtractResources call.
 type ResourcePage struct {
-	pagination.SinglePageBase
+	pagination.MarkerPageBase
 }
 
 // IsEmpty checks whether a ResourcePage struct is empty.
 func (r ResourcePage) IsEmpty() (bool, error) {
 	is, err := ExtractResources(r)
 	return len(is) == 0, err
+}
+
+// LastMarker returns the last resource ID in a ListResult.
+func (r ResourcePage) LastMarker() (string, error) {
+	resources, err := ExtractResources(r)
+	if err != nil {
+		return "", err
+	}
+	if len(resources) == 0 {
+		return "", nil
+	}
+	return resources[len(resources)-1].ID, nil
 }
 
 // ExtractResources interprets the results of a single page from a List() call,


### PR DESCRIPTION
In the current implementation, pager type of gnocchi metrics and resources list
is SinglePageBase, which is wrong. In Gnocchi, query results in one page
are limited to max_limit value set in the configuration file (default 1000).
With the current implementation, AllPages() method can only show the first
page of query result (the first 1000 metrics, for example).

The pager type should be MarkerPageBase and LastMarker() method needs to
be implemented.