### PR TITLE
Fix secure.yml error

### DIFF
--- a/openstack/clientconfig/requests.go
+++ b/openstack/clientconfig/requests.go
@@ -138,7 +138,7 @@ func LoadSecureCloudsYAML() (map[string]Cloud, error) {
 
 	_, content, err := FindAndReadSecureCloudsYAML()
 	if err != nil {
-		if err.Error() == "no secure.yaml file found" {
+		if err.Error() == "no secure.yaml file found" || err.Error() == "no secure.yml file found" {
 			// secure.yaml is optional so just ignore read error
 			return secureClouds.Clouds, nil
 		}

--- a/openstack/clientconfig/requests.go
+++ b/openstack/clientconfig/requests.go
@@ -163,7 +163,7 @@ func LoadPublicCloudsYAML() (map[string]Cloud, error) {
 
 	_, content, err := FindAndReadPublicCloudsYAML()
 	if err != nil {
-		if err.Error() == "no clouds-public.yaml file found" {
+		if err.Error() == "no clouds-public.yaml file found" || err.Error() == "no clouds-public.yml file found" {
 			// clouds-public.yaml is optional so just ignore read error
 			return publicClouds.Clouds, nil
 		}


### PR DESCRIPTION
This commit fixes a logic error which was being triggered when
secure.yml didn't exist. This file is optional and so the
warning can be ignored.

For #145 