### PR TITLE
Use default transport settings for our custom TLS HTTP client

### DIFF
--- a/openstack/clientconfig/requests.go
+++ b/openstack/clientconfig/requests.go
@@ -817,11 +817,9 @@ func NewServiceClient(service string, opts *ClientOpts) (*gophercloud.ServiceCli
 		pClient.HTTPClient = *opts.HTTPClient
 	} else {
 		// Otherwise create a new HTTP client with the generated TLS config.
-		pClient.HTTPClient = http.Client{
-			Transport: &http.Transport{
-				TLSClientConfig: tlsConfig,
-			},
-		}
+		transport := http.DefaultTransport.(*http.Transport).Clone()
+		transport.TLSClientConfig = tlsConfig
+		pClient.HTTPClient = http.Client{Transport: transport}
 	}
 
 	err = openstack.Authenticate(pClient, *ao)


### PR DESCRIPTION
f41c176 introduced a custom HTTP client to make use of the self-signed
certificate specified in the clouds.yaml file. This change however
removed all the settings that came with the DefaultTransport, including
handling of proxy environment variables and default timeouts.

This commit ensures the custom HTTP client inherits its settings from
the default transport.

Requires golang 1.13.

Fixes #148