### PR TITLE
Revert "Credit the Gophercloud authors"

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,18 +1,3 @@
-Copyright Gophercloud authors
-
-Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-this file except in compliance with the License.  You may obtain a copy of the
-License at
-
-  http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed
-under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-CONDITIONS OF ANY KIND, either express or implied.  See the License for the
-specific language governing permissions and limitations under the License.
-
-------
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/


### PR DESCRIPTION
Reverting an unnecessary change that impaired Github's license parser.

This reverts commit 69fd486f595460d68a51478518e7fd9eebf6cf9d.