### PR TITLE
clientconfig: Ignore OS_CLOUD if explicit cloud config provided

### DIFF
--- a/openstack/clientconfig/requests.go
+++ b/openstack/clientconfig/requests.go
@@ -183,6 +183,10 @@ func LoadPublicCloudsYAML() (map[string]Cloud, error) {
 
 // GetCloudFromYAML will return a cloud entry from a clouds.yaml file.
 func GetCloudFromYAML(opts *ClientOpts) (*Cloud, error) {
+	if opts == nil {
+		opts = new(ClientOpts)
+	}
+
 	if opts.YAMLOpts == nil {
 		opts.YAMLOpts = new(YAMLOpts)
 	}
@@ -197,19 +201,18 @@ func GetCloudFromYAML(opts *ClientOpts) (*Cloud, error) {
 	// Determine which cloud to use.
 	// First see if a cloud name was explicitly set in opts.
 	var cloudName string
-	if opts != nil && opts.Cloud != "" {
+	if opts.Cloud != "" {
 		cloudName = opts.Cloud
-	}
+	} else {
+		// If not, see if a cloud name was specified as an environment variable.
+		envPrefix := "OS_"
+		if opts.EnvPrefix != "" {
+			envPrefix = opts.EnvPrefix
+		}
 
-	// Next see if a cloud name was specified as an environment variable.
-	// This is supposed to override an explicit opts setting.
-	envPrefix := "OS_"
-	if opts.EnvPrefix != "" {
-		envPrefix = opts.EnvPrefix
-	}
-
-	if v := env.Getenv(envPrefix + "CLOUD"); v != "" {
-		cloudName = v
+		if v := env.Getenv(envPrefix + "CLOUD"); v != "" {
+			cloudName = v
+		}
 	}
 
 	var cloud *Cloud
@@ -351,16 +354,17 @@ func AuthOptions(opts *ClientOpts) (*gophercloud.AuthOptions, error) {
 	var cloudName string
 	if opts.Cloud != "" {
 		cloudName = opts.Cloud
-	}
+	} else {
+		// If not, see if a cloud name was specified as an environment
+		// variable.
+		envPrefix := "OS_"
+		if opts.EnvPrefix != "" {
+			envPrefix = opts.EnvPrefix
+		}
 
-	// Next see if a cloud name was specified as an environment variable.
-	envPrefix := "OS_"
-	if opts.EnvPrefix != "" {
-		envPrefix = opts.EnvPrefix
-	}
-
-	if v := env.Getenv(envPrefix + "CLOUD"); v != "" {
-		cloudName = v
+		if v := env.Getenv(envPrefix + "CLOUD"); v != "" {
+			cloudName = v
+		}
 	}
 
 	// If a cloud name was determined, try to look it up in clouds.yaml.

--- a/openstack/clientconfig/testing/requests_test.go
+++ b/openstack/clientconfig/testing/requests_test.go
@@ -86,6 +86,7 @@ func TestGetCloudFromYAML(t *testing.T) {
 
 func TestGetCloudFromYAMLOSCLOUD(t *testing.T) {
 	os.Setenv("OS_CLOUD", "california")
+	defer os.Unsetenv("OS_CLOUD")
 
 	clientOpts := &clientconfig.ClientOpts{
 		Cloud: "hawaii",
@@ -94,18 +95,15 @@ func TestGetCloudFromYAMLOSCLOUD(t *testing.T) {
 	actual, err := clientconfig.GetCloudFromYAML(clientOpts)
 	th.AssertNoErr(t, err)
 	th.AssertDeepEquals(t, &HawaiiCloudYAML, actual)
-
-	os.Unsetenv("OS_CLOUD")
 }
 
 func TestGetCloudFromYAMLMissingClientOpts(t *testing.T) {
 	os.Setenv("OS_CLOUD", "california")
+	defer os.Unsetenv("OS_CLOUD")
 
 	actual, err := clientconfig.GetCloudFromYAML(nil)
 	th.AssertNoErr(t, err)
 	th.AssertDeepEquals(t, &CaliforniaCloudYAML, actual)
-
-	os.Unsetenv("OS_CLOUD")
 }
 
 func TestAuthOptionsExplicitCloud(t *testing.T) {
@@ -125,6 +123,7 @@ func TestAuthOptionsExplicitCloud(t *testing.T) {
 
 func TestAuthOptionsOSCLOUD(t *testing.T) {
 	os.Setenv("FOO_CLOUD", "hawaii")
+	defer os.Unsetenv("FOO_CLOUD")
 
 	clientOpts := &clientconfig.ClientOpts{
 		EnvPrefix: "FOO_",
@@ -136,12 +135,11 @@ func TestAuthOptionsOSCLOUD(t *testing.T) {
 	}
 
 	th.AssertDeepEquals(t, HawaiiAuthOpts, actual)
-
-	os.Unsetenv("FOO_CLOUD")
 }
 
 func TestAuthOptionsExplicitCloudAndOSCLOUD(t *testing.T) {
 	os.Setenv("FOO_CLOUD", "hawaii")
+	defer os.Unsetenv("FOO_CLOUD")
 
 	clientOpts := &clientconfig.ClientOpts{
 		EnvPrefix: "FOO_",
@@ -155,12 +153,11 @@ func TestAuthOptionsExplicitCloudAndOSCLOUD(t *testing.T) {
 
 	// We should have ignored the cloud configuration option
 	th.AssertDeepEquals(t, CaliforniaAuthOpts, actual)
-
-	os.Unsetenv("FOO_CLOUD")
 }
 
 func TestAuthOptionsMissingClientOpts(t *testing.T) {
 	os.Setenv("OS_CLOUD", "hawaii")
+	defer os.Unsetenv("OS_CLOUD")
 
 	actual, err := clientconfig.AuthOptions(nil)
 	if err != nil {
@@ -170,8 +167,6 @@ func TestAuthOptionsMissingClientOpts(t *testing.T) {
 	// We should have handled the missing config opts and fallen back to
 	// defaults
 	th.AssertDeepEquals(t, HawaiiAuthOpts, actual)
-
-	os.Unsetenv("OS_CLOUD")
 }
 
 func TestAuthOptionsCreationFromCloudsYAML(t *testing.T) {
@@ -304,15 +299,12 @@ func TestAuthOptionsCreationFromEnv(t *testing.T) {
 	for cloud, envVars := range allEnvVars {
 		for k, v := range envVars {
 			os.Setenv(k, v)
+			defer os.Unsetenv(k)
 		}
 
 		actualAuthOpts, err := clientconfig.AuthOptions(nil)
 		th.AssertNoErr(t, err)
 		th.AssertDeepEquals(t, expectedAuthOpts[cloud], actualAuthOpts)
-
-		for k := range envVars {
-			os.Unsetenv(k)
-		}
 	}
 }
 
@@ -332,15 +324,12 @@ func TestAuthOptionsCreationFromLegacyEnv(t *testing.T) {
 	for cloud, envVars := range allEnvVars {
 		for k, v := range envVars {
 			os.Setenv(k, v)
+			defer os.Unsetenv(k)
 		}
 
 		actualAuthOpts, err := clientconfig.AuthOptions(nil)
 		th.AssertNoErr(t, err)
 		th.AssertDeepEquals(t, expectedAuthOpts[cloud], actualAuthOpts)
-
-		for k := range envVars {
-			os.Unsetenv(k)
-		}
 	}
 }
 

--- a/openstack/clientconfig/testing/requests_test.go
+++ b/openstack/clientconfig/testing/requests_test.go
@@ -84,6 +84,30 @@ func TestGetCloudFromYAML(t *testing.T) {
 	}
 }
 
+func TestGetCloudFromYAMLOSCLOUD(t *testing.T) {
+	os.Setenv("OS_CLOUD", "california")
+
+	clientOpts := &clientconfig.ClientOpts{
+		Cloud: "hawaii",
+	}
+
+	actual, err := clientconfig.GetCloudFromYAML(clientOpts)
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, &HawaiiCloudYAML, actual)
+
+	os.Unsetenv("OS_CLOUD")
+}
+
+func TestGetCloudFromYAMLMissingClientOpts(t *testing.T) {
+	os.Setenv("OS_CLOUD", "california")
+
+	actual, err := clientconfig.GetCloudFromYAML(nil)
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, &CaliforniaCloudYAML, actual)
+
+	os.Unsetenv("OS_CLOUD")
+}
+
 func TestAuthOptionsExplicitCloud(t *testing.T) {
 	os.Unsetenv("OS_CLOUD")
 
@@ -114,6 +138,40 @@ func TestAuthOptionsOSCLOUD(t *testing.T) {
 	th.AssertDeepEquals(t, HawaiiAuthOpts, actual)
 
 	os.Unsetenv("FOO_CLOUD")
+}
+
+func TestAuthOptionsExplicitCloudAndOSCLOUD(t *testing.T) {
+	os.Setenv("FOO_CLOUD", "hawaii")
+
+	clientOpts := &clientconfig.ClientOpts{
+		EnvPrefix: "FOO_",
+		Cloud:     "california",
+	}
+
+	actual, err := clientconfig.AuthOptions(clientOpts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// We should have ignored the cloud configuration option
+	th.AssertDeepEquals(t, CaliforniaAuthOpts, actual)
+
+	os.Unsetenv("FOO_CLOUD")
+}
+
+func TestAuthOptionsMissingClientOpts(t *testing.T) {
+	os.Setenv("OS_CLOUD", "hawaii")
+
+	actual, err := clientconfig.AuthOptions(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// We should have handled the missing config opts and fallen back to
+	// defaults
+	th.AssertDeepEquals(t, HawaiiAuthOpts, actual)
+
+	os.Unsetenv("OS_CLOUD")
 }
 
 func TestAuthOptionsCreationFromCloudsYAML(t *testing.T) {


### PR DESCRIPTION
The current behavior of the `GetCloudFromYAML` and `AuthOptions` utilities is confusing and the source of much pulled hair. As discussed in the linked bug, the equivalent Python libraries, openstacksdk and (legacy) os_client_config, both default to reading `OS_CLOUD` only if explicit cloud config has not been provided. However, we're actually overriding what the user provided if `OS_CLOUD` is set. This is clearly incorrect. Correct things to prefer user-provide cloud configuration, falling back to the environment variable only if this is not provided.

While we're here, correctly handle a nil `opts` arguments in the `GetCloudFromYAML` function. Previously this was done ad-hoc and was incomplete.

Closes: #164