### PR TITLE
openstack/clientconfig: fix dropped errors

### DIFF
--- a/openstack/clientconfig/requests.go
+++ b/openstack/clientconfig/requests.go
@@ -330,7 +330,7 @@ func GetCloudFromYAML(opts *ClientOpts) (*Cloud, error) {
 
 	cloud.Interface = ""
 
-	return cloud, nil
+	return cloud, err
 }
 
 // AuthOptions creates a gophercloud.AuthOptions structure with the

--- a/openstack/clientconfig/utils.go
+++ b/openstack/clientconfig/utils.go
@@ -46,6 +46,9 @@ func mergeClouds(override, cloud interface{}) (*Cloud, error) {
 	var mergedCloud Cloud
 	mergedInterface := mergeInterfaces(overrideInterface, cloudInterface)
 	mergedJson, err := json.Marshal(mergedInterface)
+	if err != nil {
+		return nil, err
+	}
 	err = json.Unmarshal(mergedJson, &mergedCloud)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This picks up two dropped `err` variables in `openstack/clientconfig`.