### PR TITLE
Add mutexkv and hashcode packages

### DIFF
--- a/terraform/auth/config.go
+++ b/terraform/auth/config.go
@@ -13,10 +13,11 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/objectstorage/v1/swauth"
 	osClient "github.com/gophercloud/utils/client"
 	"github.com/gophercloud/utils/openstack/clientconfig"
+	"github.com/gophercloud/utils/terraform/mutexkv"
 )
 
 // This is a global MutexKV for use within this package.
-var osMutexKV = newMutexKV()
+var osMutexKV = mutexkv.NewMutexKV()
 
 type Config struct {
 	CACertFile                  string

--- a/terraform/auth/util.go
+++ b/terraform/auth/util.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"os"
 	"strings"
-	"sync"
 
 	"github.com/mitchellh/go-homedir"
 )
@@ -37,51 +36,6 @@ func pathOrContents(poc string) (string, bool, error) {
 	}
 
 	return poc, false, nil
-}
-
-// MutexKV is a simple key/value store for arbitrary mutexes. It can be used to
-// serialize changes across arbitrary collaborators that share knowledge of the
-// keys they must serialize on.
-//
-// The initial use case is to let aws_security_group_rule resources serialize
-// their access to individual security groups based on SG ID.
-type mutexKV struct {
-	lock  sync.Mutex
-	store map[string]*sync.Mutex
-}
-
-// Locks the mutex for the given key. Caller is responsible for calling Unlock
-// for the same key
-func (m *mutexKV) Lock(key string) {
-	log.Printf("[DEBUG] Locking %q", key)
-	m.get(key).Lock()
-	log.Printf("[DEBUG] Locked %q", key)
-}
-
-// Unlock the mutex for the given key. Caller must have called Lock for the same key first
-func (m *mutexKV) Unlock(key string) {
-	log.Printf("[DEBUG] Unlocking %q", key)
-	m.get(key).Unlock()
-	log.Printf("[DEBUG] Unlocked %q", key)
-}
-
-// Returns a mutex for the given key, no guarantee of its lock status
-func (m *mutexKV) get(key string) *sync.Mutex {
-	m.lock.Lock()
-	defer m.lock.Unlock()
-	mutex, ok := m.store[key]
-	if !ok {
-		mutex = &sync.Mutex{}
-		m.store[key] = mutex
-	}
-	return mutex
-}
-
-// Returns a properly initalized MutexKV
-func newMutexKV() *mutexKV {
-	return &mutexKV{
-		store: make(map[string]*sync.Mutex),
-	}
 }
 
 const uaEnvVar = "TF_APPEND_USER_AGENT"

--- a/terraform/hashcode/hashcode.go
+++ b/terraform/hashcode/hashcode.go
@@ -1,0 +1,35 @@
+package hashcode
+
+import (
+	"bytes"
+	"fmt"
+	"hash/crc32"
+)
+
+// String hashes a string to a unique hashcode.
+//
+// crc32 returns a uint32, but for our use we need
+// and non negative integer. Here we cast to an integer
+// and invert it if the result is negative.
+func String(s string) int {
+	v := int(crc32.ChecksumIEEE([]byte(s)))
+	if v >= 0 {
+		return v
+	}
+	if -v >= 0 {
+		return -v
+	}
+	// v == MinInt
+	return 0
+}
+
+// Strings hashes a list of strings to a unique hashcode.
+func Strings(strings []string) string {
+	var buf bytes.Buffer
+
+	for _, s := range strings {
+		buf.WriteString(fmt.Sprintf("%s-", s))
+	}
+
+	return fmt.Sprintf("%d", String(buf.String()))
+}

--- a/terraform/hashcode/hashcode_test.go
+++ b/terraform/hashcode/hashcode_test.go
@@ -1,0 +1,37 @@
+package hashcode
+
+import (
+	"testing"
+)
+
+func TestString(t *testing.T) {
+	v := "hello, world"
+	expected := String(v)
+	for i := 0; i < 100; i++ {
+		actual := String(v)
+		if actual != expected {
+			t.Fatalf("bad: %#v\n\t%#v", actual, expected)
+		}
+	}
+}
+
+func TestStrings(t *testing.T) {
+	v := []string{"hello", ",", "world"}
+	expected := Strings(v)
+	for i := 0; i < 100; i++ {
+		actual := Strings(v)
+		if actual != expected {
+			t.Fatalf("bad: %#v\n\t%#v", actual, expected)
+		}
+	}
+}
+
+func TestString_positiveIndex(t *testing.T) {
+	// "2338615298" hashes to uint32(2147483648) which is math.MinInt32
+	ips := []string{"192.168.1.3", "192.168.1.5", "2338615298"}
+	for _, ip := range ips {
+		if index := String(ip); index < 0 {
+			t.Fatalf("Bad Index %#v for ip %s", index, ip)
+		}
+	}
+}

--- a/terraform/mutexkv/mutexkv.go
+++ b/terraform/mutexkv/mutexkv.go
@@ -1,0 +1,51 @@
+package mutexkv
+
+import (
+	"log"
+	"sync"
+)
+
+// MutexKV is a simple key/value store for arbitrary mutexes. It can be used to
+// serialize changes across arbitrary collaborators that share knowledge of the
+// keys they must serialize on.
+//
+// The initial use case is to let aws_security_group_rule resources serialize
+// their access to individual security groups based on SG ID.
+type MutexKV struct {
+	lock  sync.Mutex
+	store map[string]*sync.Mutex
+}
+
+// Locks the mutex for the given key. Caller is responsible for calling Unlock
+// for the same key.
+func (m *MutexKV) Lock(key string) {
+	log.Printf("[DEBUG] Locking %q", key)
+	m.get(key).Lock()
+	log.Printf("[DEBUG] Locked %q", key)
+}
+
+// Unlock the mutex for the given key. Caller must have called Lock for the same key first.
+func (m *MutexKV) Unlock(key string) {
+	log.Printf("[DEBUG] Unlocking %q", key)
+	m.get(key).Unlock()
+	log.Printf("[DEBUG] Unlocked %q", key)
+}
+
+// Returns a mutex for the given key, no guarantee of its lock status.
+func (m *MutexKV) get(key string) *sync.Mutex {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	mutex, ok := m.store[key]
+	if !ok {
+		mutex = &sync.Mutex{}
+		m.store[key] = mutex
+	}
+	return mutex
+}
+
+// Returns a properly initialized MutexKV.
+func NewMutexKV() *MutexKV {
+	return &MutexKV{
+		store: make(map[string]*sync.Mutex),
+	}
+}

--- a/terraform/mutexkv/mutexkv_test.go
+++ b/terraform/mutexkv/mutexkv_test.go
@@ -1,0 +1,67 @@
+package mutexkv
+
+import (
+	"testing"
+	"time"
+)
+
+func TestMutexKVLock(t *testing.T) {
+	mkv := NewMutexKV()
+
+	mkv.Lock("foo")
+
+	doneCh := make(chan struct{})
+
+	go func() {
+		mkv.Lock("foo")
+		close(doneCh)
+	}()
+
+	select {
+	case <-doneCh:
+		t.Fatal("Second lock was able to be taken. This shouldn't happen.")
+	case <-time.After(50 * time.Millisecond):
+		// pass
+	}
+}
+
+func TestMutexKVUnlock(t *testing.T) {
+	mkv := NewMutexKV()
+
+	mkv.Lock("foo")
+	mkv.Unlock("foo")
+
+	doneCh := make(chan struct{})
+
+	go func() {
+		mkv.Lock("foo")
+		close(doneCh)
+	}()
+
+	select {
+	case <-doneCh:
+		// pass
+	case <-time.After(50 * time.Millisecond):
+		t.Fatal("Second lock blocked after unlock. This shouldn't happen.")
+	}
+}
+
+func TestMutexKVDifferentKeys(t *testing.T) {
+	mkv := NewMutexKV()
+
+	mkv.Lock("foo")
+
+	doneCh := make(chan struct{})
+
+	go func() {
+		mkv.Lock("bar")
+		close(doneCh)
+	}()
+
+	select {
+	case <-doneCh:
+		// pass
+	case <-time.After(50 * time.Millisecond):
+		t.Fatal("Second lock on a different key blocked. This shouldn't happen.")
+	}
+}


### PR DESCRIPTION
After [some discussion here](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1080) with @ozerovandrei and @kayrus there is an intention to add globally available mutexkv and hashcode packages.