### PR TITLE
Pin goimports to a version that Go v1.15 supports

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -22,7 +22,12 @@ jobs:
 
       - name: Setup environment
         run: |
-          go get golang.org/x/tools/cmd/goimports
+          # Changing into a different directory to avoid polluting go.sum with "go get"
+          cd "$(mktemp -d)"
+          go mod init unit_tests
+
+          # Pin to a version that Go v1.15 supports
+          go get golang.org/x/tools/cmd/goimports@v0.8.0
 
       - name: Run go vet
         run: |


### PR DESCRIPTION
until we bump the Go version in `go.mod`.

Analogous to https://github.com/gophercloud/gophercloud/pull/2620