### PR TITLE
clouds: support clouds.yml in addition to clouds.yaml

### DIFF
--- a/openstack/clientconfig/utils.go
+++ b/openstack/clientconfig/utils.go
@@ -108,15 +108,27 @@ func FindAndReadCloudsYAML() (string, []byte, error) {
 		}
 	}
 
-	return FindAndReadYAML("clouds.yaml")
+	s, b, err := FindAndReadYAML("clouds.yaml")
+	if s == "" {
+		return FindAndReadYAML("clouds.yml")
+	}
+	return s, b, err
 }
 
 func FindAndReadPublicCloudsYAML() (string, []byte, error) {
-	return FindAndReadYAML("clouds-public.yaml")
+	s, b, err := FindAndReadYAML("clouds-public.yaml")
+	if s == "" {
+		return FindAndReadYAML("clouds-public.yml")
+	}
+	return s, b, err
 }
 
 func FindAndReadSecureCloudsYAML() (string, []byte, error) {
-	return FindAndReadYAML("secure.yaml")
+	s, b, err := FindAndReadYAML("secure.yaml")
+	if s == "" {
+		return FindAndReadYAML("secure.yml")
+	}
+	return s, b, err
 }
 
 func FindAndReadYAML(yamlFile string) (string, []byte, error) {


### PR DESCRIPTION
While not clearly documented, the native openstacksdk package supports both
extensions. This brings parity with the official Python SDK.