### PR TITLE
[terraform] define SystemScope in AuthInfo

### DIFF
--- a/terraform/auth/config.go
+++ b/terraform/auth/config.go
@@ -151,6 +151,12 @@ func (c *Config) LoadAndValidate() error {
 			ApplicationCredentialName:   c.ApplicationCredentialName,
 			ApplicationCredentialSecret: c.ApplicationCredentialSecret,
 		}
+
+		// Define System Scope if enabled
+		if c.AuthOpts.Scope.System {
+			authInfo.SystemScope = "true"
+		}
+
 		clientOpts.AuthInfo = authInfo
 	}
 


### PR DESCRIPTION
Related PR https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1517

Hope this is last PR to add system scoped authorization support to terraform-provider-openstack.

Builded and tested this time, provider "works on my PC" ;)

Debug logs from 
```
2023-03-24T01:03:43.329+0600 [INFO]  provider.terraform-provider-openstack_v1.51.0: 2023/03/24 01:03:43 [DEBUG] OpenStack Request Body: {
  "auth": {
    "identity": {
      "methods": [
        "password"
      ],
      "password": {
        "user": {
          "domain": {
            "name": "Default"
          },
          "name": "askar.sabyrov",
          "password": "***"
        }
      }
    },
    "scope": {
      "system": {
        "all": true
      }
    }
  }
}
```

