### PR TITLE
Default to blockstorage v3 API

### DIFF
--- a/openstack/clientconfig/requests.go
+++ b/openstack/clientconfig/requests.go
@@ -916,7 +916,7 @@ func NewServiceClient(service string, opts *ClientOpts) (*gophercloud.ServiceCli
 	case "sharev2":
 		return openstack.NewSharedFileSystemV2(pClient, eo)
 	case "volume":
-		volumeVersion := "2"
+		volumeVersion := "3"
 		if v := cloud.VolumeAPIVersion; v != "" {
 			volumeVersion = v
 		}


### PR DESCRIPTION
The blockstorage v2 API [1] was deprecated in Pike and removed in Xena.
We should make v3 the default API version when none is explicitly
specified.

[1] https://docs.openstack.org/api-ref/block-storage/v2/