### PR TITLE
compute: add helper to return available AZs

### DIFF
--- a/openstack/compute/v2/availabilityzones/utils.go
+++ b/openstack/compute/v2/availabilityzones/utils.go
@@ -1,0 +1,27 @@
+package availabilityzones
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/availabilityzones"
+)
+
+// ListAvailableAvailabilityZones is a convenience function that return a slice of available Availability Zones.
+func ListAvailableAvailabilityZones(client *gophercloud.ServiceClient) ([]string, error) {
+	var ret []string
+	allPages, err := availabilityzones.List(client).AllPages()
+	if err != nil {
+		return ret, err
+	}
+
+	availabilityZoneInfo, err := availabilityzones.ExtractAvailabilityZones(allPages)
+	if err != nil {
+		return ret, err
+	}
+
+	for _, zoneInfo := range availabilityZoneInfo {
+		if zoneInfo.ZoneState.Available {
+			ret = append(ret, zoneInfo.ZoneName)
+		}
+	}
+	return ret, nil
+}


### PR DESCRIPTION
Add a new function, named ListAvailableAvailabilityZones, that return
a slice of AZs that are actually available.

Note: it uses availabilityzones.List() which doesn't require admin
privileges (comparing to availabilityzones.ListDetail() which does).