### PR TITLE
Support compute default microversion in clouds.yaml

### DIFF
--- a/openstack/clientconfig/results.go
+++ b/openstack/clientconfig/results.go
@@ -35,6 +35,9 @@ type Cloud struct {
 	IdentityAPIVersion string `yaml:"identity_api_version,omitempty" json:"identity_api_version,omitempty"`
 	VolumeAPIVersion   string `yaml:"volume_api_version,omitempty" json:"volume_api_version,omitempty"`
 
+	// Service default microversion overrides.
+	ComputeDefaultMicroversion string `yaml:"compute_default_microversion,omitempty" json:"compute_default_microversion,omitempty"`
+
 	// Verify whether or not SSL API requests should be verified.
 	Verify *bool `yaml:"verify,omitempty" json:"verify,omitempty"`
 

--- a/openstack/clientconfig/testing/clouds.yaml
+++ b/openstack/clientconfig/testing/clouds.yaml
@@ -7,6 +7,7 @@ clouds:
       project_name: "Some Project"
       domain_name: "default"
     region_name: "HNL"
+    compute_default_microversion: "2.87"
   florida:
     interface: "admin"
     auth:
@@ -139,11 +140,13 @@ clouds:
       username: "jdoe"
       password: "password"
       project_name: "Some Project"
+    compute_default_microversion: "2.87"
     regions:
       - name: PHL1
         values:
           auth:
             auth_url: "https://phl1.example.com:5000/v3"
+          compute_default_microversion: "2.79"
       - PHL2
   virginia:
     auth_type: "v3applicationcredential"

--- a/openstack/clientconfig/testing/fixtures.go
+++ b/openstack/clientconfig/testing/fixtures.go
@@ -51,10 +51,14 @@ var PhiladelphiaComplexPhl1CloudYAML = clientconfig.Cloud{
 		Password:    "password",
 		ProjectName: "Some Project",
 	},
+	ComputeDefaultMicroversion: "2.79",
 	Regions: []clientconfig.Region{
 		{
-			Name:   "PHL1",
-			Values: clientconfig.Cloud{AuthInfo: &clientconfig.AuthInfo{AuthURL: "https://phl1.example.com:5000/v3"}},
+			Name: "PHL1",
+			Values: clientconfig.Cloud{
+				AuthInfo:                   &clientconfig.AuthInfo{AuthURL: "https://phl1.example.com:5000/v3"},
+				ComputeDefaultMicroversion: "2.79",
+			},
 		},
 		{
 			Name:   "PHL2",
@@ -71,10 +75,14 @@ var PhiladelphiaComplexPhl2CloudYAML = clientconfig.Cloud{
 		Password:    "password",
 		ProjectName: "Some Project",
 	},
+	ComputeDefaultMicroversion: "2.87",
 	Regions: []clientconfig.Region{
 		{
-			Name:   "PHL1",
-			Values: clientconfig.Cloud{AuthInfo: &clientconfig.AuthInfo{AuthURL: "https://phl1.example.com:5000/v3"}},
+			Name: "PHL1",
+			Values: clientconfig.Cloud{
+				AuthInfo:                   &clientconfig.AuthInfo{AuthURL: "https://phl1.example.com:5000/v3"},
+				ComputeDefaultMicroversion: "2.79",
+			},
 		},
 		{
 			Name:   "PHL2",
@@ -170,7 +178,8 @@ var ChicagoCloudUseProfileYAML = clientconfig.Cloud{
 }
 
 var HawaiiCloudYAML = clientconfig.Cloud{
-	RegionName: "HNL",
+	RegionName:                 "HNL",
+	ComputeDefaultMicroversion: "2.87",
 	AuthInfo: &clientconfig.AuthInfo{
 		AuthURL:     "https://hi.example.com:5000/v3",
 		Username:    "jdoe",

--- a/openstack/clientconfig/testing/results_test.go
+++ b/openstack/clientconfig/testing/results_test.go
@@ -29,6 +29,7 @@ var HawaiiExpected = `clouds:
             project_name: Some Project
             domain_name: default
         region_name: HNL
+        compute_default_microversion: "2.87"
         verify: true
 `
 


### PR DESCRIPTION
## Summary

Add `compute_default_microversion` to `clientconfig.Cloud` and cover clouds.yaml parsing/region override behavior.

This is the clientconfig-side compute example for broader service default microversion support.

Related: https://github.com/gophercloud/gophercloud/issues/3882
Companion: https://github.com/gophercloud/gophercloud/pull/3881

## Testing

- `go test ./openstack/clientconfig/...`