### PR TITLE
fixes merging of clouds.yaml & secure.yaml

### DIFF
--- a/openstack/clientconfig/requests.go
+++ b/openstack/clientconfig/requests.go
@@ -299,6 +299,16 @@ func GetCloudFromYAML(opts *ClientOpts) (*Cloud, error) {
 		cloud.Verify = &iTrue
 	}
 
+	// merging per-region value overrides
+	if opts.RegionName != "" {
+		for _, v := range cloud.Regions {
+			if opts.RegionName == v.Name {
+				cloud, err = mergeClouds(v.Values, cloud)
+				break
+			}
+		}
+	}
+
 	// TODO: this is where reading vendor files should go be considered when not found in
 	// clouds-public.yml
 	// https://github.com/openstack/openstacksdk/tree/master/openstack/config/vendors

--- a/openstack/clientconfig/testing/clouds.yaml
+++ b/openstack/clientconfig/testing/clouds.yaml
@@ -133,6 +133,18 @@ clouds:
       password: "this should be overwritten by secure.yaml"
       project_name: "Some Project"
     region_name: "PHL"
+  philadelphia_complex:
+    auth:
+      auth_url: "https://phl.example.com:5000/v3"
+      username: "jdoe"
+      password: "password"
+      project_name: "Some Project"
+    regions:
+      - name: PHL1
+        values:
+          auth:
+            auth_url: "https://phl1.example.com:5000/v3"
+      - PHL2
   virginia:
     auth_type: "v3applicationcredential"
     auth:

--- a/openstack/clientconfig/testing/clouds.yaml
+++ b/openstack/clientconfig/testing/clouds.yaml
@@ -152,3 +152,21 @@ clouds:
       application_credential_id: "app-cred-id"
       application_credential_secret: "secret"
     region_name: "VA"
+  disconnected_clouds:
+    auth:
+      username: "jdoe"
+      password: "password"
+      project_name: "Some Project"
+    regions:
+      - name: SOMEWHERE
+        values:
+          auth:
+            auth_url: "https://somewhere.example.com:5000/v3"
+      - name: ANYWHERE
+        values:
+          auth:
+            auth_url: "https://anywhere.example.com:5000/v3"
+      - name: NOWHERE
+        values:
+          auth:
+            auth_url: "https://nowhere.example.com:5000/v3"

--- a/openstack/clientconfig/testing/fixtures.go
+++ b/openstack/clientconfig/testing/fixtures.go
@@ -44,6 +44,46 @@ var PhiladelphiaCloudYAML = clientconfig.Cloud{
 	AuthType: "password",
 }
 
+var PhiladelphiaComplexPhl1CloudYAML = clientconfig.Cloud{
+	AuthInfo: &clientconfig.AuthInfo{
+		AuthURL:     "https://phl1.example.com:5000/v3",
+		Username:    "jdoe",
+		Password:    "password",
+		ProjectName: "Some Project",
+	},
+	Regions: []clientconfig.Region{
+		{
+			Name:   "PHL1",
+			Values: clientconfig.Cloud{AuthInfo: &clientconfig.AuthInfo{AuthURL: "https://phl1.example.com:5000/v3"}},
+		},
+		{
+			Name:   "PHL2",
+			Values: clientconfig.Cloud{},
+		},
+	},
+	Verify: &iTrue,
+}
+
+var PhiladelphiaComplexPhl2CloudYAML = clientconfig.Cloud{
+	AuthInfo: &clientconfig.AuthInfo{
+		AuthURL:     "https://phl.example.com:5000/v3",
+		Username:    "jdoe",
+		Password:    "password",
+		ProjectName: "Some Project",
+	},
+	Regions: []clientconfig.Region{
+		{
+			Name:   "PHL1",
+			Values: clientconfig.Cloud{AuthInfo: &clientconfig.AuthInfo{AuthURL: "https://phl1.example.com:5000/v3"}},
+		},
+		{
+			Name:   "PHL2",
+			Values: clientconfig.Cloud{},
+		},
+	},
+	Verify: &iTrue,
+}
+
 var ChicagoCloudYAML = clientconfig.Cloud{
 	Profile:    "rackspace",
 	RegionName: "ORD",
@@ -197,10 +237,11 @@ var FloridaAuthOpts = &gophercloud.AuthOptions{
 
 var CaliforniaCloudYAML = clientconfig.Cloud{
 	EndpointType: "internal",
-	Regions: []interface{}{
-		"SAN",
-		"LAX",
-	},
+	Regions: []clientconfig.Region{{
+		Name: "SAN",
+	}, {
+		Name: "LAX",
+	}},
 	AuthInfo: &clientconfig.AuthInfo{
 		AuthURL:           "https://ca.example.com:5000/v3",
 		Username:          "jdoe",

--- a/openstack/clientconfig/testing/fixtures.go
+++ b/openstack/clientconfig/testing/fixtures.go
@@ -84,6 +84,54 @@ var PhiladelphiaComplexPhl2CloudYAML = clientconfig.Cloud{
 	Verify: &iTrue,
 }
 
+var disconnected_regions = []clientconfig.Region{
+	{
+		Name:   "SOMEWHERE",
+		Values: clientconfig.Cloud{AuthInfo: &clientconfig.AuthInfo{AuthURL: "https://somewhere.example.com:5000/v3"}},
+	},
+	{
+		Name:   "ANYWHERE",
+		Values: clientconfig.Cloud{AuthInfo: &clientconfig.AuthInfo{AuthURL: "https://anywhere.example.com:5000/v3"}},
+	},
+	{
+		Name:   "NOWHERE",
+		Values: clientconfig.Cloud{AuthInfo: &clientconfig.AuthInfo{AuthURL: "https://nowhere.example.com:5000/v3"}},
+	},
+}
+
+var DisconnectedSomewhereCloudYAML = clientconfig.Cloud{
+	AuthInfo: &clientconfig.AuthInfo{
+		AuthURL:     "https://somewhere.example.com:5000/v3",
+		Username:    "jdoe",
+		Password:    "password",
+		ProjectName: "Some Project",
+	},
+	Regions: disconnected_regions,
+	Verify:  &iTrue,
+}
+
+var DisconnectedAnywhereCloudYAML = clientconfig.Cloud{
+	AuthInfo: &clientconfig.AuthInfo{
+		AuthURL:     "https://anywhere.example.com:5000/v3",
+		Username:    "jdoe",
+		Password:    "password",
+		ProjectName: "Some Project",
+	},
+	Regions: disconnected_regions,
+	Verify:  &iTrue,
+}
+
+var DisconnectedNowhereCloudYAML = clientconfig.Cloud{
+	AuthInfo: &clientconfig.AuthInfo{
+		AuthURL:     "https://nowhere.example.com:5000/v3",
+		Username:    "jdoe",
+		Password:    "password",
+		ProjectName: "Some Project",
+	},
+	Regions: disconnected_regions,
+	Verify:  &iTrue,
+}
+
 var ChicagoCloudYAML = clientconfig.Cloud{
 	Profile:    "rackspace",
 	RegionName: "ORD",

--- a/openstack/clientconfig/testing/requests_test.go
+++ b/openstack/clientconfig/testing/requests_test.go
@@ -42,6 +42,18 @@ func TestGetCloudFromYAML(t *testing.T) {
 			RegionName: "PHL2",
 		},
 		"virginia": {Cloud: "virginia"},
+		"disconnected_smw": {
+			Cloud:      "disconnected_clouds",
+			RegionName: "SOMEWHERE",
+		},
+		"disconnected_anw": {
+			Cloud:      "disconnected_clouds",
+			RegionName: "ANYWHERE",
+		},
+		"disconnected_now": {
+			Cloud:      "disconnected_clouds",
+			RegionName: "NOWHERE",
+		},
 	}
 
 	expectedClouds := map[string]*clientconfig.Cloud{
@@ -60,6 +72,9 @@ func TestGetCloudFromYAML(t *testing.T) {
 		"philadelphia_phl1":  &PhiladelphiaComplexPhl1CloudYAML,
 		"philadelphia_phl2":  &PhiladelphiaComplexPhl2CloudYAML,
 		"virginia":           &VirginiaCloudYAML,
+		"disconnected_smw":   &DisconnectedSomewhereCloudYAML,
+		"disconnected_anw":   &DisconnectedAnywhereCloudYAML,
+		"disconnected_now":   &DisconnectedNowhereCloudYAML,
 	}
 
 	for cloud, clientOpts := range allClientOpts {

--- a/openstack/clientconfig/testing/requests_test.go
+++ b/openstack/clientconfig/testing/requests_test.go
@@ -33,7 +33,15 @@ func TestGetCloudFromYAML(t *testing.T) {
 		"chicago_legacy":     {Cloud: "chicago_legacy"},
 		"chicago_useprofile": {Cloud: "chicago_useprofile"},
 		"philadelphia":       {Cloud: "philadelphia"},
-		"virginia":           {Cloud: "virginia"},
+		"philadelphia_phl1": {
+			Cloud:      "philadelphia_complex",
+			RegionName: "PHL1",
+		},
+		"philadelphia_phl2": {
+			Cloud:      "philadelphia_complex",
+			RegionName: "PHL2",
+		},
+		"virginia": {Cloud: "virginia"},
 	}
 
 	expectedClouds := map[string]*clientconfig.Cloud{
@@ -49,6 +57,8 @@ func TestGetCloudFromYAML(t *testing.T) {
 		"chicago_legacy":     &ChicagoCloudLegacyYAML,
 		"chicago_useprofile": &ChicagoCloudUseProfileYAML,
 		"philadelphia":       &PhiladelphiaCloudYAML,
+		"philadelphia_phl1":  &PhiladelphiaComplexPhl1CloudYAML,
+		"philadelphia_phl2":  &PhiladelphiaComplexPhl2CloudYAML,
 		"virginia":           &VirginiaCloudYAML,
 	}
 

--- a/openstack/clientconfig/utils.go
+++ b/openstack/clientconfig/utils.go
@@ -46,7 +46,10 @@ func mergeClouds(override, cloud interface{}) (*Cloud, error) {
 	var mergedCloud Cloud
 	mergedInterface := mergeInterfaces(overrideInterface, cloudInterface)
 	mergedJson, err := json.Marshal(mergedInterface)
-	json.Unmarshal(mergedJson, &mergedCloud)
+	err = json.Unmarshal(mergedJson, &mergedCloud)
+	if err != nil {
+		return nil, err
+	}
 	return &mergedCloud, nil
 }
 

--- a/terraform/auth/config.go
+++ b/terraform/auth/config.go
@@ -96,6 +96,9 @@ func (c *Config) LoadAndValidate() error {
 	if c.Cloud != "" {
 		clientOpts.Cloud = c.Cloud
 
+		// Passing region allows GetCloudFromYAML to apply per-region overrides
+		clientOpts.RegionName = c.Region
+
 		cloud, err := clientconfig.GetCloudFromYAML(clientOpts)
 		if err != nil {
 			return err


### PR DESCRIPTION
Failures due to "json: unsupported type: map[interface {}]interface {}" are
avoided by using jsoniter package. In addition, "complex" clouds.yaml are now
supported with per-region overrides (such as auth_url).

Fixes #68