### PR TITLE
Add function to remove a volume if its state is ready

### DIFF
--- a/openstack/blockstorage/v3/volumes/utils.go
+++ b/openstack/blockstorage/v3/volumes/utils.go
@@ -1,6 +1,8 @@
 package volumes
 
 import (
+	"fmt"
+
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes"
 )
@@ -44,4 +46,21 @@ func IDsFromName(client *gophercloud.ServiceClient, name string) ([]string, erro
 	}
 
 	return IDs, nil
+}
+
+// SafeVolumeDelete is a convenience function that returns an error if a volume can't be removed because it's in a wrong
+// state (e.g. it's attached to a server).
+func SafeVolumeDelete(client *gophercloud.ServiceClient, id string, opts volumes.DeleteOpts) error {
+	vol, err := volumes.Get(client, id).Extract()
+	if err != nil {
+		return err
+	}
+	status := vol.Status
+	switch status {
+	// https://docs.openstack.org/api-ref/block-storage/v3/index.html?expanded=delete-a-volume-detail#delete-a-volume
+	case "available", "error", "error_restoring", "error_extending", "error_managing":
+		return volumes.Delete(client, id, opts).ExtractErr()
+	default:
+		return fmt.Errorf("volume %s is in %s state, can't delete", id, status)
+	}
 }


### PR DESCRIPTION
Volumes can only be removed when in a certain state.
This function can be used to check if a volume can be removed before
actually removing it.

Note that this function will remove the volume if it's ready.

API doc:
https://docs.openstack.org/api-ref/block-storage/v3/index.html?expanded=delete-a-volume-detail#delete-a-volume
