### PR TITLE
TLS improvements

### DIFF
--- a/internal/util.go
+++ b/internal/util.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"bytes"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
@@ -50,7 +51,9 @@ func PrepareTLSConfig(caCertFile, clientCertFile, clientKeyFile string, insecure
 		}
 
 		caCertPool := x509.NewCertPool()
-		caCertPool.AppendCertsFromPEM(caCert)
+		if ok := caCertPool.AppendCertsFromPEM(bytes.TrimSpace(caCert)); !ok {
+			return nil, fmt.Errorf("Error parsing CA Cert from %s", caCertFile)
+		}
 		config.RootCAs = caCertPool
 	}
 


### PR DESCRIPTION
This commit contains two improvements to the existing TLS module:

1. Now the library ignores the fact the CA certificate can be broken (if it can't parse it for some reason, it just leaves an empty string
without a notice). From now we raise an error in this case.

2. It tries to prevent some obvious formatting errors in the certificate like leading and trailing spaces, additional new lines etc.