### PR TITLE
Replace hashicorp/go-uuid import with gofrs/uuid

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/gophercloud/utils/v2
 go 1.22
 
 require (
+	github.com/gofrs/uuid/v5 v5.2.0
 	github.com/gophercloud/gophercloud/v2 v2.0.0-rc.1
-	github.com/hashicorp/go-uuid v1.0.3
 	github.com/mitchellh/go-homedir v1.1.0
 	golang.org/x/sys v0.20.0
 	golang.org/x/text v0.15.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
+github.com/gofrs/uuid/v5 v5.2.0 h1:qw1GMx6/y8vhVsx626ImfKMuS5CvJmhIKKtuyvfajMM=
+github.com/gofrs/uuid/v5 v5.2.0/go.mod h1:CDOjlDMVAtN56jqyRUZh58JT31Tiw7/oQyEXZV+9bD8=
 github.com/gophercloud/gophercloud/v2 v2.0.0-rc.1 h1:B0J9VVGlNuMF/743KMVFScDB8M2Bd5N1KlsEZykSBlc=
 github.com/gophercloud/gophercloud/v2 v2.0.0-rc.1/go.mod h1:cwPW9cbJmfBt1c7o/yzXuNjwonhWA+F9Zw8LNQzd3Zk=
-github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
-github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 golang.org/x/sys v0.20.0 h1:Od9JTbYCk261bKm4M/mw7AklTlFYIa0bIp9BgSm1S8Y=

--- a/openstack/clientconfig/requests.go
+++ b/openstack/clientconfig/requests.go
@@ -15,7 +15,8 @@ import (
 	"github.com/gophercloud/utils/v2/gnocchi"
 	"github.com/gophercloud/utils/v2/internal"
 
-	"github.com/hashicorp/go-uuid"
+	"github.com/gofrs/uuid/v5"
+
 	yaml "gopkg.in/yaml.v3"
 )
 
@@ -923,11 +924,11 @@ func NewServiceClient(ctx context.Context, service string, opts *ClientOpts) (*g
 	case "load-balancer":
 		return openstack.NewLoadBalancerV2(pClient, eo)
 	case "messaging":
-		clientID, err := uuid.GenerateUUID()
+		clientID, err := uuid.NewV4()
 		if err != nil {
 			return nil, fmt.Errorf("failed to generate UUID: %w", err)
 		}
-		return openstack.NewMessagingV2(pClient, clientID, eo)
+		return openstack.NewMessagingV2(pClient, clientID.String(), eo)
 	case "network":
 		return openstack.NewNetworkV2(pClient, eo)
 	case "object-store":


### PR DESCRIPTION
Replace import of hashicorp/go-uuid as its license MPL 2.0 is not incompatible with the license of the project Apache 2.0. Instead use gofrs/uuid which is compatible. It uses an MIT license.