### PR TITLE
Fix client config unit tests

### DIFF
--- a/openstack/clientconfig/testing/requests_test.go
+++ b/openstack/clientconfig/testing/requests_test.go
@@ -297,14 +297,16 @@ func TestAuthOptionsCreationFromEnv(t *testing.T) {
 	}
 
 	for cloud, envVars := range allEnvVars {
-		for k, v := range envVars {
-			os.Setenv(k, v)
-			defer os.Unsetenv(k)
-		}
+		t.Run(cloud, func(t *testing.T) {
+			for k, v := range envVars {
+				os.Setenv(k, v)
+				defer os.Unsetenv(k)
+			}
 
-		actualAuthOpts, err := clientconfig.AuthOptions(nil)
-		th.AssertNoErr(t, err)
-		th.AssertDeepEquals(t, expectedAuthOpts[cloud], actualAuthOpts)
+			actualAuthOpts, err := clientconfig.AuthOptions(nil)
+			th.AssertNoErr(t, err)
+			th.AssertDeepEquals(t, expectedAuthOpts[cloud], actualAuthOpts)
+		})
 	}
 }
 
@@ -322,14 +324,16 @@ func TestAuthOptionsCreationFromLegacyEnv(t *testing.T) {
 	}
 
 	for cloud, envVars := range allEnvVars {
-		for k, v := range envVars {
-			os.Setenv(k, v)
-			defer os.Unsetenv(k)
-		}
+		t.Run(cloud, func(t *testing.T) {
+			for k, v := range envVars {
+				os.Setenv(k, v)
+				defer os.Unsetenv(k)
+			}
 
-		actualAuthOpts, err := clientconfig.AuthOptions(nil)
-		th.AssertNoErr(t, err)
-		th.AssertDeepEquals(t, expectedAuthOpts[cloud], actualAuthOpts)
+			actualAuthOpts, err := clientconfig.AuthOptions(nil)
+			th.AssertNoErr(t, err)
+			th.AssertDeepEquals(t, expectedAuthOpts[cloud], actualAuthOpts)
+		})
 	}
 }
 


### PR DESCRIPTION
Commit b2ceaa8efa963941aa70d34d113d27740a4545e9 broke some the unit
tests by deferring the cleanup of environment variables to when the
function exits. Wrap each test in it's own test function so that cleanup
happens when needed.