### PR TITLE
clientconfig: fix file load error checks

### DIFF
--- a/openstack/clientconfig/requests.go
+++ b/openstack/clientconfig/requests.go
@@ -1,8 +1,10 @@
 package clientconfig
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
+	"os"
 	"reflect"
 	"strings"
 
@@ -122,7 +124,7 @@ func LoadCloudsYAML() (map[string]Cloud, error) {
 	var clouds Clouds
 	err = yaml.Unmarshal(content, &clouds)
 	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal yaml: %v", err)
+		return nil, fmt.Errorf("failed to unmarshal yaml: %w", err)
 	}
 
 	return clouds.Clouds, nil
@@ -138,7 +140,7 @@ func LoadSecureCloudsYAML() (map[string]Cloud, error) {
 
 	_, content, err := FindAndReadSecureCloudsYAML()
 	if err != nil {
-		if err.Error() == "no secure.yaml file found" {
+		if errors.Is(err, os.ErrNotExist) {
 			// secure.yaml is optional so just ignore read error
 			return secureClouds.Clouds, nil
 		}
@@ -147,7 +149,7 @@ func LoadSecureCloudsYAML() (map[string]Cloud, error) {
 
 	err = yaml.Unmarshal(content, &secureClouds)
 	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal yaml: %v", err)
+		return nil, fmt.Errorf("failed to unmarshal yaml: %w", err)
 	}
 
 	return secureClouds.Clouds, nil
@@ -163,7 +165,7 @@ func LoadPublicCloudsYAML() (map[string]Cloud, error) {
 
 	_, content, err := FindAndReadPublicCloudsYAML()
 	if err != nil {
-		if err.Error() == "no clouds-public.yaml file found" {
+		if errors.Is(err, os.ErrNotExist) {
 			// clouds-public.yaml is optional so just ignore read error
 			return publicClouds.Clouds, nil
 		}
@@ -173,7 +175,7 @@ func LoadPublicCloudsYAML() (map[string]Cloud, error) {
 
 	err = yaml.Unmarshal(content, &publicClouds)
 	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal yaml: %v", err)
+		return nil, fmt.Errorf("failed to unmarshal yaml: %w", err)
 	}
 
 	return publicClouds.Clouds, nil
@@ -189,7 +191,7 @@ func GetCloudFromYAML(opts *ClientOpts) (*Cloud, error) {
 
 	clouds, err := yamlOpts.LoadCloudsYAML()
 	if err != nil {
-		return nil, fmt.Errorf("unable to load clouds.yaml: %s", err)
+		return nil, fmt.Errorf("unable to load clouds.yaml: %w", err)
 	}
 
 	// Determine which cloud to use.
@@ -236,7 +238,7 @@ func GetCloudFromYAML(opts *ClientOpts) (*Cloud, error) {
 		if profileName != "" {
 			publicClouds, err := yamlOpts.LoadPublicCloudsYAML()
 			if err != nil {
-				return nil, fmt.Errorf("unable to load clouds-public.yaml: %s", err)
+				return nil, fmt.Errorf("unable to load clouds-public.yaml: %w", err)
 			}
 
 			publicCloud, ok := publicClouds[profileName]
@@ -255,7 +257,7 @@ func GetCloudFromYAML(opts *ClientOpts) (*Cloud, error) {
 	// can be found or merged.
 	secureClouds, err := yamlOpts.LoadSecureCloudsYAML()
 	if err != nil {
-		return nil, fmt.Errorf("unable to load secure.yaml: %s", err)
+		return nil, fmt.Errorf("unable to load secure.yaml: %w", err)
 	}
 
 	if secureClouds != nil {

--- a/openstack/clientconfig/utils.go
+++ b/openstack/clientconfig/utils.go
@@ -138,7 +138,7 @@ func FindAndReadYAML(yamlFile string) (string, []byte, error) {
 	// current directory
 	cwd, err := os.Getwd()
 	if err != nil {
-		return "", nil, fmt.Errorf("unable to determine working directory: %s", err)
+		return "", nil, fmt.Errorf("unable to determine working directory: %w", err)
 	}
 
 	filename := filepath.Join(cwd, yamlFile)
@@ -166,7 +166,7 @@ func FindAndReadYAML(yamlFile string) (string, []byte, error) {
 		return filename, content, err
 	}
 
-	return "", nil, fmt.Errorf("no " + yamlFile + " file found")
+	return "", nil, fmt.Errorf("no %s file found: %w", yamlFile, os.ErrNotExist)
 }
 
 // fileExists checks for the existence of a file at a given location.


### PR DESCRIPTION
In addition wraps underline Errorf's errors.
Requires Go 1.13+

Fix #145.