### PR TITLE
Consider TLS options when we create a service client

### DIFF
--- a/internal/util.go
+++ b/internal/util.go
@@ -1,8 +1,15 @@
 package internal
 
 import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+	"os"
 	"reflect"
 	"strings"
+
+	"github.com/mitchellh/go-homedir"
 )
 
 // RemainingKeys will inspect a struct and compare it to a map. Any struct
@@ -31,4 +38,71 @@ func RemainingKeys(s interface{}, m map[string]interface{}) (extras map[string]i
 	}
 
 	return
+}
+
+// PrepareTLSConfig generates TLS config based on the specifed parameters
+func PrepareTLSConfig(caCertFile, clientCertFile, clientKeyFile string, insecure *bool) (*tls.Config, error) {
+	config := &tls.Config{}
+	if caCertFile != "" {
+		caCert, _, err := pathOrContents(caCertFile)
+		if err != nil {
+			return nil, fmt.Errorf("Error reading CA Cert: %s", err)
+		}
+
+		caCertPool := x509.NewCertPool()
+		caCertPool.AppendCertsFromPEM(caCert)
+		config.RootCAs = caCertPool
+	}
+
+	if insecure == nil {
+		config.InsecureSkipVerify = false
+	} else {
+		config.InsecureSkipVerify = *insecure
+	}
+
+	if clientCertFile != "" && clientKeyFile != "" {
+		clientCert, _, err := pathOrContents(clientCertFile)
+		if err != nil {
+			return nil, fmt.Errorf("Error reading Client Cert: %s", err)
+		}
+		clientKey, _, err := pathOrContents(clientKeyFile)
+		if err != nil {
+			return nil, fmt.Errorf("Error reading Client Key: %s", err)
+		}
+
+		cert, err := tls.X509KeyPair(clientCert, clientKey)
+		if err != nil {
+			return nil, err
+		}
+
+		config.Certificates = []tls.Certificate{cert}
+		config.BuildNameToCertificate()
+	}
+
+	return config, nil
+}
+
+func pathOrContents(poc string) ([]byte, bool, error) {
+	if len(poc) == 0 {
+		return nil, false, nil
+	}
+
+	path := poc
+	if path[0] == '~' {
+		var err error
+		path, err = homedir.Expand(path)
+		if err != nil {
+			return []byte(path), true, err
+		}
+	}
+
+	if _, err := os.Stat(path); err == nil {
+		contents, err := ioutil.ReadFile(path)
+		if err != nil {
+			return contents, true, err
+		}
+		return contents, true, nil
+	}
+
+	return []byte(poc), false, nil
 }

--- a/terraform/auth/util.go
+++ b/terraform/auth/util.go
@@ -2,41 +2,13 @@ package auth
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"strings"
-
-	"github.com/mitchellh/go-homedir"
 )
 
 // This is copied directly from Terraform in order to remove a single legacy
 // vendor dependency.
-
-func pathOrContents(poc string) (string, bool, error) {
-	if len(poc) == 0 {
-		return poc, false, nil
-	}
-
-	path := poc
-	if path[0] == '~' {
-		var err error
-		path, err = homedir.Expand(path)
-		if err != nil {
-			return path, true, err
-		}
-	}
-
-	if _, err := os.Stat(path); err == nil {
-		contents, err := ioutil.ReadFile(path)
-		if err != nil {
-			return string(contents), true, err
-		}
-		return string(contents), true, nil
-	}
-
-	return poc, false, nil
-}
 
 const uaEnvVar = "TF_APPEND_USER_AGENT"
 


### PR DESCRIPTION
Now, when we create a service client with gophercloud/utils, TLS options[1] are ignored, which leads to the fact that we can't work with self-signed certificates out of the box. Also it creates inconsistencies with python-openstackclient, where these options matter.

To remove the discrepancy this commit implements full TLS support.
The work is based on the Terraform client[2], and now that code is shared between the clients.

[1] https://github.com/gophercloud/utils/blob/88c6e9e533261350ec733e2e2147a1d3f8eb62de/openstack/clientconfig/results.go#L39-L49
[2] https://github.com/gophercloud/utils/blob/88c6e9e533261350ec733e2e2147a1d3f8eb62de/terraform/auth/config.go#L144-L179