### PR TITLE
imageutils: Use the Image service

### DIFF
--- a/openstack/compute/v2/images/utils.go
+++ b/openstack/compute/v2/images/utils.go
@@ -2,44 +2,37 @@ package images
 
 import (
 	"github.com/gophercloud/gophercloud"
-	"github.com/gophercloud/gophercloud/openstack/compute/v2/images"
+	"github.com/gophercloud/gophercloud/openstack/imageservice/v2/images"
 )
 
 // IDFromName is a convienience function that returns an image's ID given its
 // name.
 func IDFromName(client *gophercloud.ServiceClient, name string) (string, error) {
-	count := 0
-	id := ""
-	allPages, err := images.ListDetail(client, nil).AllPages()
+	allPages, err := images.List(client, images.ListOpts{
+		Name: name,
+	}).AllPages()
 	if err != nil {
 		return "", err
 	}
 
-	all, err := images.ExtractImages(allPages)
+	allImages, err := images.ExtractImages(allPages)
 	if err != nil {
 		return "", err
 	}
 
-	for _, f := range all {
-		if f.Name == name {
-			count++
-			id = f.ID
-		}
-	}
-
-	switch count {
+	switch len(allImages) {
 	case 0:
 		err := &gophercloud.ErrResourceNotFound{}
 		err.ResourceType = "image"
 		err.Name = name
 		return "", err
 	case 1:
-		return id, nil
+		return allImages[0].ID, nil
 	default:
 		err := &gophercloud.ErrMultipleResourcesFound{}
 		err.ResourceType = "image"
 		err.Name = name
-		err.Count = count
+		err.Count = len(allImages)
 		return "", err
 	}
 }


### PR DESCRIPTION
Use the Image Service instead of the deprecated image endpoint of the
Compute Service.