### PR TITLE
Add support for OpenStack trusts 

### DIFF
--- a/openstack/clientconfig/requests.go
+++ b/openstack/clientconfig/requests.go
@@ -655,6 +655,12 @@ func v3auth(cloud *Cloud, opts *ClientOpts) (*gophercloud.AuthOptions, error) {
 		}
 	}
 
+	if cloud.AuthInfo.TrustID == "" {
+		if v := env.Getenv(envPrefix + "TRUST_ID"); v != "" {
+			cloud.AuthInfo.TrustID = v
+		}
+	}
+
 	// Build a scope and try to do it correctly.
 	// https://github.com/openstack/os-client-config/blob/master/os_client_config/config.py#L595
 	scope := new(gophercloud.AuthScope)
@@ -664,6 +670,8 @@ func v3auth(cloud *Cloud, opts *ClientOpts) (*gophercloud.AuthOptions, error) {
 		// If Domain* is set, but UserDomain* or ProjectDomain* aren't,
 		// then use Domain* as the default setting.
 		cloud = setDomainIfNeeded(cloud)
+	} else if cloud.AuthInfo.TrustID != "" {
+		scope.TrustID = cloud.AuthInfo.TrustID
 	} else {
 		if !isProjectScoped(cloud.AuthInfo) {
 			if cloud.AuthInfo.DomainID != "" {

--- a/openstack/clientconfig/results.go
+++ b/openstack/clientconfig/results.go
@@ -136,6 +136,10 @@ type AuthInfo struct {
 	// false, it will not cache these settings, but re-authentication will not be
 	// possible.  This setting defaults to false.
 	AllowReauth bool `yaml:"allow_reauth,omitempty" json:"allow_reauth,omitempty"`
+
+	// TrustID is used the authenticate using Keystone trusts.
+	// Must also provide trustee Username or UserID with Password and Domain.
+	TrustID string `yaml:"trust_id,omitempty" json:"trust_id,omitempty"`
 }
 
 // Region represents a region included as part of cloud in clouds.yaml


### PR DESCRIPTION
This change adds support for trust_id in `AuthInfo` and `OS_TRUST_ID` environment variable.