### PR TITLE
all: IDsFromName to return multiple results

### DIFF
--- a/openstack/blockstorage/extensions/backups/utils.go
+++ b/openstack/blockstorage/extensions/backups/utils.go
@@ -5,38 +5,43 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/backups"
 )
 
-// IDFromName is a convienience function that returns a backups's ID given its name.
+// IDFromName is a convenience function that returns a backup's ID given its
+// name. Errors when the number of items found is not one.
 func IDFromName(client *gophercloud.ServiceClient, name string) (string, error) {
-	count := 0
-	id := ""
-
-	listOpts := backups.ListOpts{
-		Name: name,
-	}
-
-	pages, err := backups.List(client, listOpts).AllPages()
+	IDs, err := IDsFromName(client, name)
 	if err != nil {
 		return "", err
+	}
+
+	switch count := len(IDs); count {
+	case 0:
+		return "", gophercloud.ErrResourceNotFound{Name: name, ResourceType: "backup"}
+	case 1:
+		return IDs[0], nil
+	default:
+		return "", gophercloud.ErrMultipleResourcesFound{Name: name, Count: count, ResourceType: "backup"}
+	}
+}
+
+// IDsFromName returns zero or more IDs corresponding to a name. The returned
+// error is only non-nil in case of failure.
+func IDsFromName(client *gophercloud.ServiceClient, name string) ([]string, error) {
+	pages, err := backups.List(client, backups.ListOpts{
+		Name: name,
+	}).AllPages()
+	if err != nil {
+		return nil, err
 	}
 
 	all, err := backups.ExtractBackups(pages)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	for _, s := range all {
-		if s.Name == name {
-			count++
-			id = s.ID
-		}
+	IDs := make([]string, len(all))
+	for i := range all {
+		IDs[i] = all[i].ID
 	}
 
-	switch count {
-	case 0:
-		return "", gophercloud.ErrResourceNotFound{Name: name, ResourceType: "backup"}
-	case 1:
-		return id, nil
-	default:
-		return "", gophercloud.ErrMultipleResourcesFound{Name: name, Count: count, ResourceType: "backup"}
-	}
+	return IDs, nil
 }

--- a/openstack/blockstorage/v1/snapshots/utils.go
+++ b/openstack/blockstorage/v1/snapshots/utils.go
@@ -5,7 +5,7 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v1/snapshots"
 )
 
-// IDFromName is a convienience function that returns a snapshot's ID given its name.
+// IDFromName is a convenience function that returns a snapshot's ID given its name.
 func IDFromName(client *gophercloud.ServiceClient, name string) (string, error) {
 	count := 0
 	id := ""

--- a/openstack/blockstorage/v1/volumes/utils.go
+++ b/openstack/blockstorage/v1/volumes/utils.go
@@ -5,7 +5,7 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v1/volumes"
 )
 
-// IDFromName is a convienience function that returns a volume's ID given its name.
+// IDFromName is a convenience function that returns a volume's ID given its name.
 func IDFromName(client *gophercloud.ServiceClient, name string) (string, error) {
 	count := 0
 	id := ""

--- a/openstack/blockstorage/v2/snapshots/utils.go
+++ b/openstack/blockstorage/v2/snapshots/utils.go
@@ -5,7 +5,7 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v2/snapshots"
 )
 
-// IDFromName is a convienience function that returns a snapshot's ID given its name.
+// IDFromName is a convenience function that returns a snapshot's ID given its name.
 func IDFromName(client *gophercloud.ServiceClient, name string) (string, error) {
 	count := 0
 	id := ""

--- a/openstack/blockstorage/v2/volumes/utils.go
+++ b/openstack/blockstorage/v2/volumes/utils.go
@@ -5,7 +5,7 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v2/volumes"
 )
 
-// IDFromName is a convienience function that returns a volume's ID given its name.
+// IDFromName is a convenience function that returns a volume's ID given its name.
 func IDFromName(client *gophercloud.ServiceClient, name string) (string, error) {
 	count := 0
 	id := ""

--- a/openstack/blockstorage/v3/snapshots/utils.go
+++ b/openstack/blockstorage/v3/snapshots/utils.go
@@ -5,38 +5,43 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/snapshots"
 )
 
-// IDFromName is a convienience function that returns a snapshot's ID given its name.
+// IDFromName is a convenience function that returns a snapshot's ID given its
+// name. Errors when the number of items found is not one.
 func IDFromName(client *gophercloud.ServiceClient, name string) (string, error) {
-	count := 0
-	id := ""
-
-	listOpts := snapshots.ListOpts{
-		Name: name,
-	}
-
-	pages, err := snapshots.List(client, listOpts).AllPages()
+	IDs, err := IDsFromName(client, name)
 	if err != nil {
 		return "", err
+	}
+
+	switch count := len(IDs); count {
+	case 0:
+		return "", gophercloud.ErrResourceNotFound{Name: name, ResourceType: "snapshot"}
+	case 1:
+		return IDs[0], nil
+	default:
+		return "", gophercloud.ErrMultipleResourcesFound{Name: name, Count: count, ResourceType: "snapshot"}
+	}
+}
+
+// IDsFromName returns zero or more IDs corresponding to a name. The returned
+// error is only non-nil in case of failure.
+func IDsFromName(client *gophercloud.ServiceClient, name string) ([]string, error) {
+	pages, err := snapshots.List(client, snapshots.ListOpts{
+		Name: name,
+	}).AllPages()
+	if err != nil {
+		return nil, err
 	}
 
 	all, err := snapshots.ExtractSnapshots(pages)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	for _, s := range all {
-		if s.Name == name {
-			count++
-			id = s.ID
-		}
+	IDs := make([]string, len(all))
+	for i := range all {
+		IDs[i] = all[i].ID
 	}
 
-	switch count {
-	case 0:
-		return "", gophercloud.ErrResourceNotFound{Name: name, ResourceType: "snapshot"}
-	case 1:
-		return id, nil
-	default:
-		return "", gophercloud.ErrMultipleResourcesFound{Name: name, Count: count, ResourceType: "snapshot"}
-	}
+	return IDs, nil
 }

--- a/openstack/blockstorage/v3/volumes/utils.go
+++ b/openstack/blockstorage/v3/volumes/utils.go
@@ -5,38 +5,43 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes"
 )
 
-// IDFromName is a convienience function that returns a volume's ID given its name.
+// IDFromName is a convenience function that returns a volume's ID given its
+// name. Errors when the number of items found is not one.
 func IDFromName(client *gophercloud.ServiceClient, name string) (string, error) {
-	count := 0
-	id := ""
-
-	listOpts := volumes.ListOpts{
-		Name: name,
-	}
-
-	pages, err := volumes.List(client, listOpts).AllPages()
+	IDs, err := IDsFromName(client, name)
 	if err != nil {
 		return "", err
+	}
+
+	switch count := len(IDs); count {
+	case 0:
+		return "", gophercloud.ErrResourceNotFound{Name: name, ResourceType: "volume"}
+	case 1:
+		return IDs[0], nil
+	default:
+		return "", gophercloud.ErrMultipleResourcesFound{Name: name, Count: count, ResourceType: "volume"}
+	}
+}
+
+// IDsFromName returns zero or more IDs corresponding to a name. The returned
+// error is only non-nil in case of failure.
+func IDsFromName(client *gophercloud.ServiceClient, name string) ([]string, error) {
+	pages, err := volumes.List(client, volumes.ListOpts{
+		Name: name,
+	}).AllPages()
+	if err != nil {
+		return nil, err
 	}
 
 	all, err := volumes.ExtractVolumes(pages)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	for _, s := range all {
-		if s.Name == name {
-			count++
-			id = s.ID
-		}
+	IDs := make([]string, len(all))
+	for i := range all {
+		IDs[i] = all[i].ID
 	}
 
-	switch count {
-	case 0:
-		return "", gophercloud.ErrResourceNotFound{Name: name, ResourceType: "volume"}
-	case 1:
-		return id, nil
-	default:
-		return "", gophercloud.ErrMultipleResourcesFound{Name: name, Count: count, ResourceType: "volume"}
-	}
+	return IDs, nil
 }

--- a/openstack/imageservice/v2/images/utils.go
+++ b/openstack/imageservice/v2/images/utils.go
@@ -5,33 +5,43 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/imageservice/v2/images"
 )
 
-// IDFromName is a convienience function that returns an image's ID given its name.
+// IDFromName is a convenience function that returns an image's ID given its
+// name. Errors when the number of items found is not one.
 func IDFromName(client *gophercloud.ServiceClient, name string) (string, error) {
-	allPages, err := images.List(client, images.ListOpts{
+	IDs, err := IDsFromName(client, name)
+	if err != nil {
+		return "", err
+	}
+
+	switch count := len(IDs); count {
+	case 0:
+		return "", gophercloud.ErrResourceNotFound{Name: name, ResourceType: "image"}
+	case 1:
+		return IDs[0], nil
+	default:
+		return "", gophercloud.ErrMultipleResourcesFound{Name: name, Count: count, ResourceType: "image"}
+	}
+}
+
+// IDsFromName returns zero or more IDs corresponding to a name. The returned
+// error is only non-nil in case of failure.
+func IDsFromName(client *gophercloud.ServiceClient, name string) ([]string, error) {
+	pages, err := images.List(client, images.ListOpts{
 		Name: name,
 	}).AllPages()
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	allImages, err := images.ExtractImages(allPages)
+	all, err := images.ExtractImages(pages)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	switch count := len(allImages); count {
-	case 0:
-		return "", gophercloud.ErrResourceNotFound{
-			Name:         name,
-			ResourceType: "image",
-		}
-	case 1:
-		return allImages[0].ID, nil
-	default:
-		return "", gophercloud.ErrMultipleResourcesFound{
-			Name:         name,
-			Count:        count,
-			ResourceType: "image",
-		}
+	IDs := make([]string, len(all))
+	for i := range all {
+		IDs[i] = all[i].ID
 	}
+
+	return IDs, nil
 }

--- a/openstack/networking/v2/networks/utils.go
+++ b/openstack/networking/v2/networks/utils.go
@@ -5,39 +5,43 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
 )
 
-// IDFromName is a convenience function that returns a network's ID, given
-// its name.
+// IDFromName is a convenience function that returns a network's ID given its
+// name. Errors when the number of items found is not one.
 func IDFromName(client *gophercloud.ServiceClient, name string) (string, error) {
-	count := 0
-	id := ""
-
-	listOpts := networks.ListOpts{
-		Name: name,
-	}
-
-	pages, err := networks.List(client, listOpts).AllPages()
+	IDs, err := IDsFromName(client, name)
 	if err != nil {
 		return "", err
+	}
+
+	switch count := len(IDs); count {
+	case 0:
+		return "", gophercloud.ErrResourceNotFound{Name: name, ResourceType: "network"}
+	case 1:
+		return IDs[0], nil
+	default:
+		return "", gophercloud.ErrMultipleResourcesFound{Name: name, Count: count, ResourceType: "network"}
+	}
+}
+
+// IDsFromName returns zero or more IDs corresponding to a name. The returned
+// error is only non-nil in case of failure.
+func IDsFromName(client *gophercloud.ServiceClient, name string) ([]string, error) {
+	pages, err := networks.List(client, networks.ListOpts{
+		Name: name,
+	}).AllPages()
+	if err != nil {
+		return nil, err
 	}
 
 	all, err := networks.ExtractNetworks(pages)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	for _, s := range all {
-		if s.Name == name {
-			count++
-			id = s.ID
-		}
+	IDs := make([]string, len(all))
+	for i := range all {
+		IDs[i] = all[i].ID
 	}
 
-	switch count {
-	case 0:
-		return "", gophercloud.ErrResourceNotFound{Name: name, ResourceType: "network"}
-	case 1:
-		return id, nil
-	default:
-		return "", gophercloud.ErrMultipleResourcesFound{Name: name, Count: count, ResourceType: "network"}
-	}
+	return IDs, nil
 }

--- a/openstack/networking/v2/subnets/utils.go
+++ b/openstack/networking/v2/subnets/utils.go
@@ -5,39 +5,43 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
 )
 
-// IDFromName is a convenience function that returns a subnet's ID,
-// given its name.
+// IDFromName is a convenience function that returns a subnet's ID given its
+// name. Errors when the number of items found is not one.
 func IDFromName(client *gophercloud.ServiceClient, name string) (string, error) {
-	count := 0
-	id := ""
-
-	listOpts := subnets.ListOpts{
-		Name: name,
-	}
-
-	pages, err := subnets.List(client, listOpts).AllPages()
+	IDs, err := IDsFromName(client, name)
 	if err != nil {
 		return "", err
+	}
+
+	switch count := len(IDs); count {
+	case 0:
+		return "", gophercloud.ErrResourceNotFound{Name: name, ResourceType: "subnet"}
+	case 1:
+		return IDs[0], nil
+	default:
+		return "", gophercloud.ErrMultipleResourcesFound{Name: name, Count: count, ResourceType: "subnet"}
+	}
+}
+
+// IDsFromName returns zero or more IDs corresponding to a name. The returned
+// error is only non-nil in case of failure.
+func IDsFromName(client *gophercloud.ServiceClient, name string) ([]string, error) {
+	pages, err := subnets.List(client, subnets.ListOpts{
+		Name: name,
+	}).AllPages()
+	if err != nil {
+		return nil, err
 	}
 
 	all, err := subnets.ExtractSubnets(pages)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	for _, s := range all {
-		if s.Name == name {
-			count++
-			id = s.ID
-		}
+	IDs := make([]string, len(all))
+	for i := range all {
+		IDs[i] = all[i].ID
 	}
 
-	switch count {
-	case 0:
-		return "", gophercloud.ErrResourceNotFound{Name: name, ResourceType: "subnet"}
-	case 1:
-		return id, nil
-	default:
-		return "", gophercloud.ErrMultipleResourcesFound{Name: name, Count: count, ResourceType: "subnet"}
-	}
+	return IDs, nil
 }

--- a/openstack/sharedfilesystems/v2/shares/utils.go
+++ b/openstack/sharedfilesystems/v2/shares/utils.go
@@ -5,28 +5,43 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/shares"
 )
 
-// IDFromName is a convenience function that returns a share's ID given its name.
+// IDFromName is a convenience function that returns a share's ID given its
+// name. Errors when the number of items found is not one.
 func IDFromName(client *gophercloud.ServiceClient, name string) (string, error) {
-	listOpts := shares.ListOpts{
-		Name: name,
-	}
-
-	r, err := shares.ListDetail(client, listOpts).AllPages()
+	IDs, err := IDsFromName(client, name)
 	if err != nil {
 		return "", err
 	}
 
-	ss, err := shares.ExtractShares(r)
-	if err != nil {
-		return "", err
-	}
-
-	switch len(ss) {
+	switch count := len(IDs); count {
 	case 0:
 		return "", gophercloud.ErrResourceNotFound{Name: name, ResourceType: "share"}
 	case 1:
-		return ss[0].ID, nil
+		return IDs[0], nil
 	default:
-		return "", gophercloud.ErrMultipleResourcesFound{Name: name, Count: len(ss), ResourceType: "share"}
+		return "", gophercloud.ErrMultipleResourcesFound{Name: name, Count: count, ResourceType: "share"}
 	}
+}
+
+// IDsFromName returns zero or more IDs corresponding to a name. The returned
+// error is only non-nil in case of failure.
+func IDsFromName(client *gophercloud.ServiceClient, name string) ([]string, error) {
+	pages, err := shares.ListDetail(client, shares.ListOpts{
+		Name: name,
+	}).AllPages()
+	if err != nil {
+		return nil, err
+	}
+
+	all, err := shares.ExtractShares(pages)
+	if err != nil {
+		return nil, err
+	}
+
+	IDs := make([]string, len(all))
+	for i := range all {
+		IDs[i] = all[i].ID
+	}
+
+	return IDs, nil
 }


### PR DESCRIPTION
This patch adds a function in the utils packages that returns all the
IDs of the items with the given name.

This patch leaves the behaviour of the existing `IDFromName` functions
untouched, while it reduces code duplication.
