### PR TITLE
Terraform: use reference to MutexKV in Config

### DIFF
--- a/terraform/auth/config.go
+++ b/terraform/auth/config.go
@@ -58,7 +58,7 @@ type Config struct {
 	TerraformVersion string
 	SDKVersion       string
 
-	mutexkv.MutexKV
+	*mutexkv.MutexKV
 }
 
 // LoadAndValidate performs the authentication and initial configuration

--- a/terraform/mutexkv/mutexkv_test.go
+++ b/terraform/mutexkv/mutexkv_test.go
@@ -6,14 +6,18 @@ import (
 )
 
 func TestMutexKVLock(t *testing.T) {
-	mkv := NewMutexKV()
+	s := struct {
+		mkv *MutexKV
+	}{
+		mkv: NewMutexKV(),
+	}
 
-	mkv.Lock("foo")
+	s.mkv.Lock("foo")
 
 	doneCh := make(chan struct{})
 
 	go func() {
-		mkv.Lock("foo")
+		s.mkv.Lock("foo")
 		close(doneCh)
 	}()
 
@@ -26,15 +30,19 @@ func TestMutexKVLock(t *testing.T) {
 }
 
 func TestMutexKVUnlock(t *testing.T) {
-	mkv := NewMutexKV()
+	s := struct {
+		mkv *MutexKV
+	}{
+		mkv: NewMutexKV(),
+	}
 
-	mkv.Lock("foo")
-	mkv.Unlock("foo")
+	s.mkv.Lock("foo")
+	s.mkv.Unlock("foo")
 
 	doneCh := make(chan struct{})
 
 	go func() {
-		mkv.Lock("foo")
+		s.mkv.Lock("foo")
 		close(doneCh)
 	}()
 
@@ -47,14 +55,18 @@ func TestMutexKVUnlock(t *testing.T) {
 }
 
 func TestMutexKVDifferentKeys(t *testing.T) {
-	mkv := NewMutexKV()
+	s := struct {
+		mkv *MutexKV
+	}{
+		mkv: NewMutexKV(),
+	}
 
-	mkv.Lock("foo")
+	s.mkv.Lock("foo")
 
 	doneCh := make(chan struct{})
 
 	go func() {
-		mkv.Lock("bar")
+		s.mkv.Lock("bar")
 		close(doneCh)
 	}()
 


### PR DESCRIPTION
We don't want to have a copy of the `sync.Locker` in the
`Config` since lock value shold not be copied.

Usually `Config` used as a singleton in different Terraform provider
resources and all of them should use a single `sync.Locker` instead of
different copies.

This commit changes `MutexKV` field of the `Config` to be a reference
instead of a copy and updates `MutexKV` tests to check that `MutexKV` is
used in a proper way.

Currently you can run `govet` linter and find the issue in the following files of the Terraform OpenStack provider:
https://github.com/terraform-provider-openstack/terraform-provider-openstack/blob/main/openstack/provider.go#L513
https://github.com/terraform-provider-openstack/terraform-provider-openstack/blob/main/openstack/resource_openstack_networking_router_route_v2.go#L58

