### PR TITLE
Add possibility to set AllowReauth in clientOpts

### DIFF
--- a/openstack/clientconfig/requests.go
+++ b/openstack/clientconfig/requests.go
@@ -373,9 +373,17 @@ func AuthOptions(opts *ClientOpts) (*gophercloud.AuthOptions, error) {
 		}
 	}
 
+	// Set default value for AllowReauth
+	if opts.AuthInfo != nil {
+		allowReauth := false
+		if opts.AuthInfo.AllowReauth == nil {
+			opts.AuthInfo.AllowReauth = &allowReauth
+		}
+	}
+
 	// If cloud.AuthInfo is nil, then no cloud was specified.
 	if cloud.AuthInfo == nil {
-		// If opts.Auth is not nil, then try using the auth settings from it.
+		// If opts.AuthInfo is not nil, then try using the auth settings from it.
 		if opts.AuthInfo != nil {
 			cloud.AuthInfo = opts.AuthInfo
 		}
@@ -512,6 +520,7 @@ func v2auth(cloud *Cloud, opts *ClientOpts) (*gophercloud.AuthOptions, error) {
 		Password:         cloud.AuthInfo.Password,
 		TenantID:         cloud.AuthInfo.ProjectID,
 		TenantName:       cloud.AuthInfo.ProjectName,
+		AllowReauth:      *cloud.AuthInfo.AllowReauth,
 	}
 
 	return ao, nil
@@ -684,6 +693,7 @@ func v3auth(cloud *Cloud, opts *ClientOpts) (*gophercloud.AuthOptions, error) {
 		ApplicationCredentialID:     cloud.AuthInfo.ApplicationCredentialID,
 		ApplicationCredentialName:   cloud.AuthInfo.ApplicationCredentialName,
 		ApplicationCredentialSecret: cloud.AuthInfo.ApplicationCredentialSecret,
+		AllowReauth:                 *cloud.AuthInfo.AllowReauth,
 	}
 
 	// If an auth_type of "token" was specified, then make sure

--- a/openstack/clientconfig/requests.go
+++ b/openstack/clientconfig/requests.go
@@ -373,14 +373,6 @@ func AuthOptions(opts *ClientOpts) (*gophercloud.AuthOptions, error) {
 		}
 	}
 
-	// Set default value for AllowReauth
-	if opts.AuthInfo != nil {
-		allowReauth := false
-		if opts.AuthInfo.AllowReauth == nil {
-			opts.AuthInfo.AllowReauth = &allowReauth
-		}
-	}
-
 	// If cloud.AuthInfo is nil, then no cloud was specified.
 	if cloud.AuthInfo == nil {
 		// If opts.AuthInfo is not nil, then try using the auth settings from it.
@@ -520,7 +512,7 @@ func v2auth(cloud *Cloud, opts *ClientOpts) (*gophercloud.AuthOptions, error) {
 		Password:         cloud.AuthInfo.Password,
 		TenantID:         cloud.AuthInfo.ProjectID,
 		TenantName:       cloud.AuthInfo.ProjectName,
-		AllowReauth:      *cloud.AuthInfo.AllowReauth,
+		AllowReauth:      cloud.AuthInfo.AllowReauth,
 	}
 
 	return ao, nil
@@ -693,7 +685,7 @@ func v3auth(cloud *Cloud, opts *ClientOpts) (*gophercloud.AuthOptions, error) {
 		ApplicationCredentialID:     cloud.AuthInfo.ApplicationCredentialID,
 		ApplicationCredentialName:   cloud.AuthInfo.ApplicationCredentialName,
 		ApplicationCredentialSecret: cloud.AuthInfo.ApplicationCredentialSecret,
-		AllowReauth:                 *cloud.AuthInfo.AllowReauth,
+		AllowReauth:                 cloud.AuthInfo.AllowReauth,
 	}
 
 	// If an auth_type of "token" was specified, then make sure

--- a/openstack/clientconfig/results.go
+++ b/openstack/clientconfig/results.go
@@ -139,7 +139,7 @@ type AuthInfo struct {
 	// the RoundTripper interface and stores the number of failed retries. For an
 	// example of this, see here:
 	// https://github.com/rackspace/rack/blob/1.0.0/auth/clients.go#L311
-	AllowReauth *bool `yaml:"allow_reauth,omitempty" json:"allow_reauth,omitempty"`
+	AllowReauth bool `yaml:"allow_reauth,omitempty" json:"allow_reauth,omitempty"`
 }
 
 // Region represents a region included as part of cloud in clouds.yaml

--- a/openstack/clientconfig/results.go
+++ b/openstack/clientconfig/results.go
@@ -126,6 +126,20 @@ type AuthInfo struct {
 	// DefaultDomain is the domain ID to fall back on if no other domain has
 	// been specified and a domain is required for scope.
 	DefaultDomain string `yaml:"default_domain,omitempty" json:"default_domain,omitempty"`
+
+	// AllowReauth should be set to true if you grant permission for Gophercloud to
+	// cache your credentials in memory, and to allow Gophercloud to attempt to
+	// re-authenticate automatically if/when your token expires.  If you set it to
+	// false, it will not cache these settings, but re-authentication will not be
+	// possible.  This setting defaults to false.
+	//
+	// NOTE: The reauth function will try to re-authenticate endlessly if left
+	// unchecked. The way to limit the number of attempts is to provide a custom
+	// HTTP client to the provider client and provide a transport that implements
+	// the RoundTripper interface and stores the number of failed retries. For an
+	// example of this, see here:
+	// https://github.com/rackspace/rack/blob/1.0.0/auth/clients.go#L311
+	AllowReauth *bool `yaml:"allow_reauth,omitempty" json:"allow_reauth,omitempty"`
 }
 
 // Region represents a region included as part of cloud in clouds.yaml

--- a/openstack/clientconfig/results.go
+++ b/openstack/clientconfig/results.go
@@ -132,13 +132,6 @@ type AuthInfo struct {
 	// re-authenticate automatically if/when your token expires.  If you set it to
 	// false, it will not cache these settings, but re-authentication will not be
 	// possible.  This setting defaults to false.
-	//
-	// NOTE: The reauth function will try to re-authenticate endlessly if left
-	// unchecked. The way to limit the number of attempts is to provide a custom
-	// HTTP client to the provider client and provide a transport that implements
-	// the RoundTripper interface and stores the number of failed retries. For an
-	// example of this, see here:
-	// https://github.com/rackspace/rack/blob/1.0.0/auth/clients.go#L311
 	AllowReauth bool `yaml:"allow_reauth,omitempty" json:"allow_reauth,omitempty"`
 }
 

--- a/terraform/auth/config.go
+++ b/terraform/auth/config.go
@@ -150,7 +150,6 @@ func (c *Config) LoadAndValidate() error {
 			ApplicationCredentialID:     c.ApplicationCredentialID,
 			ApplicationCredentialName:   c.ApplicationCredentialName,
 			ApplicationCredentialSecret: c.ApplicationCredentialSecret,
-			AllowReauth:                 &c.AllowReauth,
 		}
 		clientOpts.AuthInfo = authInfo
 	}

--- a/terraform/auth/config.go
+++ b/terraform/auth/config.go
@@ -150,6 +150,7 @@ func (c *Config) LoadAndValidate() error {
 			ApplicationCredentialID:     c.ApplicationCredentialID,
 			ApplicationCredentialName:   c.ApplicationCredentialName,
 			ApplicationCredentialSecret: c.ApplicationCredentialSecret,
+			AllowReauth:                 &c.AllowReauth,
 		}
 		clientOpts.AuthInfo = authInfo
 	}


### PR DESCRIPTION
AllowReauth cannot be set using `clientconfig`

This PR adds possibility to set this feature from AuthInfo in utils/clientconfig.

Signed-off-by: Ondrej Vasko <ondrej.vaskoo@gmail.com>